### PR TITLE
Update lib definitions

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,6 +1,4 @@
-
-# raylib-libretro-static static library
-add_library(raylib-libretro-static STATIC
+set(RAYLIB_LIBRETRO_LIB_SOURCES
     raylib-libretro-static.c
     ../vendor/libretro-common/compat/compat_strl.c
     ../vendor/libretro-common/compat/compat_posix_string.c
@@ -9,16 +7,23 @@ add_library(raylib-libretro-static STATIC
     ../vendor/libretro-common/file/file_path.c
     ../vendor/libretro-common/dynamic/dylib.c
 )
-target_link_libraries(raylib-libretro-static PUBLIC
-    raylib
-    raylib-libretro-h
-    ${CMAKE_DL_LIBS}
-)
-target_include_directories(raylib-libretro-static PUBLIC
-    ../vendor/libretro-common/include
-)
-target_compile_definitions(raylib-libretro-static PUBLIC
-    HAVE_DYNAMIC=1
-)
+
+set(RAYLIB_LIBRETRO_LIB_INCLUDES ../vendor/libretro-common/include)
+set(RAYLIB_LIBRETRO_LIB_DEFINES HAVE_DYNAMIC=1)
+
+# raylib-libretro-static
+add_library(raylib-libretro-static STATIC ${RAYLIB_LIBRETRO_LIB_SOURCES})
+target_link_libraries(raylib-libretro-static PUBLIC raylib raylib-libretro-h ${CMAKE_DL_LIBS})
+target_include_directories(raylib-libretro-static PUBLIC ${RAYLIB_LIBRETRO_LIB_INCLUDES})
+target_compile_definitions(raylib-libretro-static PUBLIC ${RAYLIB_LIBRETRO_LIB_DEFINES})
 install(TARGETS raylib-libretro-static DESTINATION lib)
 install(FILES ../include/raylib-libretro.h DESTINATION include)
+
+# raylib-libretro-shared
+# set(BUILD_SHARED_LIBS TRUE)
+# add_library(raylib-libretro-shared SHARED ${RAYLIB_LIBRETRO_LIB_SOURCES})
+# set_property(TARGET raylib-libretro-shared PROPERTY POSITION_INDEPENDENT_CODE ON)
+# set_property(TARGET raylib-libretro-shared PROPERTY POSITION_INDEPENDENT_CODE ON)
+# target_link_libraries(raylib-libretro-shared PUBLIC raylib_static raylib-libretro-h ${CMAKE_DL_LIBS})
+# target_include_directories(raylib-libretro-shared PUBLIC ${RAYLIB_LIBRETRO_LIB_INCLUDES})
+# target_compile_definitions(raylib-libretro-shared PUBLIC ${RAYLIB_LIBRETRO_LIB_DEFINES})


### PR DESCRIPTION
@konsumer Right now the `lib` directory builds out a static build to ease integration. I tried to build a shared library, but raylib_shared cmake was complaining. Have you been able to build raylib_shared throug cmake to use as a shared library before?

```
[ 37%] Built target glfw
[ 55%] Built target raylib
[ 57%] Linking C shared library libraylib-libretro-shared.so
/usr/bin/ld: ../vendor/raylib/raylib/libraylib.a(rtextures.c.o): relocation R_X86_64_TPOFF32 against `stbi__g_failure_reason' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: ../vendor/raylib/raylib/libraylib.a(rcore.c.o): relocation R_X86_64_PC32 against symbol `GLAD_GL_VERSION_1_0' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
make[2]: *** [lib/CMakeFiles/raylib-libretro-shared.dir/build.make:180: lib/libraylib-libretro-shared.so] Error 1
make[1]: *** [CMakeFiles/Makefile2:291: lib/CMakeFiles/raylib-libretro-shared.dir/all] Error 2
make: *** [Makefile:152: all] Error 2
```