### PR TITLE
Add fullscreen toggle to Options screen in menu

### DIFF
--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -190,14 +190,14 @@ LibretroMenu* InitLibretroMenu(void) {
 
     // Build the Menu
     nk_console_button(menu.console, "Load Game");
+    nk_console_button(menu.console, "Options");
     menu.fullscreen = (nk_bool)IsWindowFullscreen();
-    nk_console* options = nk_console_button(menu.console, "Options");
+    nk_console* settings = nk_console_button(menu.console, "Settings");
     {
-        nk_console* fullscreenCheckbox = nk_console_checkbox(options, "Fullscreen", &menu.fullscreen);
+        nk_console* fullscreenCheckbox = nk_console_checkbox(settings, "Fullscreen", &menu.fullscreen);
         nk_console_add_event(fullscreenCheckbox, NK_CONSOLE_EVENT_CHANGED, LibretroMenuFullscreenChanged);
-        nk_console_button_onclick(options, "Back", &nk_console_button_back);
+        nk_console_button_onclick(settings, "Back", &nk_console_button_back);
     }
-    nk_console_button(menu.console, "Settings");
     nk_console_button(menu.console, "Save State");
     nk_console_button(menu.console, "Load State");
     nk_console_button(menu.console, "Quit");

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -50,6 +50,7 @@ typedef struct LibretroMenu {
     nk_console* console;
     bool active;
     struct nk_rect lastBounds;
+    nk_bool fullscreen;
 } LibretroMenu;
 
 #if defined(__cplusplus)
@@ -160,6 +161,12 @@ void SetLibretroMenuStyle(LibretroMenuStyle style) {
     }
 }
 
+static void LibretroMenuFullscreenChanged(nk_console* widget, void* user_data) {
+    (void)widget;
+    (void)user_data;
+    ToggleFullscreen();
+}
+
 LibretroMenu* InitLibretroMenu(void) {
     menu = (LibretroMenu){0};
     menu.font = LoadFontFromNuklear(52);
@@ -183,10 +190,11 @@ LibretroMenu* InitLibretroMenu(void) {
 
     // Build the Menu
     nk_console_button(menu.console, "Load Game");
+    menu.fullscreen = (nk_bool)IsWindowFullscreen();
     nk_console* options = nk_console_button(menu.console, "Options");
     {
-        nk_console_button(options, "Some cool option!");
-        nk_console_button(options, "Option #2");
+        nk_console* fullscreenCheckbox = nk_console_checkbox(options, "Fullscreen", &menu.fullscreen);
+        nk_console_add_event(fullscreenCheckbox, NK_CONSOLE_EVENT_CHANGED, LibretroMenuFullscreenChanged);
         nk_console_button_onclick(options, "Back", &nk_console_button_back);
     }
     nk_console_button(menu.console, "Settings");
@@ -233,6 +241,9 @@ void UpdateLibretroMenu(void) {
     if (!menu.active) {
         return;
     }
+
+    // Keep fullscreen checkbox in sync with the actual window state (e.g. F11 presses).
+    menu.fullscreen = (nk_bool)IsWindowFullscreen();
 
     // Render the console centered in the screen, using last frame's bounds for height
     struct nk_rect windowPos;


### PR DESCRIPTION
Replaces placeholder options with a Fullscreen checkbox that calls
ToggleFullscreen() when toggled. The checkbox stays in sync with the
window's actual fullscreen state (e.g. F11 key presses) each frame.

https://claude.ai/code/session_014QC2Cx4p6Zy7H87hg7EYsp