### PR TITLE
Add directory configuration for Cores, Games, Saves, Screenshots

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,42 +141,6 @@ CloseWindow();
 - `GetLibretroSerializedData(&size)` → `void*` (caller must `MemFree()`)
 - `SetLibretroSerializedData(data, size)` → `bool`
 
-## Shader System (raylib-libretro-shaders.h)
-
-### Available Shader Types
-
-| Enum | Name | Notes |
-|------|------|-------|
-| `SHADER_NONE` | None | Pass-through |
-| `SHADER_CRT` | CRT | Barrel distortion, phosphor mask |
-| `SHADER_SCANLINES` | Scanlines | Horizontal scanline overlay |
-| `SHADER_VIGNETTE` | Vignette | Darkened corners |
-| `SHADER_GRAYSCALE` | Grayscale | Monochrome + tint |
-| `SHADER_NTSC` | NTSC | Composite artifacts |
-
-### Shader Usage
-
-```c
-LoadLibretroShaders();                     // Load all shaders with defaults
-
-while (!WindowShouldClose()) {
-    UpdateLibretroShaders(GetFrameTime()); // F10 = next, F9 = previous
-    BeginDrawing();
-        BeginLibretroShader();
-            DrawLibretro();
-        EndLibretroShader();
-    EndDrawing();
-}
-
-UnloadLibretroShaders();
-```
-
-Key shader API functions: `LoadLibretroShader(type)`, `LoadLibretroShaderEx(type, params)`, `SetActiveLibretroShader(type)`, `GetActiveLibretroShaderType()`, `GetActiveLibretroShaderState()`, `CycleLibretroShader()`, `CycleLibretroShaderReverse()`.
-
-GLSL sources are embedded directly in the header as string literals, with multiple versions (GLSL 100 for OpenGL ES / web, 120 for older desktop, 330 for modern desktop). Platform selection is via `PLATFORM_DESKTOP`.
-
----
-
 ## Build System
 
 ### Prerequisites
@@ -229,8 +193,6 @@ bin/raylib-libretro ~/.config/retroarch/cores/fceumm_libretro.so smb.nes
 # macOS example
 bin/raylib-libretro ~/Library/Application\ Support/RetroArch/cores/fceumm_libretro.dylib smb.nes
 ```
-
-Tested cores: `fceumm` (NES), `snes9x` (SNES), `picodrive` (Sega).
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ bin/raylib-libretro ~/.config/retroarch/cores/fceumm_libretro.so smb.nes
 
 ### Mac OSX
 
-- Make sure you have you have cmake/xcode-cli-tools installed
+- Make sure you have you have `cmake/xcode-cli-tools` installed
 - Run the above compile instructions
 - After installing RetroArch and some cores, you should be able to run the below:
     ```bash
