### PR TITLE
Add Emscripten web build

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -24,6 +24,19 @@ jobs:
     - name: Build
       run: cmake --build build
 
+  build-web:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - name: Install Emscripten
+      uses: mymindstorm/setup-emsdk@v14
+    - name: Configure
+      run: emcmake cmake -DPLATFORM=Web -DCMAKE_BUILD_TYPE=Release -B build .
+    - name: Build
+      run: cmake --build build
+
 #   build-windows:
 #     runs-on: windows-latest
 #     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,46 @@ endif()
 add_subdirectory(include)
 add_subdirectory(lib)
 
+# Directory where downloaded resources are extracted
+if (NOT DEFINED RESOURCES_DIR)
+    set(RESOURCES_DIR "${CMAKE_BINARY_DIR}/resources")
+endif()
+
+# download_resources(<url> [<url> ...])
+# Downloads each zip URL to the build directory and extracts it into RESOURCES_DIR.
+# Already-downloaded archives are skipped on subsequent runs.
+function(download_resources)
+    file(MAKE_DIRECTORY "${RESOURCES_DIR}")
+    foreach(URL IN LISTS ARGN)
+        get_filename_component(ARCHIVE_NAME "${URL}" NAME)
+        set(ARCHIVE_PATH "${CMAKE_BINARY_DIR}/${ARCHIVE_NAME}")
+
+        if (NOT EXISTS "${ARCHIVE_PATH}")
+            message(STATUS "Downloading ${URL}")
+            file(DOWNLOAD "${URL}" "${ARCHIVE_PATH}"
+                STATUS DOWNLOAD_STATUS
+                SHOW_PROGRESS
+            )
+            list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
+            list(GET DOWNLOAD_STATUS 1 STATUS_MSG)
+            if (NOT STATUS_CODE EQUAL 0)
+                message(WARNING "Failed to download ${URL}: ${STATUS_MSG}")
+                continue()
+            endif()
+        endif()
+
+        message(STATUS "Extracting ${ARCHIVE_NAME} to ${RESOURCES_DIR}")
+        execute_process(
+            COMMAND ${CMAKE_COMMAND} -E tar xf "${ARCHIVE_PATH}"
+            WORKING_DIRECTORY "${RESOURCES_DIR}"
+            RESULT_VARIABLE EXTRACT_RESULT
+        )
+        if (NOT EXTRACT_RESULT EQUAL 0)
+            message(WARNING "Failed to extract ${ARCHIVE_NAME}")
+        endif()
+    endforeach()
+endfunction()
+
 # Example
 option(BUILD_RAYLIB_LIBRETRO_EXAMPLE "Build Examples" ON)
 if (BUILD_RAYLIB_LIBRETRO_EXAMPLE)
@@ -28,4 +68,21 @@ endif()
 option(BUILD_RAYLIB_LIBRETRO "raylib-libretro" ON)
 if(BUILD_RAYLIB_LIBRETRO)
     add_subdirectory(bin)
+endif()
+
+# OSX
+if (APPLE)
+    target_link_libraries(${PROJECT_NAME} "-framework IOKit")
+    target_link_libraries(${PROJECT_NAME} "-framework Cocoa")
+    target_link_libraries(${PROJECT_NAME} "-framework OpenGL")
+endif()
+
+# Web
+if ("${PLATFORM}" STREQUAL "Web")
+    set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "index")
+    set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".html")
+    target_link_options(${PROJECT_NAME} PUBLIC -sUSE_GLFW=3 PUBLIC --preload-file "${CMAKE_BINARY_DIR}/resources")
+
+    download_resources("https://cdn.jsdelivr.net/gh/arianrhodsandlot/retroarch-emscripten-build@v1.22.2/retroarch/fceumm_libretro.zip")
+
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,11 @@ endif()
 if ("${PLATFORM}" STREQUAL "Web")
     set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "index")
     set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".html")
-    target_link_options(${PROJECT_NAME} PUBLIC -sUSE_GLFW=3 PUBLIC --preload-file "${CMAKE_BINARY_DIR}/resources")
+    target_link_options(${PROJECT_NAME} PUBLIC
+        -sUSE_GLFW=3
+        -sMAIN_MODULE=1
+        --preload-file "${CMAKE_BINARY_DIR}/resources@/resources"
+    )
 
     download_resources("https://cdn.jsdelivr.net/gh/arianrhodsandlot/retroarch-emscripten-build@v1.22.2/retroarch/fceumm_libretro.zip")
 

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -115,9 +115,15 @@ bool Init(void** userData, int argc, char** argv) {
     }
 
     // Parse the command line arguments.
-    if (argc > 1) {
+    const char* corePath = (argc > 1) ? argv[1] : NULL;
+#ifdef __EMSCRIPTEN__
+    if (!corePath) {
+        corePath = "/resources/fceumm_libretro.wasm";
+    }
+#endif
+    if (corePath) {
         // Initialize the given core.
-        if (InitLibretro(argv[1])) {
+        if (InitLibretro(corePath)) {
             // Apply any previously saved options before the game starts.
             LoadLibretroCoreOptions();
             SetLibretroVolume(data->menu->volumeSelected);

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -253,13 +253,13 @@ bool UpdateDrawFrame(void* userData) {
     }
 
     // Prev Slot
-    else if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyPrevSlot)) && !menu.active) {
+    else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyPrevSlot)) && !menu.active) {
         menu.saveSlotIndex = (menu.saveSlotIndex - 1 + 10) % 10;
         ShowLibretroMessage(TextFormat("Save Slot: %d", menu.saveSlotIndex + 1), 1.0f);
     }
 
     // Next Slot
-    else if (IsKeyReleased(NkKeyToKeyboardKey(menu.keyNextSlot)) && !menu.active) {
+    else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyNextSlot)) && !menu.active) {
         menu.saveSlotIndex = (menu.saveSlotIndex + 1) % 10;
         ShowLibretroMessage(TextFormat("Save Slot: %d", menu.saveSlotIndex + 1), 1.0f);
     }

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -310,6 +310,8 @@ LibretroMenu* InitLibretroMenu(void) {
     menu.resumeButton = nk_console_button_onclick(menu.console, "Resume", &MenuResumeClicked);
     nk_console_button_set_symbol(menu.resumeButton, NK_SYMBOL_TRIANGLE_RIGHT);
 
+    
+
     // Load Game
     nk_console_button(menu.console, "Load Game");
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -9,6 +9,10 @@ add_library(raylib-libretro-static STATIC
     ../vendor/libretro-common/file/file_path.c
     ../vendor/libretro-common/dynamic/dylib.c
     ../vendor/libretro-common/features/features_cpu.c
+    ../vendor/libretro-common/streams/file_stream.c
+    ../vendor/libretro-common/vfs/vfs_implementation.c
+    ../vendor/libretro-common/file/file_path_io.c
+    ../vendor/libretro-common/time/rtime.c
 )
 target_link_libraries(raylib-libretro-static PUBLIC
     raylib


### PR DESCRIPTION
Adds web build support via Emscripten: CI job, `-sMAIN_MODULE=1` for dlopen of wasm cores, correct preload path, and auto-load of the bundled fceumm core on web.

Fixes #55