### PR TITLE
Fix RETRO_ENVIRONMENT_GET_LIBRETRO_PATH

### DIFF
--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -363,8 +363,8 @@ LibretroMenu* InitLibretroMenu(void) {
         // Directories
         nk_console* directoryTree = nk_console_tree(settings, "Directories", nk_true);
         {
-            nk_console* libretroDirectory = nk_console_dir(directoryTree, "Cores", LibretroCore.libretroDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
-            nk_console_add_event_handler(libretroDirectory, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+            nk_console* coreDirectory = nk_console_dir(directoryTree, "Cores", LibretroCore.coreDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+            nk_console_add_event_handler(coreDirectory, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
 
             nk_console* saveDirectory = nk_console_dir(directoryTree, "Saves", LibretroCore.saveDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
             nk_console_add_event_handler(saveDirectory, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
@@ -544,7 +544,7 @@ static void LibretroMenuUpdateConfig(void) {
     rlconfig_set_int(menu.cfg, "raylib-libretro", "theme", menu.themeSelectedIndex);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "volume", (int)(menu.volumeSelected * 100.0f));
     rlconfig_set_int(menu.cfg, "raylib-libretro", "rewind", menu.rewindEnabled ? 1 : 0);
-    rlconfig_set(menu.cfg, "raylib-libretro", "libretroDirectory", LibretroCore.libretroDirectory);
+    rlconfig_set(menu.cfg, "raylib-libretro", "coreDirectory", LibretroCore.coreDirectory);
     rlconfig_set(menu.cfg, "raylib-libretro", "saveDirectory", LibretroCore.saveDirectory);
     rlconfig_set(menu.cfg, "raylib-libretro", "coreAssetsDirectory", LibretroCore.coreAssetsDirectory);
     rlconfig_set(menu.cfg, "raylib-libretro", "systemDirectory", LibretroCore.systemDirectory);
@@ -649,8 +649,8 @@ static bool LoadLibretroMenuSettings(void) {
 
     menu.rewindEnabled = rlconfig_get_int(menu.cfg, "raylib-libretro", "rewind", 0) > 0;
 
-    const char* libretroDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "libretroDirectory");
-    if (libretroDirectory) TextCopy(LibretroCore.libretroDirectory, libretroDirectory);
+    const char* coreDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "coreDirectory");
+    if (coreDirectory) TextCopy(LibretroCore.coreDirectory, coreDirectory);
     const char* saveDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "saveDirectory");
     if (saveDirectory) TextCopy(LibretroCore.saveDirectory, saveDirectory);
     const char* coreAssetsDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "coreAssetsDirectory");

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -179,6 +179,7 @@ typedef struct rLibretro {
     unsigned width, height, fps;
     double sampleRate;
     float aspectRatio;
+    char corePath[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char libraryName[200];
     char libraryVersion[200];
     char validExtensions[200];
@@ -253,7 +254,7 @@ typedef struct rLibretro {
 
     // Directory configuration. Empty string means use GetApplicationDirectory().
     // TODO: Change this to be MemAlloc-ed?
-    char libretroDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    char coreDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char saveDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char coreAssetsDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char systemDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
@@ -320,7 +321,6 @@ static const char *GetLibretroCoreOption(const char *key) {
  * Retrieves the directory that is configured as a libretro directory.
  *
  * @param directory The key of which directory to retrieve. Can be...
- * - RETRO_ENVIRONMENT_GET_LIBRETRO_PATH
  * - RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY
  * - RETRO_ENVIRONMENT_GET_CORE_ASSETS_DIRECTORY
  * - RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY
@@ -334,7 +334,6 @@ static const char* GetLibretroDirectory(int directory) {
     const char* appDir = GetApplicationDirectory();
     char* output = NULL;
     switch (directory) {
-        case RETRO_ENVIRONMENT_GET_LIBRETRO_PATH: output = LibretroCore.libretroDirectory; break;
         case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY: output = LibretroCore.saveDirectory; break;
         case RETRO_ENVIRONMENT_GET_CORE_ASSETS_DIRECTORY: output = LibretroCore.coreAssetsDirectory; break; // RETRO_ENVIRONMENT_GET_CONTENT_DIRECTORY
         case RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY: output = LibretroCore.systemDirectory; break;
@@ -690,8 +689,8 @@ static bool LibretroSetEnvironment(unsigned cmd, void * data) {
                 TraceLog(LOG_WARNING, "LIBRETRO: RETRO_ENVIRONMENT_GET_LIBRETRO_PATH no data provided");
                 return false;
             }
-            const char** dir = (const char**)data;
-            *dir = GetLibretroDirectory(RETRO_ENVIRONMENT_GET_LIBRETRO_PATH);
+            const char** path = (const char**)data;
+            *path = LibretroCore.corePath[0] != '\0' ? LibretroCore.corePath : NULL;
             return true;
         }
 
@@ -1948,6 +1947,7 @@ static bool InitLibretro(const char* core) {
     LoadLibretroMethod(retro_get_memory_size);
 
     // Initialize the core.
+    TextCopy(LibretroCore.corePath, core);
     LibretroCore.shutdown = false;
     LibretroCore.volume = 1.0f;
 


### PR DESCRIPTION
Returns the absolute path to the loaded core instead of the cores directory. Renames `libretroDirectory` to `coreDirectory` and adds `corePath` to store the path passed to `InitLibretro()`. Fixes #72