@@ -63,8 +63,8 @@ bin/raylib-libretro ~/.config/retroarch/cores/fceumm_libretro.so smb.nes
 ## Basic Usage
 
 ```c
-InitLibretro("snes9x.so");
-LoadLibretroGame("mario.rom");
+InitLibretro("fceumm.so");
+LoadLibretroGame("mario.nes");
 while (!WindowShouldClose()) {
     UpdateLibretro();
     BeginDrawing();
@@ -77,25 +77,39 @@ CloseLibretro();
 
 ## API Reference
 
-| Function | Description |
-| --- | --- |
-| `GetLibretroShaderCode(type)` | Returns the embedded GLSL source for the given type |
-| `GetLibretroShaderDefaults(type)` | Returns a state populated with default parameters |
-| `GetLibretroShaderName(type)` | Returns the display name (`"CRT"`, `"None"`, etc.) |
-| `LoadLibretroShader(type)` | Compile shader with defaults |
-| `LoadLibretroShaderEx(type, params)` | Compile shader with custom params |
-| `UpdateLibretroShader(state, dt)` | Re-upload uniforms, accumulate time |
-| `UnloadLibretroShader(state)` | Free GPU resource |
-| `LoadLibretroShaders()` | Load all shaders with defaults |
-| `UnloadLibretroShaders()` | Unload all shader GPU resources |
-| `UpdateLibretroShaders(dt)` | Update active shader; F10 = next, F9 = previous |
-| `CycleLibretroShader()` | Advance to next shader type |
-| `CycleLibretroShaderReverse()` | Go back to previous shader type |
-| `SetActiveLibretroShader(type)` | Activate a specific shader |
-| `GetActiveLibretroShaderType()` | Returns the active `LibretroShaderType` |
-| `GetActiveLibretroShaderState()` | Returns mutable pointer to active state, or NULL |
-| `BeginLibretroShader()` | Begin shader mode (no-op when `SHADER_NONE`) |
-| `EndLibretroShader()` | End shader mode (no-op when `SHADER_NONE`) |
+``` c
+static bool InitLibretro(const char* core);
+static bool LoadLibretroGame(const char* gameFile);
+static bool IsLibretroReady();
+static bool IsLibretroGameReady();
+static void UpdateLibretro();
+static bool LibretroShouldClose();
+static void DrawLibretro();
+static void DrawLibretroTint(Color tint);
+static void DrawLibretroEx(Vector2 position, float rotation, float scale, Color tint);
+static void DrawLibretroV(Vector2 position, Color tint);
+static void DrawLibretroTexture(int posX, int posY, Color tint);
+static void DrawLibretroPro(Rectangle destRec, Color tint);
+static const char* GetLibretroName();
+static const char* GetLibretroVersion();
+static unsigned GetLibretroWidth();
+static unsigned GetLibretroHeight();
+static unsigned GetLibretroRotation();
+static Texture2D GetLibretroTexture();
+static bool DoesLibretroCoreNeedContent();
+static void ResetLibretro();
+static void UnloadLibretroGame();
+static void CloseLibretro();
+static void SetLibretroVolume(float volume);
+static float GetLibretroVolume();
+static bool SetLibretroCoreOption(const char* key, const char* value);
+static const char* GetLibretroCoreOption(const char* key);
+static void* GetLibretroSerializedData(unsigned int* size);
+static bool SetLibretroSerializedData(void* data, unsigned int size);
+static void ShowLibretroMessage(const char* msg, float duration);
+static bool DrawLibretroMessage();
+static const char* GetLibretroDirectory(int directory);
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -78,37 +78,37 @@ CloseLibretro();
 ## API Reference
 
 ``` c
-static bool InitLibretro(const char* core);
-static bool LoadLibretroGame(const char* gameFile);
-static bool IsLibretroReady();
-static bool IsLibretroGameReady();
-static void UpdateLibretro();
-static bool LibretroShouldClose();
-static void DrawLibretro();
-static void DrawLibretroTint(Color tint);
-static void DrawLibretroEx(Vector2 position, float rotation, float scale, Color tint);
-static void DrawLibretroV(Vector2 position, Color tint);
-static void DrawLibretroTexture(int posX, int posY, Color tint);
-static void DrawLibretroPro(Rectangle destRec, Color tint);
-static const char* GetLibretroName();
-static const char* GetLibretroVersion();
-static unsigned GetLibretroWidth();
-static unsigned GetLibretroHeight();
-static unsigned GetLibretroRotation();
-static Texture2D GetLibretroTexture();
-static bool DoesLibretroCoreNeedContent();
-static void ResetLibretro();
-static void UnloadLibretroGame();
-static void CloseLibretro();
-static void SetLibretroVolume(float volume);
-static float GetLibretroVolume();
-static bool SetLibretroCoreOption(const char* key, const char* value);
-static const char* GetLibretroCoreOption(const char* key);
-static void* GetLibretroSerializedData(unsigned int* size);
-static bool SetLibretroSerializedData(void* data, unsigned int size);
-static void ShowLibretroMessage(const char* msg, float duration);
-static bool DrawLibretroMessage();
-static const char* GetLibretroDirectory(int directory);
+bool InitLibretro(const char* core);
+bool LoadLibretroGame(const char* gameFile);
+bool IsLibretroReady();
+bool IsLibretroGameReady();
+void UpdateLibretro();
+bool LibretroShouldClose();
+void DrawLibretro();
+void DrawLibretroTint(Color tint);
+void DrawLibretroEx(Vector2 position, float rotation, float scale, Color tint);
+void DrawLibretroV(Vector2 position, Color tint);
+void DrawLibretroTexture(int posX, int posY, Color tint);
+void DrawLibretroPro(Rectangle destRec, Color tint);
+const char* GetLibretroName();
+const char* GetLibretroVersion();
+unsigned GetLibretroWidth();
+unsigned GetLibretroHeight();
+unsigned GetLibretroRotation();
+Texture2D GetLibretroTexture();
+bool DoesLibretroCoreNeedContent();
+void ResetLibretro();
+void UnloadLibretroGame();
+void CloseLibretro();
+void SetLibretroVolume(float volume);
+float GetLibretroVolume();
+bool SetLibretroCoreOption(const char* key, const char* value);
+const char* GetLibretroCoreOption(const char* key);
+void* GetLibretroSerializedData(unsigned int* size);
+bool SetLibretroSerializedData(void* data, unsigned int size);
+void ShowLibretroMessage(const char* msg, float duration);
+bool DrawLibretroMessage();
+const char* GetLibretroDirectory(int directory);
 ```
 
 ## Development

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -207,7 +207,7 @@ bool UpdateDrawFrame(void* userData) {
 
     // Screenshot
     else if (IsKeyReleased(KEY_F8)) {
-        const char* screenshotsDir = LibretroGetDirectory(LibretroCore.screenshotsDirectory);
+        const char* screenshotsDir = GetLibretroDirectory(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY);
         const char* screenshotName = NULL;
         for (int i = 1; i < 1000; i++) {
             screenshotName = TextFormat("%s/screenshot-%i.png", screenshotsDir, i);

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -207,9 +207,10 @@ bool UpdateDrawFrame(void* userData) {
 
     // Screenshot
     else if (IsKeyReleased(KEY_F8)) {
+        const char* screenshotsDir = LibretroGetDirectory(LibretroCore.screenshotsDirectory);
         const char* screenshotName = NULL;
         for (int i = 1; i < 1000; i++) {
-            screenshotName = TextFormat("screenshot-%i.png", i);
+            screenshotName = TextFormat("%s/screenshot-%i.png", screenshotsDir, i);
             if (!FileExists(screenshotName)) {
                 TakeScreenshot(screenshotName);
                 break;

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -235,7 +235,7 @@ static void LibretroMenuSaveStateClicked(nk_console* widget, void* user_data) {
     unsigned int size;
     void* saveData = GetLibretroSerializedData(&size);
     if (saveData != NULL) {
-        const char* savesDir = LibretroGetDirectory(LibretroCore.savesDirectory);
+        const char* savesDir = GetLibretroDirectory(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY);
         SaveFileData(TextFormat("%s/save_%s.sav", savesDir, GetLibretroName()), saveData, (int)size);
         MemFree(saveData);
         ShowLibretroMessage("State Saved", 2.0f);
@@ -257,7 +257,7 @@ static void LibretroMenuLoadStateClicked(nk_console* widget, void* user_data) {
     (void)user_data;
     if (!IsLibretroGameReady()) return;
     int dataSize;
-    const char* savesDir = LibretroGetDirectory(LibretroCore.savesDirectory);
+    const char* savesDir = GetLibretroDirectory(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY);
     void* saveData = LoadFileData(TextFormat("%s/save_%s.sav", savesDir, GetLibretroName()), &dataSize);
     if (saveData != NULL) {
         SetLibretroSerializedData(saveData, (unsigned int)dataSize);
@@ -358,20 +358,26 @@ LibretroMenu* InitLibretroMenu(void) {
         nk_console_add_event_handler(rewind, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
 
         // Directories
-        nk_console* coresDir = nk_console_dir(settings, "Cores Dir", LibretroCore.coresDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
-        nk_console_add_event_handler(coresDir, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
-        nk_console* systemDir = nk_console_dir(settings, "System Dir", LibretroCore.systemDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
-        nk_console_add_event_handler(systemDir, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
-        nk_console* assetsDir = nk_console_dir(settings, "Assets Dir", LibretroCore.assetsDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
-        nk_console_add_event_handler(assetsDir, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
-        nk_console* gamesDir = nk_console_dir(settings, "Games Dir", LibretroCore.gamesDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
-        nk_console_add_event_handler(gamesDir, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
-        nk_console* playlistsDir = nk_console_dir(settings, "Playlists Dir", LibretroCore.playlistsDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
-        nk_console_add_event_handler(playlistsDir, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
-        nk_console* savesDir = nk_console_dir(settings, "Saves Dir", LibretroCore.savesDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
-        nk_console_add_event_handler(savesDir, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
-        nk_console* screenshotsDir = nk_console_dir(settings, "Screenshots Dir", LibretroCore.screenshotsDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
-        nk_console_add_event_handler(screenshotsDir, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+        nk_console* directoryTree = nk_console_tree(settings, "Directories", nk_true);
+        {
+            nk_console* libretroDirectory = nk_console_dir(directoryTree, "Cores", LibretroCore.libretroDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+            nk_console_add_event_handler(libretroDirectory, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+
+            nk_console* saveDirectory = nk_console_dir(directoryTree, "Saves", LibretroCore.saveDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+            nk_console_add_event_handler(saveDirectory, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+
+            nk_console* coreAssetsDirectory = nk_console_dir(directoryTree, "Assets", LibretroCore.coreAssetsDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+            nk_console_add_event_handler(coreAssetsDirectory, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+
+            nk_console* systemDirectory = nk_console_dir(directoryTree, "System", LibretroCore.systemDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+            nk_console_add_event_handler(systemDirectory, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+
+            nk_console* playlistsDirectory = nk_console_dir(directoryTree, "Playlists", LibretroCore.playlistsDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+            nk_console_add_event_handler(playlistsDirectory, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+
+            nk_console* fileBrowserStartDirectory = nk_console_dir(directoryTree, "Content", LibretroCore.fileBrowserStartDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+            nk_console_add_event_handler(fileBrowserStartDirectory, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+        }
     }
 
     // Core Options
@@ -535,13 +541,12 @@ static void LibretroMenuUpdateConfig(void) {
     rlconfig_set_int(menu.cfg, "raylib-libretro", "theme", menu.themeSelectedIndex);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "volume", (int)(menu.volumeSelected * 100.0f));
     rlconfig_set_int(menu.cfg, "raylib-libretro", "rewind", menu.rewindEnabled ? 1 : 0);
-    rlconfig_set(menu.cfg, "raylib-libretro", "coresDirectory", LibretroCore.coresDirectory);
+    rlconfig_set(menu.cfg, "raylib-libretro", "libretroDirectory", LibretroCore.libretroDirectory);
+    rlconfig_set(menu.cfg, "raylib-libretro", "saveDirectory", LibretroCore.saveDirectory);
+    rlconfig_set(menu.cfg, "raylib-libretro", "coreAssetsDirectory", LibretroCore.coreAssetsDirectory);
     rlconfig_set(menu.cfg, "raylib-libretro", "systemDirectory", LibretroCore.systemDirectory);
-    rlconfig_set(menu.cfg, "raylib-libretro", "assetsDirectory", LibretroCore.assetsDirectory);
-    rlconfig_set(menu.cfg, "raylib-libretro", "gamesDirectory", LibretroCore.gamesDirectory);
     rlconfig_set(menu.cfg, "raylib-libretro", "playlistsDirectory", LibretroCore.playlistsDirectory);
-    rlconfig_set(menu.cfg, "raylib-libretro", "savesDirectory", LibretroCore.savesDirectory);
-    rlconfig_set(menu.cfg, "raylib-libretro", "screenshotsDirectory", LibretroCore.screenshotsDirectory);
+    rlconfig_set(menu.cfg, "raylib-libretro", "fileBrowserStartDirectory", LibretroCore.fileBrowserStartDirectory);
 #endif
 }
 
@@ -641,20 +646,18 @@ static bool LoadLibretroMenuSettings(void) {
 
     menu.rewindEnabled = rlconfig_get_int(menu.cfg, "raylib-libretro", "rewind", 0) > 0;
 
-    const char* savedCoresDir = rlconfig_get(menu.cfg, "raylib-libretro", "coresDirectory");
-    if (savedCoresDir) TextCopy(LibretroCore.coresDirectory, savedCoresDir);
-    const char* savedSystemDir = rlconfig_get(menu.cfg, "raylib-libretro", "systemDirectory");
-    if (savedSystemDir) TextCopy(LibretroCore.systemDirectory, savedSystemDir);
-    const char* savedAssetsDir = rlconfig_get(menu.cfg, "raylib-libretro", "assetsDirectory");
-    if (savedAssetsDir) TextCopy(LibretroCore.assetsDirectory, savedAssetsDir);
-    const char* savedGamesDir = rlconfig_get(menu.cfg, "raylib-libretro", "gamesDirectory");
-    if (savedGamesDir) TextCopy(LibretroCore.gamesDirectory, savedGamesDir);
-    const char* savedPlaylistsDir = rlconfig_get(menu.cfg, "raylib-libretro", "playlistsDirectory");
-    if (savedPlaylistsDir) TextCopy(LibretroCore.playlistsDirectory, savedPlaylistsDir);
-    const char* savedSavesDir = rlconfig_get(menu.cfg, "raylib-libretro", "savesDirectory");
-    if (savedSavesDir) TextCopy(LibretroCore.savesDirectory, savedSavesDir);
-    const char* savedScreenshotsDir = rlconfig_get(menu.cfg, "raylib-libretro", "screenshotsDirectory");
-    if (savedScreenshotsDir) TextCopy(LibretroCore.screenshotsDirectory, savedScreenshotsDir);
+    const char* libretroDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "libretroDirectory");
+    if (libretroDirectory) TextCopy(LibretroCore.libretroDirectory, libretroDirectory);
+    const char* saveDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "saveDirectory");
+    if (saveDirectory) TextCopy(LibretroCore.saveDirectory, saveDirectory);
+    const char* coreAssetsDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "coreAssetsDirectory");
+    if (coreAssetsDirectory) TextCopy(LibretroCore.coreAssetsDirectory, coreAssetsDirectory);
+    const char* systemDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "gamesDirectory");
+    if (systemDirectory) TextCopy(LibretroCore.systemDirectory, systemDirectory);
+    const char* playlistsDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "playlistsDirectory");
+    if (playlistsDirectory) TextCopy(LibretroCore.playlistsDirectory, playlistsDirectory);
+    const char* fileBrowserStartDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "fileBrowserStartDirectory");
+    if (fileBrowserStartDirectory) TextCopy(LibretroCore.fileBrowserStartDirectory, fileBrowserStartDirectory);
 
     TraceLog(LOG_INFO, "MENU: Loaded menu settings from %s", RAYLIB_LIBRETRO_CFG_FILE);
     return true;

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -362,6 +362,8 @@ LibretroMenu* InitLibretroMenu(void) {
         nk_console_add_event_handler(coresDir, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
         nk_console* systemDir = nk_console_dir(settings, "System Dir", LibretroCore.systemDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
         nk_console_add_event_handler(systemDir, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+        nk_console* assetsDir = nk_console_dir(settings, "Assets Dir", LibretroCore.assetsDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+        nk_console_add_event_handler(assetsDir, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
         nk_console* gamesDir = nk_console_dir(settings, "Games Dir", LibretroCore.gamesDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
         nk_console_add_event_handler(gamesDir, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
         nk_console* playlistsDir = nk_console_dir(settings, "Playlists Dir", LibretroCore.playlistsDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
@@ -535,6 +537,7 @@ static void LibretroMenuUpdateConfig(void) {
     rlconfig_set_int(menu.cfg, "raylib-libretro", "rewind", menu.rewindEnabled ? 1 : 0);
     rlconfig_set(menu.cfg, "raylib-libretro", "coresDirectory", LibretroCore.coresDirectory);
     rlconfig_set(menu.cfg, "raylib-libretro", "systemDirectory", LibretroCore.systemDirectory);
+    rlconfig_set(menu.cfg, "raylib-libretro", "assetsDirectory", LibretroCore.assetsDirectory);
     rlconfig_set(menu.cfg, "raylib-libretro", "gamesDirectory", LibretroCore.gamesDirectory);
     rlconfig_set(menu.cfg, "raylib-libretro", "playlistsDirectory", LibretroCore.playlistsDirectory);
     rlconfig_set(menu.cfg, "raylib-libretro", "savesDirectory", LibretroCore.savesDirectory);
@@ -642,6 +645,8 @@ static bool LoadLibretroMenuSettings(void) {
     if (savedCoresDir) TextCopy(LibretroCore.coresDirectory, savedCoresDir);
     const char* savedSystemDir = rlconfig_get(menu.cfg, "raylib-libretro", "systemDirectory");
     if (savedSystemDir) TextCopy(LibretroCore.systemDirectory, savedSystemDir);
+    const char* savedAssetsDir = rlconfig_get(menu.cfg, "raylib-libretro", "assetsDirectory");
+    if (savedAssetsDir) TextCopy(LibretroCore.assetsDirectory, savedAssetsDir);
     const char* savedGamesDir = rlconfig_get(menu.cfg, "raylib-libretro", "gamesDirectory");
     if (savedGamesDir) TextCopy(LibretroCore.gamesDirectory, savedGamesDir);
     const char* savedPlaylistsDir = rlconfig_get(menu.cfg, "raylib-libretro", "playlistsDirectory");

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -360,8 +360,12 @@ LibretroMenu* InitLibretroMenu(void) {
         // Directories
         nk_console* coresDir = nk_console_dir(settings, "Cores Dir", LibretroCore.coresDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
         nk_console_add_event_handler(coresDir, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+        nk_console* systemDir = nk_console_dir(settings, "System Dir", LibretroCore.systemDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+        nk_console_add_event_handler(systemDir, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
         nk_console* gamesDir = nk_console_dir(settings, "Games Dir", LibretroCore.gamesDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
         nk_console_add_event_handler(gamesDir, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+        nk_console* playlistsDir = nk_console_dir(settings, "Playlists Dir", LibretroCore.playlistsDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+        nk_console_add_event_handler(playlistsDir, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
         nk_console* savesDir = nk_console_dir(settings, "Saves Dir", LibretroCore.savesDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
         nk_console_add_event_handler(savesDir, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
         nk_console* screenshotsDir = nk_console_dir(settings, "Screenshots Dir", LibretroCore.screenshotsDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
@@ -530,7 +534,9 @@ static void LibretroMenuUpdateConfig(void) {
     rlconfig_set_int(menu.cfg, "raylib-libretro", "volume", (int)(menu.volumeSelected * 100.0f));
     rlconfig_set_int(menu.cfg, "raylib-libretro", "rewind", menu.rewindEnabled ? 1 : 0);
     rlconfig_set(menu.cfg, "raylib-libretro", "coresDirectory", LibretroCore.coresDirectory);
+    rlconfig_set(menu.cfg, "raylib-libretro", "systemDirectory", LibretroCore.systemDirectory);
     rlconfig_set(menu.cfg, "raylib-libretro", "gamesDirectory", LibretroCore.gamesDirectory);
+    rlconfig_set(menu.cfg, "raylib-libretro", "playlistsDirectory", LibretroCore.playlistsDirectory);
     rlconfig_set(menu.cfg, "raylib-libretro", "savesDirectory", LibretroCore.savesDirectory);
     rlconfig_set(menu.cfg, "raylib-libretro", "screenshotsDirectory", LibretroCore.screenshotsDirectory);
 #endif
@@ -634,8 +640,12 @@ static bool LoadLibretroMenuSettings(void) {
 
     const char* savedCoresDir = rlconfig_get(menu.cfg, "raylib-libretro", "coresDirectory");
     if (savedCoresDir) TextCopy(LibretroCore.coresDirectory, savedCoresDir);
+    const char* savedSystemDir = rlconfig_get(menu.cfg, "raylib-libretro", "systemDirectory");
+    if (savedSystemDir) TextCopy(LibretroCore.systemDirectory, savedSystemDir);
     const char* savedGamesDir = rlconfig_get(menu.cfg, "raylib-libretro", "gamesDirectory");
     if (savedGamesDir) TextCopy(LibretroCore.gamesDirectory, savedGamesDir);
+    const char* savedPlaylistsDir = rlconfig_get(menu.cfg, "raylib-libretro", "playlistsDirectory");
+    if (savedPlaylistsDir) TextCopy(LibretroCore.playlistsDirectory, savedPlaylistsDir);
     const char* savedSavesDir = rlconfig_get(menu.cfg, "raylib-libretro", "savesDirectory");
     if (savedSavesDir) TextCopy(LibretroCore.savesDirectory, savedSavesDir);
     const char* savedScreenshotsDir = rlconfig_get(menu.cfg, "raylib-libretro", "screenshotsDirectory");

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -235,7 +235,8 @@ static void LibretroMenuSaveStateClicked(nk_console* widget, void* user_data) {
     unsigned int size;
     void* saveData = GetLibretroSerializedData(&size);
     if (saveData != NULL) {
-        SaveFileData(TextFormat("save_%s.sav", GetLibretroName()), saveData, (int)size);
+        const char* savesDir = LibretroGetDirectory(LibretroCore.savesDirectory);
+        SaveFileData(TextFormat("%s/save_%s.sav", savesDir, GetLibretroName()), saveData, (int)size);
         MemFree(saveData);
         ShowLibretroMessage("State Saved", 2.0f);
         menu.active = false;
@@ -256,7 +257,8 @@ static void LibretroMenuLoadStateClicked(nk_console* widget, void* user_data) {
     (void)user_data;
     if (!IsLibretroGameReady()) return;
     int dataSize;
-    void* saveData = LoadFileData(TextFormat("save_%s.sav", GetLibretroName()), &dataSize);
+    const char* savesDir = LibretroGetDirectory(LibretroCore.savesDirectory);
+    void* saveData = LoadFileData(TextFormat("%s/save_%s.sav", savesDir, GetLibretroName()), &dataSize);
     if (saveData != NULL) {
         SetLibretroSerializedData(saveData, (unsigned int)dataSize);
         MemFree(saveData);
@@ -354,6 +356,16 @@ LibretroMenu* InitLibretroMenu(void) {
         // Rewind
         nk_console* rewind = nk_console_checkbox(settings, "Rewind", &menu.rewindEnabled);
         nk_console_add_event_handler(rewind, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+
+        // Directories
+        nk_console* coresDir = nk_console_dir(settings, "Cores Dir", LibretroCore.coresDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+        nk_console_add_event_handler(coresDir, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+        nk_console* gamesDir = nk_console_dir(settings, "Games Dir", LibretroCore.gamesDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+        nk_console_add_event_handler(gamesDir, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+        nk_console* savesDir = nk_console_dir(settings, "Saves Dir", LibretroCore.savesDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+        nk_console_add_event_handler(savesDir, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+        nk_console* screenshotsDir = nk_console_dir(settings, "Screenshots Dir", LibretroCore.screenshotsDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+        nk_console_add_event_handler(screenshotsDir, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
     }
 
     // Core Options
@@ -517,6 +529,10 @@ static void LibretroMenuUpdateConfig(void) {
     rlconfig_set_int(menu.cfg, "raylib-libretro", "theme", menu.themeSelectedIndex);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "volume", (int)(menu.volumeSelected * 100.0f));
     rlconfig_set_int(menu.cfg, "raylib-libretro", "rewind", menu.rewindEnabled ? 1 : 0);
+    rlconfig_set(menu.cfg, "raylib-libretro", "coresDirectory", LibretroCore.coresDirectory);
+    rlconfig_set(menu.cfg, "raylib-libretro", "gamesDirectory", LibretroCore.gamesDirectory);
+    rlconfig_set(menu.cfg, "raylib-libretro", "savesDirectory", LibretroCore.savesDirectory);
+    rlconfig_set(menu.cfg, "raylib-libretro", "screenshotsDirectory", LibretroCore.screenshotsDirectory);
 #endif
 }
 
@@ -615,6 +631,15 @@ static bool LoadLibretroMenuSettings(void) {
     SetLibretroVolume(menu.volumeSelected);
 
     menu.rewindEnabled = rlconfig_get_int(menu.cfg, "raylib-libretro", "rewind", 0) > 0;
+
+    const char* savedCoresDir = rlconfig_get(menu.cfg, "raylib-libretro", "coresDirectory");
+    if (savedCoresDir) TextCopy(LibretroCore.coresDirectory, savedCoresDir);
+    const char* savedGamesDir = rlconfig_get(menu.cfg, "raylib-libretro", "gamesDirectory");
+    if (savedGamesDir) TextCopy(LibretroCore.gamesDirectory, savedGamesDir);
+    const char* savedSavesDir = rlconfig_get(menu.cfg, "raylib-libretro", "savesDirectory");
+    if (savedSavesDir) TextCopy(LibretroCore.savesDirectory, savedSavesDir);
+    const char* savedScreenshotsDir = rlconfig_get(menu.cfg, "raylib-libretro", "screenshotsDirectory");
+    if (savedScreenshotsDir) TextCopy(LibretroCore.screenshotsDirectory, savedScreenshotsDir);
 
     TraceLog(LOG_INFO, "MENU: Loaded menu settings from %s", RAYLIB_LIBRETRO_CFG_FILE);
     return true;

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -236,6 +236,7 @@ static void LibretroMenuSaveStateClicked(nk_console* widget, void* user_data) {
     void* saveData = GetLibretroSerializedData(&size);
     if (saveData != NULL) {
         const char* savesDir = GetLibretroDirectory(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY);
+        // TODO: Add the content name in here if applicable too.
         SaveFileData(TextFormat("%s/save_%s.sav", savesDir, GetLibretroName()), saveData, (int)size);
         MemFree(saveData);
         ShowLibretroMessage("State Saved", 2.0f);
@@ -258,6 +259,7 @@ static void LibretroMenuLoadStateClicked(nk_console* widget, void* user_data) {
     if (!IsLibretroGameReady()) return;
     int dataSize;
     const char* savesDir = GetLibretroDirectory(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY);
+    // TODO: Add the libretro content name in here too.
     void* saveData = LoadFileData(TextFormat("%s/save_%s.sav", savesDir, GetLibretroName()), &dataSize);
     if (saveData != NULL) {
         SetLibretroSerializedData(saveData, (unsigned int)dataSize);

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -252,7 +252,9 @@ typedef struct rLibretro {
 
     // Directory configuration. Empty string means use GetApplicationDirectory().
     char coresDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    char systemDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char gamesDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    char playlistsDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char savesDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char screenshotsDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
 } rLibretro;
@@ -510,7 +512,7 @@ static bool LibretroSetEnvironment(unsigned cmd, void * data) {
                 TraceLog(LOG_WARNING, "LIBRETRO: RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY no data set");
                 return false;
             }
-            *dir = LibretroGetDirectory(LibretroCore.coresDirectory);
+            *dir = LibretroGetDirectory(LibretroCore.systemDirectory);
             return true;
         }
 
@@ -1254,7 +1256,7 @@ static bool LibretroSetEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const char** dir = (const char**)data;
-            *dir = LibretroGetDirectory(LibretroCore.gamesDirectory);
+            *dir = LibretroGetDirectory(LibretroCore.playlistsDirectory);
             return true;
         }
 

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -80,6 +80,7 @@ static void* GetLibretroSerializedData(unsigned int* size);     // Retrieve the 
 static bool SetLibretroSerializedData(void* data, unsigned int size);
 static void ShowLibretroMessage(const char* msg, float duration); // Show an OSD message for the given duration in seconds.
 static bool DrawLibretroMessage(); // Displays the OSD message on the screen. Returns true if there was one.
+static const char* GetLibretroDirectory(int directory);
 
 static void LibretroMapPixelFormatARGB1555ToRGB565(void *output_, const void *input_,
         int width, int height,
@@ -251,13 +252,13 @@ typedef struct rLibretro {
     retro_perf_tick_t gameTimeNSEC;
 
     // Directory configuration. Empty string means use GetApplicationDirectory().
-    char coresDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    // TODO: Change this to be MemAlloc-ed?
+    char libretroDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    char saveDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    char coreAssetsDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char systemDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
-    char assetsDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
-    char gamesDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char playlistsDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
-    char savesDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
-    char screenshotsDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    char fileBrowserStartDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
 } rLibretro;
 
 #if defined(__cplusplus)
@@ -315,9 +316,38 @@ static const char *GetLibretroCoreOption(const char *key) {
     return LibretroGetCoreVariable(key);
 }
 
-static const char* LibretroGetDirectory(const char* configured) {
-    if (configured && configured[0] != '\0') return configured;
-    return GetApplicationDirectory();
+/**
+ * Retrieves the directory that is configured as a libretro directory.
+ *
+ * @param directory The key of which directory to retrieve. Can be...
+ * - RETRO_ENVIRONMENT_GET_LIBRETRO_PATH
+ * - RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY
+ * - RETRO_ENVIRONMENT_GET_CORE_ASSETS_DIRECTORY
+ * - RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY
+ * - RETRO_ENVIRONMENT_GET_PLAYLIST_DIRECTORY
+ * - RETRO_ENVIRONMENT_GET_FILE_BROWSER_START_DIRECTORY
+ * - RETRO_ENVIRONMENT_GET_CONTENT_DIRECTORY
+ *
+ * @return The directory that's currently configured for the libretro directory. The application directory by default, or NULL if it's an incorrect directory.
+ */
+static const char* GetLibretroDirectory(int directory) {
+    const char* appDir = GetApplicationDirectory();
+    char* output = NULL;
+    switch (directory) {
+        case RETRO_ENVIRONMENT_GET_LIBRETRO_PATH: output = LibretroCore.libretroDirectory; break;
+        case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY: output = LibretroCore.saveDirectory; break;
+        case RETRO_ENVIRONMENT_GET_CORE_ASSETS_DIRECTORY: output = LibretroCore.coreAssetsDirectory; break; // RETRO_ENVIRONMENT_GET_CONTENT_DIRECTORY
+        case RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY: output = LibretroCore.systemDirectory; break;
+        case RETRO_ENVIRONMENT_GET_PLAYLIST_DIRECTORY: output = LibretroCore.playlistsDirectory; break;
+        case RETRO_ENVIRONMENT_GET_FILE_BROWSER_START_DIRECTORY: output = LibretroCore.fileBrowserStartDirectory; break;
+        default: return NULL;
+    }
+
+    if (output == NULL || output[0] == '\0')
+        return GetApplicationDirectory();
+
+    // TODO: Resolve to an absolute path.
+    return output;
 }
 
 static void LibretroLogger(enum retro_log_level level, const char *fmt, ...) {
@@ -513,7 +543,7 @@ static bool LibretroSetEnvironment(unsigned cmd, void * data) {
                 TraceLog(LOG_WARNING, "LIBRETRO: RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY no data set");
                 return false;
             }
-            *dir = LibretroGetDirectory(LibretroCore.systemDirectory);
+            *dir = GetLibretroDirectory(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY);
             return true;
         }
 
@@ -661,7 +691,7 @@ static bool LibretroSetEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const char** dir = (const char**)data;
-            *dir = LibretroGetDirectory(LibretroCore.coresDirectory);
+            *dir = GetLibretroDirectory(RETRO_ENVIRONMENT_GET_LIBRETRO_PATH);
             return true;
         }
 
@@ -754,7 +784,7 @@ static bool LibretroSetEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const char** dir = (const char**)data;
-            *dir = LibretroGetDirectory(LibretroCore.assetsDirectory);
+            *dir = GetLibretroDirectory(RETRO_ENVIRONMENT_GET_CORE_ASSETS_DIRECTORY);
             return true;
         }
 
@@ -763,7 +793,7 @@ static bool LibretroSetEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const char** dir = (const char**)data;
-            *dir = LibretroGetDirectory(LibretroCore.savesDirectory);
+            *dir = GetLibretroDirectory(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY);
             return true;
         }
 
@@ -1257,7 +1287,7 @@ static bool LibretroSetEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const char** dir = (const char**)data;
-            *dir = LibretroGetDirectory(LibretroCore.playlistsDirectory);
+            *dir = GetLibretroDirectory(RETRO_ENVIRONMENT_GET_PLAYLIST_DIRECTORY);
             return true;
         }
 
@@ -1267,7 +1297,7 @@ static bool LibretroSetEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const char** dir = (const char**)data;
-            *dir = LibretroGetDirectory(LibretroCore.gamesDirectory);
+            *dir = GetLibretroDirectory(RETRO_ENVIRONMENT_GET_FILE_BROWSER_START_DIRECTORY);
             return true;
         }
 

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -253,6 +253,7 @@ typedef struct rLibretro {
     // Directory configuration. Empty string means use GetApplicationDirectory().
     char coresDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char systemDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    char assetsDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char gamesDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char playlistsDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char savesDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
@@ -753,7 +754,7 @@ static bool LibretroSetEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const char** dir = (const char**)data;
-            *dir = LibretroGetDirectory(LibretroCore.coresDirectory);
+            *dir = LibretroGetDirectory(LibretroCore.assetsDirectory);
             return true;
         }
 

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -249,6 +249,12 @@ typedef struct rLibretro {
 
     // Accumulated in-game time in nanoseconds (does not advance while menu is open).
     retro_perf_tick_t gameTimeNSEC;
+
+    // Directory configuration. Empty string means use GetApplicationDirectory().
+    char coresDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    char gamesDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    char savesDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    char screenshotsDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
 } rLibretro;
 
 #if defined(__cplusplus)
@@ -304,6 +310,11 @@ static bool SetLibretroCoreOption(const char *key, const char *value) {
 
 static const char *GetLibretroCoreOption(const char *key) {
     return LibretroGetCoreVariable(key);
+}
+
+static const char* LibretroGetDirectory(const char* configured) {
+    if (configured && configured[0] != '\0') return configured;
+    return GetApplicationDirectory();
 }
 
 static void LibretroLogger(enum retro_log_level level, const char *fmt, ...) {
@@ -499,7 +510,7 @@ static bool LibretroSetEnvironment(unsigned cmd, void * data) {
                 TraceLog(LOG_WARNING, "LIBRETRO: RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY no data set");
                 return false;
             }
-            *dir = GetWorkingDirectory();
+            *dir = LibretroGetDirectory(LibretroCore.coresDirectory);
             return true;
         }
 
@@ -647,7 +658,7 @@ static bool LibretroSetEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const char** dir = (const char**)data;
-            *dir = GetWorkingDirectory();
+            *dir = LibretroGetDirectory(LibretroCore.coresDirectory);
             return true;
         }
 
@@ -740,7 +751,7 @@ static bool LibretroSetEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const char** dir = (const char**)data;
-            *dir = GetWorkingDirectory();
+            *dir = LibretroGetDirectory(LibretroCore.coresDirectory);
             return true;
         }
 
@@ -749,7 +760,7 @@ static bool LibretroSetEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const char** dir = (const char**)data;
-            *dir = GetWorkingDirectory();
+            *dir = LibretroGetDirectory(LibretroCore.savesDirectory);
             return true;
         }
 
@@ -1243,7 +1254,7 @@ static bool LibretroSetEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const char** dir = (const char**)data;
-            *dir = GetWorkingDirectory();
+            *dir = LibretroGetDirectory(LibretroCore.gamesDirectory);
             return true;
         }
 
@@ -1253,7 +1264,7 @@ static bool LibretroSetEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const char** dir = (const char**)data;
-            *dir = GetWorkingDirectory();
+            *dir = LibretroGetDirectory(LibretroCore.gamesDirectory);
             return true;
         }
 


### PR DESCRIPTION
Adds four configurable directory paths (Cores, Games, Saves, Screenshots) to the Settings menu. Each defaults to `GetApplicationDirectory()` when empty. Paths are persisted to config and used in libretro callbacks, save states, and screenshots. Fixes #68