### PR TITLE
Add Keys section in menu

### DIFF
--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -232,6 +232,30 @@ bool UpdateDrawFrame(void* userData) {
         LibretroMenuLoadStateClicked(menu.console, NULL);
     }
 
+    // Reset
+    else if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyReset))) {
+        if (IsLibretroGameReady()) {
+            ResetLibretro();
+            ShowLibretroMessage("Reset", 2.0f);
+        }
+    }
+
+    // Volume
+    else if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyVolumeUp))) {
+        float vol = GetLibretroVolume() + 0.1f;
+        if (vol > 1.0f) vol = 1.0f;
+        SetLibretroVolume(vol);
+        menu.volumeSelected = vol;
+        ShowLibretroMessage(TextFormat("Volume: %d%%", (int)(vol * 100.0f)), 1.0f);
+    }
+    else if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyVolumeDown))) {
+        float vol = GetLibretroVolume() - 0.1f;
+        if (vol < 0.0f) vol = 0.0f;
+        SetLibretroVolume(vol);
+        menu.volumeSelected = vol;
+        ShowLibretroMessage(TextFormat("Volume: %d%%", (int)(vol * 100.0f)), 1.0f);
+    }
+
     return true;
 }
 

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -145,7 +145,7 @@ bool UpdateDrawFrame(void* userData) {
     // Run a frame of the core.
     if (!data->menu->active) {
         if (data->menu->rewindEnabled && IsLibretroGameReady()) {
-            if (IsNkKeyDown(data->menu->keyRewind)) {
+            if (IsKeyDown(NkKeyToKeyboardKey(data->menu->keyRewind))) {
                 void* stateData = NULL;
                 unsigned int stateSize = 0;
                 if (RewindBufferPop(&data->rewind, &stateData, &stateSize)) {
@@ -201,12 +201,12 @@ bool UpdateDrawFrame(void* userData) {
     EndDrawing();
 
     // Fullscreen
-    if (IsNkKeyReleased(menu.keyFullscreen)) {
+    if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyFullscreen))) {
         LibretroMenuFullscreenChanged(menu.console, NULL);
     }
 
     // Screenshot
-    else if (IsNkKeyReleased(menu.keyScreenshot)) {
+    else if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyScreenshot))) {
         const char* screenshotsDir = GetLibretroDirectory(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY);
         const char* screenshotName = NULL;
         for (int i = 1; i < 1000; i++) {
@@ -222,12 +222,12 @@ bool UpdateDrawFrame(void* userData) {
     }
 
     // Save State
-    else if (IsNkKeyReleased(menu.keySaveState)) {
+    else if (IsKeyReleased(NkKeyToKeyboardKey(menu.keySaveState))) {
         LibretroMenuSaveStateClicked(menu.console, NULL);
     }
 
     // Load State
-    else if (IsNkKeyReleased(menu.keyLoadState)) {
+    else if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyLoadState))) {
         LibretroMenuLoadStateClicked(menu.console, NULL);
     }
 

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -246,6 +246,7 @@ bool UpdateDrawFrame(void* userData) {
         if (vol > 1.0f) vol = 1.0f;
         SetLibretroVolume(vol);
         menu.volumeSelected = vol;
+        SaveLibretroMenuSettings();
         ShowLibretroMessage(TextFormat("Volume: %d%%", (int)(vol * 100.0f)), 1.0f);
     }
     else if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyVolumeDown))) {
@@ -253,6 +254,7 @@ bool UpdateDrawFrame(void* userData) {
         if (vol < 0.0f) vol = 0.0f;
         SetLibretroVolume(vol);
         menu.volumeSelected = vol;
+        SaveLibretroMenuSettings();
         ShowLibretroMessage(TextFormat("Volume: %d%%", (int)(vol * 100.0f)), 1.0f);
     }
 

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -145,7 +145,7 @@ bool UpdateDrawFrame(void* userData) {
     // Run a frame of the core.
     if (!data->menu->active) {
         if (data->menu->rewindEnabled && IsLibretroGameReady()) {
-            if (IsKeyDown(KEY_R)) {
+            if (IsNkKeyDown(data->menu->keyRewind)) {
                 void* stateData = NULL;
                 unsigned int stateSize = 0;
                 if (RewindBufferPop(&data->rewind, &stateData, &stateSize)) {
@@ -201,12 +201,12 @@ bool UpdateDrawFrame(void* userData) {
     EndDrawing();
 
     // Fullscreen
-    if (IsKeyReleased(KEY_F11)) {
+    if (IsNkKeyReleased(menu.keyFullscreen)) {
         LibretroMenuFullscreenChanged(menu.console, NULL);
     }
 
     // Screenshot
-    else if (IsKeyReleased(KEY_F8)) {
+    else if (IsNkKeyReleased(menu.keyScreenshot)) {
         const char* screenshotsDir = GetLibretroDirectory(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY);
         const char* screenshotName = NULL;
         for (int i = 1; i < 1000; i++) {
@@ -222,12 +222,12 @@ bool UpdateDrawFrame(void* userData) {
     }
 
     // Save State
-    else if (IsKeyReleased(KEY_F2)) {
+    else if (IsNkKeyReleased(menu.keySaveState)) {
         LibretroMenuSaveStateClicked(menu.console, NULL);
     }
 
     // Load State
-    else if (IsKeyReleased(KEY_F4)) {
+    else if (IsNkKeyReleased(menu.keyLoadState)) {
         LibretroMenuLoadStateClicked(menu.console, NULL);
     }
 

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -96,6 +96,7 @@ typedef struct {
 
 bool Init(void** userData, int argc, char** argv) {
     SetWindowMinSize(400, 300);
+    SetExitKey(KEY_NULL);
 
     AppData* data = (AppData*)MemAlloc(sizeof(AppData));
     memset(data, 0, sizeof(AppData));

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -120,6 +120,7 @@ bool Init(void** userData, int argc, char** argv) {
         if (InitLibretro(argv[1])) {
             // Apply any previously saved options before the game starts.
             LoadLibretroCoreOptions();
+            SetLibretroVolume(data->menu->volumeSelected);
 
             // Load the given game.
             const char* gameFile = (argc > 2) ? argv[2] : NULL;
@@ -136,17 +137,12 @@ bool Init(void** userData, int argc, char** argv) {
 bool UpdateDrawFrame(void* userData) {
     AppData* data = (AppData*)userData;
 
-    // Update the shaders, then show OSD if a shader key was pressed.
-    LibretroShaderType shaderTypeBefore = GetActiveLibretroShaderType();
-    UpdateLibretroShaders(GetFrameTime());
-    if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyPrevShader))) CycleLibretroShaderReverse();
-    if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyNextShader))) CycleLibretroShader();
-    if (GetActiveLibretroShaderType() != shaderTypeBefore) {
-        ShowLibretroMessage(GetLibretroShaderName(GetActiveLibretroShaderType()), 2.0f);
-    }
-
     // Run a frame of the core.
     if (!data->menu->active) {
+        // Update the shaders, then show OSD if a shader key was pressed.
+        LibretroShaderType shaderTypeBefore = GetActiveLibretroShaderType();
+        UpdateLibretroShaders(GetFrameTime());
+
         if (data->menu->rewindEnabled && IsLibretroGameReady()) {
             if (IsKeyDown(NkKeyToKeyboardKey(data->menu->keyRewind))) {
                 void* stateData = NULL;
@@ -224,18 +220,33 @@ bool UpdateDrawFrame(void* userData) {
         }
     }
 
+    // Cycle Shader Reverse
+    else if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyPrevShader)) && !menu.active) {
+        CycleLibretroShaderReverse();
+        ShowLibretroMessage(GetLibretroShaderName(GetActiveLibretroShaderType()), 2.0f);
+        menu.shaderSelectedIndex = (int)GetActiveLibretroShaderType();
+    }
+
+    // Cycle Shader Next
+    else if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyNextShader)) && !menu.active) {
+        CycleLibretroShader();
+        ShowLibretroMessage(GetLibretroShaderName(GetActiveLibretroShaderType()), 2.0f);
+        // TODO: For some reason, cycling the shader doens't update the menu label.
+        menu.shaderSelectedIndex = (int)GetActiveLibretroShaderType();
+    }
+
     // Save State
-    else if (IsKeyReleased(NkKeyToKeyboardKey(menu.keySaveState))) {
+    else if (IsKeyReleased(NkKeyToKeyboardKey(menu.keySaveState)) && !menu.active) {
         LibretroMenuSaveStateClicked(menu.console, NULL);
     }
 
     // Load State
-    else if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyLoadState))) {
+    else if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyLoadState)) && !menu.active) {
         LibretroMenuLoadStateClicked(menu.console, NULL);
     }
 
     // Reset
-    else if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyReset))) {
+    else if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyReset)) && !menu.active) {
         if (IsLibretroGameReady()) {
             ResetLibretro();
             ShowLibretroMessage("Reset", 2.0f);
@@ -243,21 +254,21 @@ bool UpdateDrawFrame(void* userData) {
     }
 
     // Volume
-    else if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyVolumeUp))) {
+    else if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyVolumeUp)) && !menu.active) {
         float vol = GetLibretroVolume() + 0.1f;
-        if (vol > 1.0f) vol = 1.0f;
         SetLibretroVolume(vol);
+        vol = GetLibretroVolume();
         menu.volumeSelected = vol;
         SaveLibretroMenuSettings();
-        ShowLibretroMessage(TextFormat("Volume: %d%%", (int)(vol * 100.0f)), 1.0f);
+        ShowLibretroMessage(TextFormat("Volume: %d%%", (int)(vol * 10.0f + 0.5f) * 10), 1.0f);
     }
