### PR TITLE
Integrate raylib-app

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,7 @@
 	path = vendor/c-vector
 	url = https://github.com/eteran/c-vector.git
     ignore = dirty
+[submodule "vendor/raylib-app"]
+	path = vendor/raylib-app
+	url = https://github.com/RobLoach/raylib-app
+    ignore = dirty

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -7,6 +7,7 @@ target_link_libraries(raylib-libretro PUBLIC
 )
 target_include_directories(raylib-libretro PUBLIC
     ../vendor/raygui/src
+    ../vendor/raylib-app
 )
 install(TARGETS raylib-libretro DESTINATION bin)
 install(FILES ../README.md DESTINATION share/raylib-libretro)

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -26,6 +26,8 @@
 *
 **********************************************************************************************/
 
+#include "raylib.h"
+
 #define RAYLIB_APP_IMPLEMENTATION
 #include "raylib-app.h"
 

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -164,7 +164,7 @@ void Close(void* userData) {
 
     UnloadLibretroShaders();
     CloseAudioDevice();
-    MemFree(userData);
+    MemFree(data);
 }
 
 App Main() {

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -26,7 +26,8 @@
 *
 **********************************************************************************************/
 
-#include "raylib.h"
+#define RAYLIB_APP_IMPLEMENTATION
+#include "raylib-app.h"
 
 #define RAYLIB_LIBRETRO_IMPLEMENTATION
 #include "raylib-libretro.h"
@@ -37,21 +38,26 @@
 #define RAYLIB_LIBRETRO_MENU_IMPLEMENTATION
 #include "../include/raylib-libretro-menu.h"
 
-int main(int argc, char* argv[]) {
-    // Create the window and audio.
-    SetConfigFlags(FLAG_WINDOW_RESIZABLE | FLAG_VSYNC_HINT);
-    InitWindow(800, 600, "raylib-libretro");
+typedef struct {
+    LibretroMenu* menu;
+} AppData;
+
+bool Init(void** userData, int argc, char** argv) {
     SetWindowMinSize(400, 300);
+
+    AppData* data = (AppData*)MemAlloc(sizeof(AppData));
+    *userData = data;
+
     InitAudioDevice();
 
     // Load the shaders and the menu.
     LoadLibretroShaders();
-    LibretroMenu* menu = InitLibretroMenu();
-    if (!menu) {
+    data->menu = InitLibretroMenu();
+    if (!data->menu) {
         TraceLog(LOG_ERROR, "Failed to initialize menu");
         UnloadLibretroShaders();
         CloseAudioDevice();
-        CloseWindow();
+        return false;
     }
 
     // Parse the command line arguments.
@@ -61,84 +67,94 @@ int main(int argc, char* argv[]) {
             // Load the given game.
             const char* gameFile = (argc > 2) ? argv[2] : NULL;
             if (LoadLibretroGame(gameFile)) {
-                menu->active = false;
+                data->menu->active = false;
             }
         }
     }
 
-    while (!WindowShouldClose()) {
-        // Update the shaders.
-        UpdateLibretroShaders(GetFrameTime());
+    return true;
+}
 
-        // Run a frame of the core.
-        if (!menu->active) {
-            UpdateLibretro();
+bool UpdateDrawFrame(void* userData) {
+    AppData* data = (AppData*)userData;
+
+    // Update the shaders.
+    UpdateLibretroShaders(GetFrameTime());
+
+    // Run a frame of the core.
+    if (!data->menu->active) {
+        UpdateLibretro();
+    }
+
+    UpdateLibretroMenu();
+
+    // Check if the core asks to be shutdown.
+    if (LibretroShouldClose()) {
+        UnloadLibretroGame();
+        CloseLibretro();
+    }
+
+    // Render the libretro core.
+    BeginDrawing();
+    {
+        ClearBackground(BLACK);
+
+        if (data->menu->active) {
+            BeginLibretroShader();
+            DrawLibretroTint(ColorAlpha(WHITE, 0.1f));
+            EndShaderMode();
+        }
+        else {
+            BeginLibretroShader();
+            DrawLibretro();
+            EndLibretroShader();
         }
 
-        UpdateLibretroMenu();
+        DrawLibretroMenu();
+    }
+    EndDrawing();
 
-        // Check if the core asks to be shutdown.
-        if (LibretroShouldClose()) {
-            UnloadLibretroGame();
-            CloseLibretro();
-        }
+    // Fullscreen
+    if (IsKeyReleased(KEY_F11)) {
+        ToggleFullscreen();
+    }
 
-        // Render the libretro core.
-        BeginDrawing();
-        {
-            ClearBackground(BLACK);
-
-            if (menu->active) {
-                BeginLibretroShader();
-                DrawLibretroTint(ColorAlpha(WHITE, 0.1f));
-                EndShaderMode();
-            }
-            else {
-                BeginLibretroShader();
-                DrawLibretro();
-                EndLibretroShader();
-            }
-
-            DrawLibretroMenu();
-        }
-        EndDrawing();
-
-        // Fullscreen
-        if (IsKeyReleased(KEY_F11)) {
-            ToggleFullscreen();
-        }
-
-        // Screenshot
-        else if (IsKeyReleased(KEY_F8)) {
-            for (int i = 1; i < 1000; i++) {
-                const char* screenshotName = TextFormat("screenshot-%i.png", i);
-                if (!FileExists(screenshotName)) {
-                    TakeScreenshot(screenshotName);
-                    break;
-                }
-            }
-        }
-
-        // Save State
-        else if (IsKeyReleased(KEY_F2)) {
-            unsigned int size;
-            void* data = GetLibretroSerializedData(&size);
-            if (data != NULL) {
-                SaveFileData(TextFormat("save_%s.sav", GetLibretroName()), data, (int)size);
-                MemFree(data);
-            }
-        }
-
-        // Load State
-        else if (IsKeyReleased(KEY_F4)) {
-            int dataSize;
-            void* data = LoadFileData(TextFormat("save_%s.sav", GetLibretroName()), &dataSize);
-            if (data != NULL) {
-                SetLibretroSerializedData(data, (unsigned int)dataSize);
-                MemFree(data);
+    // Screenshot
+    else if (IsKeyReleased(KEY_F8)) {
+        for (int i = 1; i < 1000; i++) {
+            const char* screenshotName = TextFormat("screenshot-%i.png", i);
+            if (!FileExists(screenshotName)) {
+                TakeScreenshot(screenshotName);
+                break;
             }
         }
     }
+
+    // Save State
+    else if (IsKeyReleased(KEY_F2)) {
+        unsigned int size;
+        void* saveData = GetLibretroSerializedData(&size);
+        if (saveData != NULL) {
+            SaveFileData(TextFormat("save_%s.sav", GetLibretroName()), saveData, (int)size);
+            MemFree(saveData);
+        }
+    }
+
+    // Load State
+    else if (IsKeyReleased(KEY_F4)) {
+        int dataSize;
+        void* saveData = LoadFileData(TextFormat("save_%s.sav", GetLibretroName()), &dataSize);
+        if (saveData != NULL) {
+            SetLibretroSerializedData(saveData, (unsigned int)dataSize);
+            MemFree(saveData);
+        }
+    }
+
+    return true;
+}
+
+void Close(void* userData) {
+    AppData* data = (AppData*)userData;
 
     // Unload the game and close the core.
     UnloadLibretroGame();
@@ -148,7 +164,17 @@ int main(int argc, char* argv[]) {
 
     UnloadLibretroShaders();
     CloseAudioDevice();
-    CloseWindow();
+    MemFree(userData);
+}
 
-    return 0;
+App Main() {
+    return (App){
+        .title = "raylib-libretro",
+        .width = 800,
+        .height = 600,
+        .init = Init,
+        .update = UpdateDrawFrame,
+        .close = Close,
+        .configFlags = FLAG_WINDOW_RESIZABLE | FLAG_VSYNC_HINT,
+    };
 }

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -4,6 +4,3 @@ add_executable(raylib-libretro-basic
 target_link_libraries(raylib-libretro-basic PUBLIC
     raylib-libretro-static
 )
-target_include_directories(raylib-libretro-basic PRIVATE
-    ../vendor/raylib-app
-)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -4,3 +4,6 @@ add_executable(raylib-libretro-basic
 target_link_libraries(raylib-libretro-basic PUBLIC
     raylib-libretro-static
 )
+target_include_directories(raylib-libretro-basic PRIVATE
+    ../vendor/raylib-app
+)

--- a/example/raylib-libretro-basic.c
+++ b/example/raylib-libretro-basic.c
@@ -26,83 +26,60 @@
 *
 **********************************************************************************************/
 
-#define RAYLIB_APP_IMPLEMENTATION
-#include "raylib-app.h"
+#include "raylib.h"
 
 #define RAYLIB_LIBRETRO_IMPLEMENTATION
 #include "raylib-libretro.h"
 
-typedef struct {
-    const char* corePath;
-    const char* gamePath;
-} AppData;
-
-bool Init(void** userData, int argc, char** argv) {
+int main(int argc, char* argv[]) {
+    // Ensure proper amount of arguments.
     if (argc <= 1) {
         TraceLog(LOG_ERROR, "Usage: %s <core> [game]", argv[0]);
-        return false;
+        return 1;
     }
 
-    AppData* data = (AppData*)MemAlloc(sizeof(AppData));
-    data->corePath = argv[1];
-    data->gamePath = (argc > 2) ? argv[2] : NULL;
-    *userData = data;
-
+    // Create the window and audio.
+    SetConfigFlags(FLAG_WINDOW_RESIZABLE);
+    InitWindow(800, 600, "raylib-libretro - basic window");
     InitAudioDevice();
 
     // Initialize the given core.
-    if (!InitLibretro(data->corePath)) {
+    if (!InitLibretro(argv[1])) {
         TraceLog(LOG_ERROR, "Failed to initialize libretro core");
         CloseAudioDevice();
-        return false;
+        CloseWindow();
+        return 1;
     }
 
     // Load the given game.
-    if (!LoadLibretroGame(data->gamePath)) {
+    const char* gameFile = (argc > 2) ? argv[2] : NULL;
+    if (!LoadLibretroGame(gameFile)) {
         TraceLog(LOG_ERROR, "Failed to initialize libretro content");
         CloseLibretro();
         CloseAudioDevice();
-        return false;
+        CloseWindow();
+        return 1;
     }
 
-    // Resize the window and set the title to match the loaded core.
-    SetWindowSize((int)GetLibretroWidth(), (int)GetLibretroHeight());
-    SetWindowTitle(GetLibretroName());
+    while (!WindowShouldClose() && !LibretroShouldClose()) {
+        // Run a frame of the core.
+        UpdateLibretro();
 
-    return true;
-}
+        // Render the libretro core.
+        BeginDrawing();
+        {
+            ClearBackground(BLACK);
+            DrawLibretro();
+        }
+        EndDrawing();
+    }
 
-bool UpdateDrawFrame(void* userData) {
-    // Run a frame of the core.
-    UpdateLibretro();
-
-    // Render the libretro core.
-    BeginDrawing();
-        ClearBackground(BLACK);
-        DrawLibretro();
-    EndDrawing();
-
-    return !LibretroShouldClose();
-}
-
-void Close(void* userData) {
     // Unload the game first, and then close the core.
     UnloadLibretroGame();
     CloseLibretro();
 
     CloseAudioDevice();
-    MemFree(userData);
-}
+    CloseWindow();
 
-App Main() {
-    return (App){
-        .title = "raylib-libretro",
-        .width = 800,
-        .height = 600,
-        .init = Init,
-        .update = UpdateDrawFrame,
-        .close = Close,
-        .fps = 60,
-        .configFlags = FLAG_WINDOW_RESIZABLE,
-    };
+    return 0;
 }

--- a/example/raylib-libretro-basic.c
+++ b/example/raylib-libretro-basic.c
@@ -26,60 +26,83 @@
 *
 **********************************************************************************************/
 
-#include "raylib.h"
+#define RAYLIB_APP_IMPLEMENTATION
+#include "raylib-app.h"
 
 #define RAYLIB_LIBRETRO_IMPLEMENTATION
 #include "raylib-libretro.h"
 
-int main(int argc, char* argv[]) {
-    // Ensure proper amount of arguments.
+typedef struct {
+    const char* corePath;
+    const char* gamePath;
+} AppData;
+
+bool Init(void** userData, int argc, char** argv) {
     if (argc <= 1) {
         TraceLog(LOG_ERROR, "Usage: %s <core> [game]", argv[0]);
-        return 1;
+        return false;
     }
 
-    // Create the window and audio.
-    SetConfigFlags(FLAG_WINDOW_RESIZABLE);
-    InitWindow(800, 600, "raylib-libretro - basic window");
+    AppData* data = (AppData*)MemAlloc(sizeof(AppData));
+    data->corePath = argv[1];
+    data->gamePath = (argc > 2) ? argv[2] : NULL;
+    *userData = data;
+
     InitAudioDevice();
 
     // Initialize the given core.
-    if (!InitLibretro(argv[1])) {
+    if (!InitLibretro(data->corePath)) {
         TraceLog(LOG_ERROR, "Failed to initialize libretro core");
         CloseAudioDevice();
-        CloseWindow();
-        return 1;
+        return false;
     }
 
     // Load the given game.
-    const char* gameFile = (argc > 2) ? argv[2] : NULL;
-    if (!LoadLibretroGame(gameFile)) {
+    if (!LoadLibretroGame(data->gamePath)) {
         TraceLog(LOG_ERROR, "Failed to initialize libretro content");
         CloseLibretro();
         CloseAudioDevice();
-        CloseWindow();
-        return 1;
+        return false;
     }
 
-    while (!WindowShouldClose() && !LibretroShouldClose()) {
-        // Run a frame of the core.
-        UpdateLibretro();
+    // Resize the window and set the title to match the loaded core.
+    SetWindowSize((int)GetLibretroWidth(), (int)GetLibretroHeight());
+    SetWindowTitle(GetLibretroName());
 
-        // Render the libretro core.
-        BeginDrawing();
-        {
-            ClearBackground(BLACK);
-            DrawLibretro();
-        }
-        EndDrawing();
-    }
+    return true;
+}
 
+bool UpdateDrawFrame(void* userData) {
+    // Run a frame of the core.
+    UpdateLibretro();
+
+    // Render the libretro core.
+    BeginDrawing();
+        ClearBackground(BLACK);
+        DrawLibretro();
+    EndDrawing();
+
+    return !LibretroShouldClose();
+}
+
+void Close(void* userData) {
     // Unload the game first, and then close the core.
     UnloadLibretroGame();
     CloseLibretro();
 
     CloseAudioDevice();
-    CloseWindow();
+    MemFree(userData);
+}
 
-    return 0;
+App Main() {
+    return (App){
+        .title = "raylib-libretro",
+        .width = 800,
+        .height = 600,
+        .init = Init,
+        .update = UpdateDrawFrame,
+        .close = Close,
+        .fps = 60,
+        .configFlags = FLAG_WINDOW_RESIZABLE,
+    };
 }


### PR DESCRIPTION
- Add vendor/raylib-app as a git submodule
- Update example/CMakeLists.txt to include vendor/raylib-app headers
- Refactor example/raylib-libretro-basic.c to use raylib-app's
  Init/UpdateDrawFrame/Close callback pattern instead of a manual
  main() loop; argc/argv are handled in Init, window size and title
  are updated from core metadata after LoadLibretroGame, and AppData
  carries corePath/gamePath through userData

https://claude.ai/code/session_01MSZ6dCRVrdx1wFe97wWvPy