-    else if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyVolumeDown))) {
+    else if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyVolumeDown)) && !menu.active) {
         float vol = GetLibretroVolume() - 0.1f;
-        if (vol < 0.0f) vol = 0.0f;
         SetLibretroVolume(vol);
+        vol = GetLibretroVolume();
         menu.volumeSelected = vol;
         SaveLibretroMenuSettings();
-        ShowLibretroMessage(TextFormat("Volume: %d%%", (int)(vol * 100.0f)), 1.0f);
+        ShowLibretroMessage(TextFormat("Volume: %d%%", (int)(vol * 10.0f + 0.5f) * 10), 1.0f);
     }
 
     return true;

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -139,6 +139,8 @@ bool UpdateDrawFrame(void* userData) {
     // Update the shaders, then show OSD if a shader key was pressed.
     LibretroShaderType shaderTypeBefore = GetActiveLibretroShaderType();
     UpdateLibretroShaders(GetFrameTime());
+    if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyPrevShader))) CycleLibretroShaderReverse();
+    if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyNextShader))) CycleLibretroShader();
     if (GetActiveLibretroShaderType() != shaderTypeBefore) {
         ShowLibretroMessage(GetLibretroShaderName(GetActiveLibretroShaderType()), 2.0f);
     }

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -138,6 +138,7 @@ static bool SaveLibretroMenuSettings(void);
 static bool SaveLibretroCoreOptions(void);
 static bool LoadLibretroMenuSettings(void);
 static void UpdateLibretroMenuVisibility(void);
+static KeyboardKey NkKeyToKeyboardKey(nk_rune key);
 
 static void LibretroMenuSettingChanged(nk_console* widget, void* user_data) {
     (void)widget;
@@ -155,46 +156,51 @@ static void LibretroMenuSettingChanged(nk_console* widget, void* user_data) {
 static void LibretroMenuKeyChanged(nk_console* widget, void* user_data) {
     (void)widget;
     (void)user_data;
-    SetLibretroShaderKeys((KeyboardKey)(int)menu.keyPrevShader, (KeyboardKey)(int)menu.keyNextShader);
+    SetLibretroShaderKeys(NkKeyToKeyboardKey(menu.keyPrevShader), NkKeyToKeyboardKey(menu.keyNextShader));
     SaveLibretroMenuSettings();
+}
+
+// Convert an nk_rune key binding to a raylib KeyboardKey.
+static KeyboardKey NkKeyToKeyboardKey(nk_rune key) {
+    if (key == 0) return KEY_NULL;
+    if (key < (nk_rune)NK_KEY_MAX) {
+        switch ((enum nk_keys)key) {
+            case NK_KEY_ENTER:     return KEY_ENTER;
+            case NK_KEY_BACKSPACE: return KEY_BACKSPACE;
+            case NK_KEY_DEL:       return KEY_DELETE;
+            case NK_KEY_UP:        return KEY_UP;
+            case NK_KEY_DOWN:      return KEY_DOWN;
+            case NK_KEY_LEFT:      return KEY_LEFT;
+            case NK_KEY_RIGHT:     return KEY_RIGHT;
+            case NK_KEY_F1:        return KEY_F1;
+            case NK_KEY_F2:        return KEY_F2;
+            case NK_KEY_F3:        return KEY_F3;
+            case NK_KEY_F4:        return KEY_F4;
+            case NK_KEY_F5:        return KEY_F5;
+            case NK_KEY_F6:        return KEY_F6;
+            case NK_KEY_F7:        return KEY_F7;
+            case NK_KEY_F8:        return KEY_F8;
+            case NK_KEY_F9:        return KEY_F9;
+            case NK_KEY_F10:       return KEY_F10;
+            case NK_KEY_F11:       return KEY_F11;
+            case NK_KEY_F12:       return KEY_F12;
+            default:               return KEY_NULL;
+        }
+    }
+    if (key >= 'a' && key <= 'z') key -= 32;
+    return (KeyboardKey)(int)key;
 }
 
 // Check if an nk_rune key binding is currently held down in raylib.
 static bool IsNkKeyDown(nk_rune key) {
-    if (key == 0) return false;
-    if (key < (nk_rune)NK_KEY_MAX) {
-        switch ((enum nk_keys)key) {
-            case NK_KEY_ENTER:     return IsKeyDown(KEY_ENTER);
-            case NK_KEY_BACKSPACE: return IsKeyDown(KEY_BACKSPACE);
-            case NK_KEY_DEL:       return IsKeyDown(KEY_DELETE);
-            case NK_KEY_UP:        return IsKeyDown(KEY_UP);
-            case NK_KEY_DOWN:      return IsKeyDown(KEY_DOWN);
-            case NK_KEY_LEFT:      return IsKeyDown(KEY_LEFT);
-            case NK_KEY_RIGHT:     return IsKeyDown(KEY_RIGHT);
-            default:               return false;
-        }
-    }
-    if (key >= 'a' && key <= 'z') key -= 32;
-    return IsKeyDown((KeyboardKey)(int)key);
+    KeyboardKey k = NkKeyToKeyboardKey(key);
+    return k != KEY_NULL && IsKeyDown(k);
 }
 
 // Check if an nk_rune key binding was just released in raylib.
 static bool IsNkKeyReleased(nk_rune key) {
-    if (key == 0) return false;
-    if (key < (nk_rune)NK_KEY_MAX) {
-        switch ((enum nk_keys)key) {
-            case NK_KEY_ENTER:     return IsKeyReleased(KEY_ENTER);
-            case NK_KEY_BACKSPACE: return IsKeyReleased(KEY_BACKSPACE);
-            case NK_KEY_DEL:       return IsKeyReleased(KEY_DELETE);
-            case NK_KEY_UP:        return IsKeyReleased(KEY_UP);
-            case NK_KEY_DOWN:      return IsKeyReleased(KEY_DOWN);
-            case NK_KEY_LEFT:      return IsKeyReleased(KEY_LEFT);
-            case NK_KEY_RIGHT:     return IsKeyReleased(KEY_RIGHT);
-            default:               return false;
-        }
-    }
-    if (key >= 'a' && key <= 'z') key -= 32;
-    return IsKeyReleased((KeyboardKey)(int)key);
+    KeyboardKey k = NkKeyToKeyboardKey(key);
+    return k != KEY_NULL && IsKeyReleased(k);
 }
 
 static LibretroMenu* GetLibretroMenu(void) {
@@ -331,14 +337,14 @@ LibretroMenu* InitLibretroMenu(void) {
     menu = (LibretroMenu){0};
     menu.themeSelectedIndex = LIBRETRO_MENU_STYLE_DRACULA;
     menu.volumeSelected = 1.0f;
-    menu.keyScreenshot  = (nk_rune)KEY_F8;
-    menu.keyRewind      = (nk_rune)KEY_R;
-    menu.keyMenu        = (nk_rune)KEY_F1;
-    menu.keySaveState   = (nk_rune)KEY_F2;
-    menu.keyLoadState   = (nk_rune)KEY_F4;
-    menu.keyFullscreen  = (nk_rune)KEY_F11;
-    menu.keyPrevShader  = (nk_rune)KEY_F9;
-    menu.keyNextShader  = (nk_rune)KEY_F10;
+    menu.keyScreenshot  = (nk_rune)NK_KEY_F8;
+    menu.keyRewind      = (nk_rune)'R';
+    menu.keyMenu        = (nk_rune)NK_KEY_F1;
+    menu.keySaveState   = (nk_rune)NK_KEY_F2;
+    menu.keyLoadState   = (nk_rune)NK_KEY_F4;
+    menu.keyFullscreen  = (nk_rune)NK_KEY_F11;
+    menu.keyPrevShader  = (nk_rune)NK_KEY_F9;
+    menu.keyNextShader  = (nk_rune)NK_KEY_F10;
     menu.font = LoadFontFromNuklear(fontSize);
     if (!IsFontValid(menu.font)) {
         return NULL;
@@ -748,7 +754,7 @@ static bool LoadLibretroMenuSettings(void) {
     menu.keyFullscreen = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyFullscreen", (int)menu.keyFullscreen);
     menu.keyPrevShader = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyPrevShader", (int)menu.keyPrevShader);
     menu.keyNextShader = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyNextShader", (int)menu.keyNextShader);
-    SetLibretroShaderKeys((KeyboardKey)(int)menu.keyPrevShader, (KeyboardKey)(int)menu.keyNextShader);
+    SetLibretroShaderKeys(NkKeyToKeyboardKey(menu.keyPrevShader), NkKeyToKeyboardKey(menu.keyNextShader));
 
     const char* coreDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "coreDirectory");
     if (coreDirectory) TextCopy(LibretroCore.coreDirectory, coreDirectory);

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -66,6 +66,14 @@ typedef struct LibretroMenu {
     int themeSelectedIndex;
     float volumeSelected;
     bool rewindEnabled;
+    nk_rune keyScreenshot;
+    nk_rune keyRewind;
+    nk_rune keyMenu;
+    nk_rune keySaveState;
+    nk_rune keyLoadState;
+    nk_rune keyFullscreen;
+    nk_rune keyPrevShader;
+    nk_rune keyNextShader;
     int optionSelectedIndices[128];       // per-option combobox index (matches LIBRETRO_MAX_CORE_VARIABLES)
     nk_bool optionCheckboxValues[128];    // per-option checkbox state for enabled/disabled options
 #ifdef RAYLIB_LIBRETRO_CONFIG_H
@@ -142,6 +150,51 @@ static void LibretroMenuSettingChanged(nk_console* widget, void* user_data) {
         LibretroInitVideo();
     }
     SaveLibretroMenuSettings();
+}
+
+static void LibretroMenuKeyChanged(nk_console* widget, void* user_data) {
+    (void)widget;
+    (void)user_data;
+    SetLibretroShaderKeys((KeyboardKey)(int)menu.keyPrevShader, (KeyboardKey)(int)menu.keyNextShader);
+    SaveLibretroMenuSettings();
+}
+
+// Check if an nk_rune key binding is currently held down in raylib.
+static bool IsNkKeyDown(nk_rune key) {
+    if (key == 0) return false;
+    if (key < (nk_rune)NK_KEY_MAX) {
+        switch ((enum nk_keys)key) {
+            case NK_KEY_ENTER:     return IsKeyDown(KEY_ENTER);
+            case NK_KEY_BACKSPACE: return IsKeyDown(KEY_BACKSPACE);
+            case NK_KEY_DEL:       return IsKeyDown(KEY_DELETE);
+            case NK_KEY_UP:        return IsKeyDown(KEY_UP);
+            case NK_KEY_DOWN:      return IsKeyDown(KEY_DOWN);
+            case NK_KEY_LEFT:      return IsKeyDown(KEY_LEFT);
+            case NK_KEY_RIGHT:     return IsKeyDown(KEY_RIGHT);
+            default:               return false;
+        }
+    }
+    if (key >= 'a' && key <= 'z') key -= 32;
+    return IsKeyDown((KeyboardKey)(int)key);
+}
+
+// Check if an nk_rune key binding was just released in raylib.
+static bool IsNkKeyReleased(nk_rune key) {
+    if (key == 0) return false;
+    if (key < (nk_rune)NK_KEY_MAX) {
+        switch ((enum nk_keys)key) {
+            case NK_KEY_ENTER:     return IsKeyReleased(KEY_ENTER);
+            case NK_KEY_BACKSPACE: return IsKeyReleased(KEY_BACKSPACE);
+            case NK_KEY_DEL:       return IsKeyReleased(KEY_DELETE);
+            case NK_KEY_UP:        return IsKeyReleased(KEY_UP);
+            case NK_KEY_DOWN:      return IsKeyReleased(KEY_DOWN);
+            case NK_KEY_LEFT:      return IsKeyReleased(KEY_LEFT);
+            case NK_KEY_RIGHT:     return IsKeyReleased(KEY_RIGHT);
+            default:               return false;
+        }
+    }
+    if (key >= 'a' && key <= 'z') key -= 32;
+    return IsKeyReleased((KeyboardKey)(int)key);
 }
 
 static LibretroMenu* GetLibretroMenu(void) {
@@ -278,6 +331,14 @@ LibretroMenu* InitLibretroMenu(void) {
     menu = (LibretroMenu){0};
     menu.themeSelectedIndex = LIBRETRO_MENU_STYLE_DRACULA;
     menu.volumeSelected = 1.0f;
+    menu.keyScreenshot  = (nk_rune)KEY_F8;
+    menu.keyRewind      = (nk_rune)KEY_R;
+    menu.keyMenu        = (nk_rune)KEY_F1;
+    menu.keySaveState   = (nk_rune)KEY_F2;
+    menu.keyLoadState   = (nk_rune)KEY_F4;
+    menu.keyFullscreen  = (nk_rune)KEY_F11;
+    menu.keyPrevShader  = (nk_rune)KEY_F9;
+    menu.keyNextShader  = (nk_rune)KEY_F10;
     menu.font = LoadFontFromNuklear(fontSize);
     if (!IsFontValid(menu.font)) {
         return NULL;
@@ -359,6 +420,28 @@ LibretroMenu* InitLibretroMenu(void) {
         // Rewind
         nk_console* rewind = nk_console_checkbox(settings, "Rewind", &menu.rewindEnabled);
         nk_console_add_event_handler(rewind, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+
+        // Keys
+        nk_console* keysTree = nk_console_tree(settings, "Keys", nk_false);
+        {
+            nk_console* w;
+            w = nk_console_key(keysTree, "Screenshot", &menu.keyScreenshot);
+            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuKeyChanged, NULL, NULL);
+            w = nk_console_key(keysTree, "Rewind", &menu.keyRewind);
+            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuKeyChanged, NULL, NULL);
+            w = nk_console_key(keysTree, "Menu", &menu.keyMenu);
+            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuKeyChanged, NULL, NULL);
+            w = nk_console_key(keysTree, "Save State", &menu.keySaveState);
+            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuKeyChanged, NULL, NULL);
+            w = nk_console_key(keysTree, "Load State", &menu.keyLoadState);
+            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuKeyChanged, NULL, NULL);
+            w = nk_console_key(keysTree, "Fullscreen", &menu.keyFullscreen);
+            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuKeyChanged, NULL, NULL);
+            w = nk_console_key(keysTree, "Previous Shader", &menu.keyPrevShader);
+            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuKeyChanged, NULL, NULL);
+            w = nk_console_key(keysTree, "Next Shader", &menu.keyNextShader);
+            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuKeyChanged, NULL, NULL);
+        }
 
         // Directories
         nk_console* directoryTree = nk_console_tree(settings, "Directories", nk_true);
@@ -544,6 +627,14 @@ static void LibretroMenuUpdateConfig(void) {
     rlconfig_set_int(menu.cfg, "raylib-libretro", "theme", menu.themeSelectedIndex);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "volume", (int)(menu.volumeSelected * 100.0f));
     rlconfig_set_int(menu.cfg, "raylib-libretro", "rewind", menu.rewindEnabled ? 1 : 0);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyScreenshot", (int)menu.keyScreenshot);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyRewind", (int)menu.keyRewind);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyMenu", (int)menu.keyMenu);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "keySaveState", (int)menu.keySaveState);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyLoadState", (int)menu.keyLoadState);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyFullscreen", (int)menu.keyFullscreen);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyPrevShader", (int)menu.keyPrevShader);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyNextShader", (int)menu.keyNextShader);
     rlconfig_set(menu.cfg, "raylib-libretro", "coreDirectory", LibretroResolveAbsoluteDirectory(LibretroCore.coreDirectory));
     rlconfig_set(menu.cfg, "raylib-libretro", "saveDirectory", LibretroResolveAbsoluteDirectory(LibretroCore.saveDirectory));
     rlconfig_set(menu.cfg, "raylib-libretro", "coreAssetsDirectory", LibretroResolveAbsoluteDirectory(LibretroCore.coreAssetsDirectory));
@@ -649,6 +740,16 @@ static bool LoadLibretroMenuSettings(void) {
 
     menu.rewindEnabled = rlconfig_get_int(menu.cfg, "raylib-libretro", "rewind", 0) > 0;
 
+    menu.keyScreenshot = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyScreenshot", (int)menu.keyScreenshot);
+    menu.keyRewind     = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyRewind",     (int)menu.keyRewind);
+    menu.keyMenu       = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyMenu",       (int)menu.keyMenu);
+    menu.keySaveState  = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keySaveState",  (int)menu.keySaveState);
+    menu.keyLoadState  = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyLoadState",  (int)menu.keyLoadState);
+    menu.keyFullscreen = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyFullscreen", (int)menu.keyFullscreen);
+    menu.keyPrevShader = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyPrevShader", (int)menu.keyPrevShader);
+    menu.keyNextShader = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyNextShader", (int)menu.keyNextShader);
+    SetLibretroShaderKeys((KeyboardKey)(int)menu.keyPrevShader, (KeyboardKey)(int)menu.keyNextShader);
+
     const char* coreDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "coreDirectory");
     if (coreDirectory) TextCopy(LibretroCore.coreDirectory, coreDirectory);
     const char* saveDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "saveDirectory");
@@ -716,7 +817,7 @@ void UpdateLibretroMenu(void) {
     }
 
     // Toggle the menu
-    if (IsGamepadButtonReleased(0, GAMEPAD_BUTTON_MIDDLE) || IsGamepadButtonReleased(1, GAMEPAD_BUTTON_MIDDLE) || IsGamepadButtonReleased(3, GAMEPAD_BUTTON_MIDDLE) || IsGamepadButtonReleased(4, GAMEPAD_BUTTON_MIDDLE) || IsKeyReleased(KEY_F1)) {
+    if (IsGamepadButtonReleased(0, GAMEPAD_BUTTON_MIDDLE) || IsGamepadButtonReleased(1, GAMEPAD_BUTTON_MIDDLE) || IsGamepadButtonReleased(3, GAMEPAD_BUTTON_MIDDLE) || IsGamepadButtonReleased(4, GAMEPAD_BUTTON_MIDDLE) || IsNkKeyReleased(menu.keyMenu)) {
         menu.active = !menu.active;
     }
 

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -74,6 +74,9 @@ typedef struct LibretroMenu {
     nk_rune keyFullscreen;
     nk_rune keyPrevShader;
     nk_rune keyNextShader;
+    nk_rune keyReset;
+    nk_rune keyVolumeUp;
+    nk_rune keyVolumeDown;
     int optionSelectedIndices[128];       // per-option combobox index (matches LIBRETRO_MAX_CORE_VARIABLES)
     nk_bool optionCheckboxValues[128];    // per-option checkbox state for enabled/disabled options
 #ifdef RAYLIB_LIBRETRO_CONFIG_H
@@ -160,15 +163,23 @@ static void LibretroMenuKeyChanged(nk_console* widget, void* user_data) {
     SaveLibretroMenuSettings();
 }
 
+static void MenuCloseOnBack(nk_console* console, void* user_data) {
+    (void)console;
+    (void)user_data;
+    menu.active = false;
+}
+
 // Convert an nk_rune key binding to a raylib KeyboardKey.
 static KeyboardKey NkKeyToKeyboardKey(nk_rune key) {
     if (key == 0) return KEY_NULL;
     if (key < (nk_rune)NK_KEY_MAX) {
         switch ((enum nk_keys)key) {
             case NK_KEY_ENTER:           return KEY_ENTER;
+            case NK_KEY_TAB:             return KEY_TAB;
+            case NK_KEY_SHIFT:           return KEY_LEFT_SHIFT;
             case NK_KEY_BACKSPACE:       return KEY_BACKSPACE;
             case NK_KEY_TEXT_RESET_MODE: return KEY_ESCAPE;
-            case NK_KEY_DEL:       return KEY_DELETE;
+            case NK_KEY_DEL:             return KEY_DELETE;
             case NK_KEY_UP:        return KEY_UP;
             case NK_KEY_DOWN:      return KEY_DOWN;
             case NK_KEY_LEFT:      return KEY_LEFT;
@@ -335,6 +346,9 @@ LibretroMenu* InitLibretroMenu(void) {
     menu.keyFullscreen  = (nk_rune)NK_KEY_F11;
     menu.keyPrevShader  = (nk_rune)NK_KEY_F9;
     menu.keyNextShader  = (nk_rune)NK_KEY_F10;
+    menu.keyReset       = (nk_rune)NK_KEY_F5;
+    menu.keyVolumeUp    = (nk_rune)NK_KEY_F7;
+    menu.keyVolumeDown  = (nk_rune)NK_KEY_F6;
     menu.font = LoadFontFromNuklear(fontSize);
     if (!IsFontValid(menu.font)) {
         return NULL;
@@ -357,6 +371,7 @@ LibretroMenu* InitLibretroMenu(void) {
 
     nk_gamepad_init(&menu.gamepads, menu.ctx, (void*)&menu.console);
     nk_console_set_gamepads(menu.console, &menu.gamepads);
+    nk_console_add_event(menu.console, NK_CONSOLE_EVENT_BACK, &MenuCloseOnBack);
 
 #ifdef RAYLIB_LIBRETRO_CONFIG_H
     menu.cfg = rlconfig_load(FileExists(RAYLIB_LIBRETRO_CFG_FILE) ? RAYLIB_LIBRETRO_CFG_FILE : NULL);
@@ -436,6 +451,12 @@ LibretroMenu* InitLibretroMenu(void) {
             w = nk_console_key(keysTree, "Previous Shader", &menu.keyPrevShader);
             nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuKeyChanged, NULL, NULL);
             w = nk_console_key(keysTree, "Next Shader", &menu.keyNextShader);
+            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuKeyChanged, NULL, NULL);
+            w = nk_console_key(keysTree, "Reset", &menu.keyReset);
+            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuKeyChanged, NULL, NULL);
+            w = nk_console_key(keysTree, "Volume Up", &menu.keyVolumeUp);
+            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuKeyChanged, NULL, NULL);
+            w = nk_console_key(keysTree, "Volume Down", &menu.keyVolumeDown);
             nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuKeyChanged, NULL, NULL);
         }
 
@@ -630,7 +651,10 @@ static void LibretroMenuUpdateConfig(void) {
     rlconfig_set_int(menu.cfg, "raylib-libretro", "keyLoadState", (int)menu.keyLoadState);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "keyFullscreen", (int)menu.keyFullscreen);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "keyPrevShader", (int)menu.keyPrevShader);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyNextShader", (int)menu.keyNextShader);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyNextShader",  (int)menu.keyNextShader);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyReset",       (int)menu.keyReset);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyVolumeUp",    (int)menu.keyVolumeUp);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyVolumeDown",  (int)menu.keyVolumeDown);
     rlconfig_set(menu.cfg, "raylib-libretro", "coreDirectory", LibretroResolveAbsoluteDirectory(LibretroCore.coreDirectory));
     rlconfig_set(menu.cfg, "raylib-libretro", "saveDirectory", LibretroResolveAbsoluteDirectory(LibretroCore.saveDirectory));
     rlconfig_set(menu.cfg, "raylib-libretro", "coreAssetsDirectory", LibretroResolveAbsoluteDirectory(LibretroCore.coreAssetsDirectory));
@@ -743,7 +767,10 @@ static bool LoadLibretroMenuSettings(void) {
     menu.keyLoadState  = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyLoadState",  (int)menu.keyLoadState);
     menu.keyFullscreen = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyFullscreen", (int)menu.keyFullscreen);
     menu.keyPrevShader = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyPrevShader", (int)menu.keyPrevShader);
-    menu.keyNextShader = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyNextShader", (int)menu.keyNextShader);
+    menu.keyNextShader  = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyNextShader",  (int)menu.keyNextShader);
+    menu.keyReset       = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyReset",       (int)menu.keyReset);
+    menu.keyVolumeUp    = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyVolumeUp",    (int)menu.keyVolumeUp);
+    menu.keyVolumeDown  = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyVolumeDown",  (int)menu.keyVolumeDown);
     SetLibretroShaderKeys(NkKeyToKeyboardKey(menu.keyPrevShader), NkKeyToKeyboardKey(menu.keyNextShader));
 
     const char* coreDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "coreDirectory");
@@ -812,15 +839,14 @@ void UpdateLibretroMenu(void) {
         return;
     }
 
-    // Toggle the menu
+    // Toggle the menu via gamepad or via the menu key when inactive.
+    // When the menu is active, nk_console handles the menu key internally:
+    // back-navigation in submenus, and MenuCloseOnBack at root level.
     if (IsGamepadButtonReleased(0, GAMEPAD_BUTTON_MIDDLE) || IsGamepadButtonReleased(1, GAMEPAD_BUTTON_MIDDLE) || IsGamepadButtonReleased(3, GAMEPAD_BUTTON_MIDDLE) || IsGamepadButtonReleased(4, GAMEPAD_BUTTON_MIDDLE)) {
         menu.active = !menu.active;
-    } else if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyMenu))) {
-        if (menu.active && nk_console_active_parent(menu.console) != menu.console) {
-            nk_console_navigate_back(nk_console_active_parent(menu.console));
-        } else {
-            menu.active = !menu.active;
-        }
+    } else if (!menu.active && IsKeyReleased(NkKeyToKeyboardKey(menu.keyMenu))) {
+        menu.active = true;
+        return;
     }
 
     if (!menu.active) {

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -75,6 +75,7 @@ typedef struct LibretroMenu {
     nk_rune keyPrevShader;
     nk_rune keyNextShader;
     nk_rune keyReset;
+    nk_rune keyQuit;
     nk_rune keyVolumeUp;
     nk_rune keyVolumeDown;
     int optionSelectedIndices[128];       // per-option combobox index (matches LIBRETRO_MAX_CORE_VARIABLES)
@@ -153,6 +154,7 @@ static void LibretroMenuSettingChanged(nk_console* widget, void* user_data) {
         LibretroCore.textureFilter = menu.textureFilterIndex;
         LibretroInitVideo();
     }
+    SetExitKey(NkKeyToKeyboardKey(menu.keyQuit));
     SaveLibretroMenuSettings();
 }
 
@@ -366,6 +368,7 @@ LibretroMenu* InitLibretroMenu(void) {
     menu.keyPrevShader  = (nk_rune)NK_KEY_F9;
     menu.keyNextShader  = (nk_rune)NK_KEY_F10;
     menu.keyReset       = (nk_rune)NK_KEY_NONE;
+    menu.keyQuit        = (nk_rune)NK_KEY_NONE;
     menu.keyVolumeUp    = (nk_rune)'=';
     menu.keyVolumeDown  = (nk_rune)'-';
     menu.font = LoadFontFromNuklear(fontSize);
@@ -475,6 +478,8 @@ LibretroMenu* InitLibretroMenu(void) {
             nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
             w = nk_console_key(keysTree, "Reset", &menu.keyReset);
             nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+            w = nk_console_key(keysTree, "Quit", &menu.keyQuit);
+            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
             w = nk_console_key(keysTree, "Volume Up", &menu.keyVolumeUp);
             nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
             w = nk_console_key(keysTree, "Volume Down", &menu.keyVolumeDown);
@@ -482,7 +487,7 @@ LibretroMenu* InitLibretroMenu(void) {
         }
 
         // Directories
-        nk_console* directoryTree = nk_console_tree(settings, "Directories", nk_true);
+        nk_console* directoryTree = nk_console_tree(settings, "Directories", nk_false);
         {
             nk_console* coreDirectory = nk_console_dir(directoryTree, "Cores", LibretroCore.coreDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
             nk_console_add_event_handler(coreDirectory, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
@@ -674,6 +679,7 @@ static void LibretroMenuUpdateConfig(void) {
     rlconfig_set_int(menu.cfg, "raylib-libretro", "keyPrevShader", (int)menu.keyPrevShader);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "keyNextShader",  (int)menu.keyNextShader);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "keyReset",       (int)menu.keyReset);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyQuit",       (int)menu.keyQuit);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "keyVolumeUp",    (int)menu.keyVolumeUp);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "keyVolumeDown",  (int)menu.keyVolumeDown);
     rlconfig_set(menu.cfg, "raylib-libretro", "coreDirectory", LibretroResolveAbsoluteDirectory(LibretroCore.coreDirectory));
@@ -790,6 +796,8 @@ static bool LoadLibretroMenuSettings(void) {
     menu.keyPrevShader = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyPrevShader", (int)menu.keyPrevShader);
     menu.keyNextShader  = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyNextShader",  (int)menu.keyNextShader);
     menu.keyReset       = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyReset",       (int)menu.keyReset);
+    menu.keyQuit       = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyQuit",       (int)menu.keyQuit);
+    SetExitKey(NkKeyToKeyboardKey(menu.keyQuit));
     menu.keyVolumeUp    = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyVolumeUp",    (int)menu.keyVolumeUp);
     menu.keyVolumeDown  = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyVolumeDown",  (int)menu.keyVolumeDown);
 

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -346,7 +346,7 @@ LibretroMenu* InitLibretroMenu(void) {
     menu.keyFullscreen  = (nk_rune)NK_KEY_F11;
     menu.keyPrevShader  = (nk_rune)NK_KEY_F9;
     menu.keyNextShader  = (nk_rune)NK_KEY_F10;
-    menu.keyReset       = (nk_rune)NK_KEY_F5;
+    menu.keyReset       = (nk_rune)NK_KEY_NONE;
     menu.keyVolumeUp    = (nk_rune)'=';
     menu.keyVolumeDown  = (nk_rune)'-';
     menu.font = LoadFontFromNuklear(fontSize);

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -165,8 +165,9 @@ static KeyboardKey NkKeyToKeyboardKey(nk_rune key) {
     if (key == 0) return KEY_NULL;
     if (key < (nk_rune)NK_KEY_MAX) {
         switch ((enum nk_keys)key) {
-            case NK_KEY_ENTER:     return KEY_ENTER;
-            case NK_KEY_BACKSPACE: return KEY_BACKSPACE;
+            case NK_KEY_ENTER:           return KEY_ENTER;
+            case NK_KEY_BACKSPACE:       return KEY_BACKSPACE;
+            case NK_KEY_TEXT_RESET_MODE: return KEY_ESCAPE;
             case NK_KEY_DEL:       return KEY_DELETE;
             case NK_KEY_UP:        return KEY_UP;
             case NK_KEY_DOWN:      return KEY_DOWN;
@@ -328,7 +329,7 @@ LibretroMenu* InitLibretroMenu(void) {
     menu.volumeSelected = 1.0f;
     menu.keyScreenshot  = (nk_rune)NK_KEY_F8;
     menu.keyRewind      = (nk_rune)'R';
-    menu.keyMenu        = (nk_rune)NK_KEY_F1;
+    menu.keyMenu        = (nk_rune)NK_KEY_TEXT_RESET_MODE;
     menu.keySaveState   = (nk_rune)NK_KEY_F2;
     menu.keyLoadState   = (nk_rune)NK_KEY_F4;
     menu.keyFullscreen  = (nk_rune)NK_KEY_F11;

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -158,14 +158,6 @@ static void LibretroMenuSettingChanged(nk_console* widget, void* user_data) {
     SaveLibretroMenuSettings();
 }
 
-static void MenuCloseOnBack(nk_console* console, void* user_data) {
-    NK_UNUSED(console);
-    NK_UNUSED(user_data);
-    if (IsLibretroGameReady()) {
-        menu.active = false;
-    }
-}
-
 // Convert an nk_rune key binding to a raylib KeyboardKey.
 static KeyboardKey NkKeyToKeyboardKey(nk_rune key) {
     if (key == 0) return KEY_NULL;
@@ -330,6 +322,8 @@ static void LibretroMenuSaveStateClicked(nk_console* widget, void* user_data) {
 }
 
 static void MenuResumeClicked(nk_console* widget, void* user_data) {
+    NK_UNUSED(widget);
+    NK_UNUSED(user_data);
     if (IsLibretroGameReady()) {
         menu.active = false;
     }
@@ -395,7 +389,7 @@ LibretroMenu* InitLibretroMenu(void) {
     nk_console_set_gamepads(menu.console, &menu.gamepads);
 
     // When trying to go back from the main menu, exit the menu.
-    nk_console_add_event(menu.console, NK_CONSOLE_EVENT_BACK, &MenuCloseOnBack);
+    nk_console_add_event(menu.console, NK_CONSOLE_EVENT_BACK, &MenuResumeClicked);
 
 #ifdef RAYLIB_LIBRETRO_CONFIG_H
     menu.cfg = rlconfig_load(FileExists(RAYLIB_LIBRETRO_CFG_FILE) ? RAYLIB_LIBRETRO_CFG_FILE : NULL);
@@ -765,8 +759,9 @@ static bool LoadLibretroMenuSettings(void) {
     menu.fullscreen = savedFullscreen;
 
     menu.shaderSelectedIndex = rlconfig_get_int(menu.cfg, "raylib-libretro", "shader", LIBRETRO_SHADER_NONE);
-    if (menu.shaderSelectedIndex < 0 || menu.shaderSelectedIndex >= LIBRETRO_SHADER_TYPE_COUNT)
+    if (menu.shaderSelectedIndex < 0 || menu.shaderSelectedIndex >= LIBRETRO_SHADER_TYPE_COUNT) {
         menu.shaderSelectedIndex = LIBRETRO_SHADER_NONE;
+    }
     SetActiveLibretroShader((LibretroShaderType)menu.shaderSelectedIndex);
 
     menu.textureFilterIndex = rlconfig_get_int(menu.cfg, "raylib-libretro", "textureFilter", 0);
@@ -779,10 +774,10 @@ static bool LoadLibretroMenuSettings(void) {
         menu.themeSelectedIndex = LIBRETRO_MENU_STYLE_DRACULA;
     SetLibretroMenuStyle((LibretroMenuStyle)menu.themeSelectedIndex);
 
-    int volumeInt = rlconfig_get_int(menu.cfg, "raylib-libretro", "volume", 100);
+    int volumeInt = (float)rlconfig_get_int(menu.cfg, "raylib-libretro", "volume", 100);
     if (volumeInt < 0) volumeInt = 0;
     if (volumeInt > 100) volumeInt = 100;
-    menu.volumeSelected = volumeInt / 100.0f;
+    menu.volumeSelected = (float)volumeInt / 100.0f;
     SetLibretroVolume(menu.volumeSelected);
 
     menu.rewindEnabled = rlconfig_get_int(menu.cfg, "raylib-libretro", "rewind", 0) > 0;
@@ -874,7 +869,6 @@ void UpdateLibretroMenu(void) {
         menu.active = !menu.active;
     } else if (!menu.active && IsKeyReleased(NkKeyToKeyboardKey(menu.keyMenu))) {
         menu.active = true;
-        return;
     }
 
     if (!menu.active) {

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -157,8 +157,8 @@ static void LibretroMenuSettingChanged(nk_console* widget, void* user_data) {
 }
 
 static void MenuCloseOnBack(nk_console* console, void* user_data) {
-    (void)console;
-    (void)user_data;
+    NK_UNUSED(console);
+    NK_UNUSED(user_data);
     if (IsLibretroGameReady()) {
         menu.active = false;
     }
@@ -390,6 +390,8 @@ LibretroMenu* InitLibretroMenu(void) {
 
     nk_gamepad_init(&menu.gamepads, menu.ctx, (void*)&menu.console);
     nk_console_set_gamepads(menu.console, &menu.gamepads);
+
+    // When trying to go back from the main menu, exit the menu.
     nk_console_add_event(menu.console, NK_CONSOLE_EVENT_BACK, &MenuCloseOnBack);
 
 #ifdef RAYLIB_LIBRETRO_CONFIG_H

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -200,6 +200,30 @@ static KeyboardKey NkKeyToKeyboardKey(nk_rune key) {
         }
     }
     if (key >= 'a' && key <= 'z') key -= 32;
+    /* Map shifted characters to their physical key on a US keyboard. */
+    switch (key) {
+        case '+': return KEY_EQUAL;
+        case '_': return KEY_MINUS;
+        case '?': return KEY_SLASH;
+        case ':': return KEY_SEMICOLON;
+        case '"': return KEY_APOSTROPHE;
+        case '<': return KEY_COMMA;
+        case '>': return KEY_PERIOD;
+        case '{': return KEY_LEFT_BRACKET;
+        case '}': return KEY_RIGHT_BRACKET;
+        case '|': return KEY_BACKSLASH;
+        case '~': return KEY_GRAVE;
+        case '!': return KEY_ONE;
+        case '@': return KEY_TWO;
+        case '#': return KEY_THREE;
+        case '$': return KEY_FOUR;
+        case '%': return KEY_FIVE;
+        case '^': return KEY_SIX;
+        case '&': return KEY_SEVEN;
+        case '*': return KEY_EIGHT;
+        case '(': return KEY_NINE;
+        case ')': return KEY_ZERO;
+    }
     return (KeyboardKey)(int)key;
 }
 

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -159,7 +159,9 @@ static void LibretroMenuSettingChanged(nk_console* widget, void* user_data) {
 static void MenuCloseOnBack(nk_console* console, void* user_data) {
     (void)console;
     (void)user_data;
-    menu.active = false;
+    if (IsLibretroGameReady()) {
+        menu.active = false;
+    }
 }
 
 // Convert an nk_rune key binding to a raylib KeyboardKey.

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -813,8 +813,14 @@ void UpdateLibretroMenu(void) {
     }
 
     // Toggle the menu
-    if (IsGamepadButtonReleased(0, GAMEPAD_BUTTON_MIDDLE) || IsGamepadButtonReleased(1, GAMEPAD_BUTTON_MIDDLE) || IsGamepadButtonReleased(3, GAMEPAD_BUTTON_MIDDLE) || IsGamepadButtonReleased(4, GAMEPAD_BUTTON_MIDDLE) || IsKeyReleased(NkKeyToKeyboardKey(menu.keyMenu))) {
+    if (IsGamepadButtonReleased(0, GAMEPAD_BUTTON_MIDDLE) || IsGamepadButtonReleased(1, GAMEPAD_BUTTON_MIDDLE) || IsGamepadButtonReleased(3, GAMEPAD_BUTTON_MIDDLE) || IsGamepadButtonReleased(4, GAMEPAD_BUTTON_MIDDLE)) {
         menu.active = !menu.active;
+    } else if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyMenu))) {
+        if (menu.active && nk_console_active_parent(menu.console) != menu.console) {
+            nk_console_navigate_back(nk_console_active_parent(menu.console));
+        } else {
+            menu.active = !menu.active;
+        }
     }
 
     if (!menu.active) {

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -159,7 +159,6 @@ static void LibretroMenuSettingChanged(nk_console* widget, void* user_data) {
 static void LibretroMenuKeyChanged(nk_console* widget, void* user_data) {
     (void)widget;
     (void)user_data;
-    SetLibretroShaderKeys(NkKeyToKeyboardKey(menu.keyPrevShader), NkKeyToKeyboardKey(menu.keyNextShader));
     SaveLibretroMenuSettings();
 }
 
@@ -795,7 +794,6 @@ static bool LoadLibretroMenuSettings(void) {
     menu.keyReset       = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyReset",       (int)menu.keyReset);
     menu.keyVolumeUp    = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyVolumeUp",    (int)menu.keyVolumeUp);
     menu.keyVolumeDown  = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyVolumeDown",  (int)menu.keyVolumeDown);
-    SetLibretroShaderKeys(NkKeyToKeyboardKey(menu.keyPrevShader), NkKeyToKeyboardKey(menu.keyNextShader));
 
     const char* coreDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "coreDirectory");
     if (coreDirectory) TextCopy(LibretroCore.coreDirectory, coreDirectory);

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -347,8 +347,8 @@ LibretroMenu* InitLibretroMenu(void) {
     menu.keyPrevShader  = (nk_rune)NK_KEY_F9;
     menu.keyNextShader  = (nk_rune)NK_KEY_F10;
     menu.keyReset       = (nk_rune)NK_KEY_F5;
-    menu.keyVolumeUp    = (nk_rune)NK_KEY_F7;
-    menu.keyVolumeDown  = (nk_rune)NK_KEY_F6;
+    menu.keyVolumeUp    = (nk_rune)'=';
+    menu.keyVolumeDown  = (nk_rune)'-';
     menu.font = LoadFontFromNuklear(fontSize);
     if (!IsFontValid(menu.font)) {
         return NULL;

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -156,12 +156,6 @@ static void LibretroMenuSettingChanged(nk_console* widget, void* user_data) {
     SaveLibretroMenuSettings();
 }
 
-static void LibretroMenuKeyChanged(nk_console* widget, void* user_data) {
-    (void)widget;
-    (void)user_data;
-    SaveLibretroMenuSettings();
-}
-
 static void MenuCloseOnBack(nk_console* console, void* user_data) {
     (void)console;
     (void)user_data;
@@ -460,27 +454,27 @@ LibretroMenu* InitLibretroMenu(void) {
         {
             nk_console* w;
             w = nk_console_key(keysTree, "Screenshot", &menu.keyScreenshot);
-            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuKeyChanged, NULL, NULL);
+            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
             w = nk_console_key(keysTree, "Rewind", &menu.keyRewind);
-            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuKeyChanged, NULL, NULL);
+            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
             w = nk_console_key(keysTree, "Menu", &menu.keyMenu);
-            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuKeyChanged, NULL, NULL);
+            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
             w = nk_console_key(keysTree, "Save State", &menu.keySaveState);
-            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuKeyChanged, NULL, NULL);
+            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
             w = nk_console_key(keysTree, "Load State", &menu.keyLoadState);
-            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuKeyChanged, NULL, NULL);
+            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
             w = nk_console_key(keysTree, "Fullscreen", &menu.keyFullscreen);
-            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuKeyChanged, NULL, NULL);
+            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
             w = nk_console_key(keysTree, "Previous Shader", &menu.keyPrevShader);
-            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuKeyChanged, NULL, NULL);
+            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
             w = nk_console_key(keysTree, "Next Shader", &menu.keyNextShader);
-            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuKeyChanged, NULL, NULL);
+            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
             w = nk_console_key(keysTree, "Reset", &menu.keyReset);
-            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuKeyChanged, NULL, NULL);
+            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
             w = nk_console_key(keysTree, "Volume Up", &menu.keyVolumeUp);
-            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuKeyChanged, NULL, NULL);
+            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
             w = nk_console_key(keysTree, "Volume Down", &menu.keyVolumeDown);
-            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuKeyChanged, NULL, NULL);
+            nk_console_add_event_handler(w, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
         }
 
         // Directories

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -191,17 +191,6 @@ static KeyboardKey NkKeyToKeyboardKey(nk_rune key) {
     return (KeyboardKey)(int)key;
 }
 
-// Check if an nk_rune key binding is currently held down in raylib.
-static bool IsNkKeyDown(nk_rune key) {
-    KeyboardKey k = NkKeyToKeyboardKey(key);
-    return k != KEY_NULL && IsKeyDown(k);
-}
-
-// Check if an nk_rune key binding was just released in raylib.
-static bool IsNkKeyReleased(nk_rune key) {
-    KeyboardKey k = NkKeyToKeyboardKey(key);
-    return k != KEY_NULL && IsKeyReleased(k);
-}
 
 static LibretroMenu* GetLibretroMenu(void) {
     return &menu;
@@ -823,7 +812,7 @@ void UpdateLibretroMenu(void) {
     }
 
     // Toggle the menu
-    if (IsGamepadButtonReleased(0, GAMEPAD_BUTTON_MIDDLE) || IsGamepadButtonReleased(1, GAMEPAD_BUTTON_MIDDLE) || IsGamepadButtonReleased(3, GAMEPAD_BUTTON_MIDDLE) || IsGamepadButtonReleased(4, GAMEPAD_BUTTON_MIDDLE) || IsNkKeyReleased(menu.keyMenu)) {
+    if (IsGamepadButtonReleased(0, GAMEPAD_BUTTON_MIDDLE) || IsGamepadButtonReleased(1, GAMEPAD_BUTTON_MIDDLE) || IsGamepadButtonReleased(3, GAMEPAD_BUTTON_MIDDLE) || IsGamepadButtonReleased(4, GAMEPAD_BUTTON_MIDDLE) || IsKeyReleased(NkKeyToKeyboardKey(menu.keyMenu))) {
         menu.active = !menu.active;
     }
 

--- a/include/raylib-libretro-shaders.h
+++ b/include/raylib-libretro-shaders.h
@@ -188,7 +188,6 @@ LibretroShaderType GetActiveLibretroShaderType(void);
    or NULL when LIBRETRO_SHADER_NONE is active. */
 LibretroShaderState* GetActiveLibretroShaderState(void);
 
-void SetLibretroShaderKeys(KeyboardKey previous, KeyboardKey next);
 void BeginLibretroShader(void);
 void EndLibretroShader(void);
 
@@ -206,8 +205,6 @@ extern "C" {
 
 static LibretroShaderState rlsh_shaders[RAYLIB_LIBRETRO_SHADERS_MAX];
 static LibretroShaderType  rlsh_current = LIBRETRO_SHADER_NONE;
-static KeyboardKey rlsh_key_prev = KEY_F9;
-static KeyboardKey rlsh_key_next = KEY_F10;
 
 const char* GetLibretroShaderCode(LibretroShaderType type) {
     switch (type) {
@@ -550,17 +547,11 @@ void UnloadLibretroShaders(void) {
 }
 
 void UpdateLibretroShaders(float dt) {
-    if (rlsh_key_prev != KEY_NULL && IsKeyReleased(rlsh_key_prev)) CycleLibretroShaderReverse();
-    if (rlsh_key_next != KEY_NULL && IsKeyReleased(rlsh_key_next)) CycleLibretroShader();
     if (rlsh_current != LIBRETRO_SHADER_NONE) {
         UpdateLibretroShader(&rlsh_shaders[(int)rlsh_current - 1], dt);
     }
 }
 
-void SetLibretroShaderKeys(KeyboardKey previous, KeyboardKey next) {
-    rlsh_key_prev = previous;
-    rlsh_key_next = next;
-}
 
 void CycleLibretroShader(void) {
     int next = (int)rlsh_current + 1;

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -225,6 +225,7 @@ typedef struct rLibretro {
     // struct retro_game_info_ext game_info_ext;
 
     // Core variables/options
+    // TODO: Switch these to MemAlloc'ed strings.
     char variableKeys[LIBRETRO_MAX_CORE_VARIABLES][LIBRETRO_CORE_VARIABLE_KEY_LEN];
     char variableValues[LIBRETRO_MAX_CORE_VARIABLES][LIBRETRO_CORE_VARIABLE_VALUE_LEN];
     char variableLabels[LIBRETRO_MAX_CORE_VARIABLES][LIBRETRO_CORE_VARIABLE_LABEL_LEN];
@@ -268,6 +269,8 @@ extern "C" {
 
 /**
  * The global libretro core object.
+ *
+ * TODO: Figure out a way to have LibretroCore not be a static global?
  */
 static rLibretro LibretroCore = {0};
 
@@ -909,7 +912,8 @@ static bool LibretroSetEnvironment(unsigned cmd, void * data) {
         }
 
         case RETRO_ENVIRONMENT_GET_CURRENT_SOFTWARE_FRAMEBUFFER: {
-            TraceLog(LOG_WARNING, "LIBRETRO: RETRO_ENVIRONMENT_GET_CURRENT_SOFTWARE_FRAMEBUFFER not implemented");
+            // This is not supported because the framebuffer format may not match the expected PixelFormat.
+            TraceLog(LOG_WARNING, "LIBRETRO: RETRO_ENVIRONMENT_GET_CURRENT_SOFTWARE_FRAMEBUFFER not supported");
             return false;
         }
 
@@ -2172,12 +2176,13 @@ static int LibretroMapRetroLogLevelToTraceLogType(int level) {
     switch (level) {
         case RETRO_LOG_DEBUG:
             return LOG_DEBUG;
-        case RETRO_LOG_INFO:
-            return LOG_INFO;
         case RETRO_LOG_WARN:
             return LOG_WARNING;
         case RETRO_LOG_ERROR:
             return LOG_ERROR;
+        case RETRO_LOG_INFO:
+        default:
+            return LOG_INFO;
     }
 
     return LOG_INFO;


### PR DESCRIPTION
Adds a Keys section under Settings that allows rebinding hotkeys for Screenshot, Rewind, Menu, Save State, Load State, Fullscreen, Previous Shader, and Next Shader. Keys are saved/loaded from config and default to the existing hardcoded values. Fixes #77