### PR TITLE
Implement per-core input descriptors and controller info

### DIFF
--- a/include/raylib-libretro-vfs.h
+++ b/include/raylib-libretro-vfs.h
@@ -39,25 +39,25 @@ extern "C" {
 #endif
 
 static const char* raylib_libretro_vfs_get_path(struct retro_vfs_file_handle* stream);
-struct retro_vfs_file_handle* raylib_libretro_vfs_open(const char* path, unsigned int mode, unsigned int hints);
-int raylib_libretro_vfs_close(struct retro_vfs_file_handle* stream);
-int64_t raylib_libretro_vfs_size(struct retro_vfs_file_handle* stream);
-int64_t raylib_libretro_vfs_truncate(struct retro_vfs_file_handle* stream, int64_t length);
-int64_t raylib_libretro_vfs_tell(struct retro_vfs_file_handle* stream);
-int64_t raylib_libretro_vfs_seek(struct retro_vfs_file_handle* stream, int64_t offset, int seek_position);
-int64_t raylib_libretro_vfs_read(struct retro_vfs_file_handle* stream, void *s, uint64_t len);
-int64_t raylib_libretro_vfs_write(struct retro_vfs_file_handle* stream, const void *s, uint64_t len);
-int raylib_libretro_vfs_flush(struct retro_vfs_file_handle* stream);
-int raylib_libretro_vfs_remove(const char* path);
-int raylib_libretro_vfs_rename(const char* old_path, const char* new_path);
-int raylib_libretro_vfs_stat(const char* path, int32_t *size);
-int raylib_libretro_vfs_stat_64(const char* path, int64_t *size);
-int raylib_libretro_vfs_mkdir(const char* dir);
-struct retro_vfs_dir_handle* raylib_libretro_vfs_opendir(const char* dir, bool include_hidden);
-bool raylib_libretro_vfs_readdir(struct retro_vfs_dir_handle* dirstream);
-const char* raylib_libretro_vfs_dirent_get_name(struct retro_vfs_dir_handle* dirstream);
-bool raylib_libretro_vfs_dirent_is_dir(struct retro_vfs_dir_handle* dirstream);
-int raylib_libretro_vfs_closedir(struct retro_vfs_dir_handle* dirstream);
+static struct retro_vfs_file_handle* raylib_libretro_vfs_open(const char* path, unsigned int mode, unsigned int hints);
+static int raylib_libretro_vfs_close(struct retro_vfs_file_handle* stream);
+static int64_t raylib_libretro_vfs_size(struct retro_vfs_file_handle* stream);
+static int64_t raylib_libretro_vfs_truncate(struct retro_vfs_file_handle* stream, int64_t length);
+static int64_t raylib_libretro_vfs_tell(struct retro_vfs_file_handle* stream);
+static int64_t raylib_libretro_vfs_seek(struct retro_vfs_file_handle* stream, int64_t offset, int seek_position);
+static int64_t raylib_libretro_vfs_read(struct retro_vfs_file_handle* stream, void *s, uint64_t len);
+static int64_t raylib_libretro_vfs_write(struct retro_vfs_file_handle* stream, const void *s, uint64_t len);
+static int raylib_libretro_vfs_flush(struct retro_vfs_file_handle* stream);
+static int raylib_libretro_vfs_remove(const char* path);
+static int raylib_libretro_vfs_rename(const char* old_path, const char* new_path);
+static int raylib_libretro_vfs_stat(const char* path, int32_t *size);
+static int raylib_libretro_vfs_stat_64(const char* path, int64_t *size);
+static int raylib_libretro_vfs_mkdir(const char* dir);
+static struct retro_vfs_dir_handle* raylib_libretro_vfs_opendir(const char* dir, bool include_hidden);
+static bool raylib_libretro_vfs_readdir(struct retro_vfs_dir_handle* dirstream);
+static const char* raylib_libretro_vfs_dirent_get_name(struct retro_vfs_dir_handle* dirstream);
+static bool raylib_libretro_vfs_dirent_is_dir(struct retro_vfs_dir_handle* dirstream);
+static int raylib_libretro_vfs_closedir(struct retro_vfs_dir_handle* dirstream);
 
 #if defined(__cplusplus)
 }
@@ -104,7 +104,7 @@ static const char* raylib_libretro_vfs_get_path(struct retro_vfs_file_handle* st
  * @see retro_vfs_open_t
  * @since VFS API v1
  */
-struct retro_vfs_file_handle* raylib_libretro_vfs_open(const char* path, unsigned int mode, unsigned int hints) {
+static struct retro_vfs_file_handle* raylib_libretro_vfs_open(const char* path, unsigned int mode, unsigned int hints) {
     if (path == NULL || TextLength(path) >= RAYLIB_LIBRETRO_VFS_MAX_PATH) {
         TraceLog(LOG_ERROR, "LIBRETRO: Path length is too long");
         return NULL;
@@ -154,7 +154,7 @@ struct retro_vfs_file_handle* raylib_libretro_vfs_open(const char* path, unsigne
  * @see retro_vfs_close_t
  * @since VFS API v1
  */
-int raylib_libretro_vfs_close(struct retro_vfs_file_handle* stream) {
+static int raylib_libretro_vfs_close(struct retro_vfs_file_handle* stream) {
     if (stream == NULL) {
         return 0;
     }
@@ -179,7 +179,7 @@ int raylib_libretro_vfs_close(struct retro_vfs_file_handle* stream) {
  * @see retro_vfs_size_t
  * @since VFS API v1
  */
-int64_t raylib_libretro_vfs_size(struct retro_vfs_file_handle* stream) {
+static int64_t raylib_libretro_vfs_size(struct retro_vfs_file_handle* stream) {
     if (stream == NULL) {
         return -1;
     }
@@ -199,7 +199,7 @@ int64_t raylib_libretro_vfs_size(struct retro_vfs_file_handle* stream) {
  * @see filestream_truncate
  * @since VFS API v2
  */
-int64_t raylib_libretro_vfs_truncate(struct retro_vfs_file_handle* stream, int64_t length) {
+static int64_t raylib_libretro_vfs_truncate(struct retro_vfs_file_handle* stream, int64_t length) {
     if (stream == NULL || length < 0) {
         return -1;
     }
@@ -233,7 +233,7 @@ int64_t raylib_libretro_vfs_truncate(struct retro_vfs_file_handle* stream, int64
  * @see filestream_tell
  * @since VFS API v1
  */
-int64_t raylib_libretro_vfs_tell(struct retro_vfs_file_handle* stream) {
+static int64_t raylib_libretro_vfs_tell(struct retro_vfs_file_handle* stream) {
     if (stream == NULL) {
         return -1;
     }
@@ -253,7 +253,7 @@ int64_t raylib_libretro_vfs_tell(struct retro_vfs_file_handle* stream) {
  * @see File Seek Positions
  * @see filestream_seek
  */
-int64_t raylib_libretro_vfs_seek(struct retro_vfs_file_handle* stream, int64_t offset, int seek_position) {
+static int64_t raylib_libretro_vfs_seek(struct retro_vfs_file_handle* stream, int64_t offset, int seek_position) {
     if (stream == NULL) {
         return -1;
     }
@@ -294,7 +294,7 @@ int64_t raylib_libretro_vfs_seek(struct retro_vfs_file_handle* stream, int64_t o
  * @since VFS API v1
  * @see filestream_read
  */
-int64_t raylib_libretro_vfs_read(struct retro_vfs_file_handle* stream, void *s, uint64_t len) {
+static int64_t raylib_libretro_vfs_read(struct retro_vfs_file_handle* stream, void *s, uint64_t len) {
     if (stream == NULL || s == NULL || stream->data == NULL) {
         return -1;
     }
@@ -326,7 +326,7 @@ int64_t raylib_libretro_vfs_read(struct retro_vfs_file_handle* stream, void *s, 
  * @since VFS API v1
  * @see filestream_write
  */
-int64_t raylib_libretro_vfs_write(struct retro_vfs_file_handle* stream, const void *s, uint64_t len) {
+static int64_t raylib_libretro_vfs_write(struct retro_vfs_file_handle* stream, const void *s, uint64_t len) {
     if (stream == NULL || s == NULL) {
         return -1;
     }
@@ -366,7 +366,7 @@ int64_t raylib_libretro_vfs_write(struct retro_vfs_file_handle* stream, const vo
  * @since VFS API v1
  * @see filestream_flush
  */
-int raylib_libretro_vfs_flush(struct retro_vfs_file_handle* stream) {
+static int raylib_libretro_vfs_flush(struct retro_vfs_file_handle* stream) {
     if (stream == NULL || !(stream->mode & RETRO_VFS_FILE_ACCESS_WRITE)) {
         return 0;
     }
@@ -386,7 +386,7 @@ int raylib_libretro_vfs_flush(struct retro_vfs_file_handle* stream) {
  * @see filestream_delete
  * @since VFS API v1
  */
-int raylib_libretro_vfs_remove(const char* path) {
+static int raylib_libretro_vfs_remove(const char* path) {
     return FileRemove(path);
 }
 
@@ -400,7 +400,7 @@ int raylib_libretro_vfs_remove(const char* path) {
  * @see filestream_rename
  * @since VFS API v1
  */
-int raylib_libretro_vfs_rename(const char* old_path, const char* new_path) {
+static int raylib_libretro_vfs_rename(const char* old_path, const char* new_path) {
     return FileRename(old_path, new_path);
 }
 
@@ -417,7 +417,7 @@ int raylib_libretro_vfs_rename(const char* old_path, const char* new_path) {
  * @see RETRO_VFS_STAT
  * @since VFS API v3
  */
-int raylib_libretro_vfs_stat(const char* path, int32_t *size) {
+static int raylib_libretro_vfs_stat(const char* path, int32_t *size) {
     // DirectoryExists must be checked first, because FileExists uses
     // access() which returns true for directories.
     if (DirectoryExists(path)) {
@@ -449,7 +449,7 @@ int raylib_libretro_vfs_stat(const char* path, int32_t *size) {
  * @see raylib_libretro_vfs_stat
  * @since VFS API v4
  */
-int raylib_libretro_vfs_stat_64(const char* path, int64_t *size) {
+static int raylib_libretro_vfs_stat_64(const char* path, int64_t *size) {
     // TODO: raylib doesn't really have an int64 file size type, so we use stat() instead.
     int32_t size32;
     int output = raylib_libretro_vfs_stat(path, &size32);
@@ -469,7 +469,7 @@ int raylib_libretro_vfs_stat_64(const char* path, int64_t *size) {
  * @see path_mkdir
  * @since VFS API v3
  */
-int raylib_libretro_vfs_mkdir(const char* dir) {
+static int raylib_libretro_vfs_mkdir(const char* dir) {
     if (DirectoryExists(dir)) {
         return -2;
     }
@@ -493,7 +493,7 @@ int raylib_libretro_vfs_mkdir(const char* dir) {
  * @see retro_opendir
  * @since VFS API v3
  */
-struct retro_vfs_dir_handle* raylib_libretro_vfs_opendir(const char* dir, bool include_hidden) {
+static struct retro_vfs_dir_handle* raylib_libretro_vfs_opendir(const char* dir, bool include_hidden) {
     if (dir == NULL) {
         return NULL;
     }
@@ -538,7 +538,7 @@ struct retro_vfs_dir_handle* raylib_libretro_vfs_opendir(const char* dir, bool i
  * @see retro_vfs_dirent_is_dir_t
  * @since VFS API v3
  */
-bool raylib_libretro_vfs_readdir(struct retro_vfs_dir_handle* dirstream) {
+static bool raylib_libretro_vfs_readdir(struct retro_vfs_dir_handle* dirstream) {
     if (dirstream == NULL) {
         return false;
     }
@@ -578,7 +578,7 @@ bool raylib_libretro_vfs_readdir(struct retro_vfs_dir_handle* dirstream) {
  * @see retro_dirent_get_name
  * @since VFS API v3
  */
-const char* raylib_libretro_vfs_dirent_get_name(struct retro_vfs_dir_handle* dirstream) {
+static const char* raylib_libretro_vfs_dirent_get_name(struct retro_vfs_dir_handle* dirstream) {
     if (dirstream == NULL) {
         return NULL;
     }
@@ -599,7 +599,7 @@ const char* raylib_libretro_vfs_dirent_get_name(struct retro_vfs_dir_handle* dir
  * @see retro_dirent_is_dir
  * @since VFS API v3
  */
-bool raylib_libretro_vfs_dirent_is_dir(struct retro_vfs_dir_handle* dirstream) {
+static bool raylib_libretro_vfs_dirent_is_dir(struct retro_vfs_dir_handle* dirstream) {
     if (dirstream == NULL) {
         return false;
     }
@@ -623,7 +623,7 @@ bool raylib_libretro_vfs_dirent_is_dir(struct retro_vfs_dir_handle* dirstream) {
  * @see retro_closedir
  * @since VFS API v3
  */
-int raylib_libretro_vfs_closedir(struct retro_vfs_dir_handle* dirstream) {
+static int raylib_libretro_vfs_closedir(struct retro_vfs_dir_handle* dirstream) {
     if (dirstream == NULL) {
         return 0;
     }

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -82,6 +82,8 @@ static bool SetLibretroSerializedData(void* data, unsigned int size);
 static void ShowLibretroMessage(const char* msg, float duration); // Show an OSD message for the given duration in seconds.
 static bool DrawLibretroMessage(); // Displays the OSD message on the screen. Returns true if there was one.
 static const char* GetLibretroDirectory(int directory);
+static const struct retro_input_descriptor* GetLibretroInputDescriptors(unsigned *count); // Get input descriptors; count set to number of entries.
+static const struct retro_controller_info* GetLibretroControllerInfo(unsigned *count);    // Get controller info; count set to number of ports.
 
 static void LibretroMapPixelFormatARGB1555ToRGB565(void *output_, const void *input_,
         int width, int height,
@@ -225,6 +227,14 @@ typedef struct rLibretro {
     struct retro_vfs_interface vfs_interface;
     // struct retro_game_info_ext game_info_ext;
 
+    // Input descriptors (RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS)
+    struct retro_input_descriptor *inputDescriptors;
+    unsigned inputDescriptorCount;
+
+    // Controller info (RETRO_ENVIRONMENT_SET_CONTROLLER_INFO)
+    struct retro_controller_info *controllerInfo;
+    unsigned controllerPortCount;
+
     // Core variables/options
     // TODO: Switch these to MemAlloc'ed strings.
     char variableKeys[LIBRETRO_MAX_CORE_VARIABLES][LIBRETRO_CORE_VARIABLE_KEY_LEN];
@@ -351,6 +361,16 @@ static const char* GetLibretroDirectory(int directory) {
 
     // TODO: Resolve to an absolute path.
     return output;
+}
+
+static const struct retro_input_descriptor* GetLibretroInputDescriptors(unsigned *count) {
+    if (count != NULL) *count = LibretroCore.inputDescriptorCount;
+    return LibretroCore.inputDescriptors;
+}
+
+static const struct retro_controller_info* GetLibretroControllerInfo(unsigned *count) {
+    if (count != NULL) *count = LibretroCore.controllerPortCount;
+    return LibretroCore.controllerInfo;
 }
 
 static const char* LibretroResolveAbsoluteDirectory(const char* path) {
@@ -605,17 +625,32 @@ static bool LibretroSetEnvironment(unsigned cmd, void * data) {
         }
 
         case RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS: {
-            // TODO: Implement RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS
             const struct retro_input_descriptor *desc = (const struct retro_input_descriptor *)data;
             if (desc == NULL) {
                 TraceLog(LOG_WARNING, "LIBRETRO: RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS no data set");
                 return false;
             }
-            for (; desc->description != NULL; desc++) {
-                TraceLog(LOG_INFO, "LIBRETRO: Input port %u device %u index %u id %u: %s",
-                    desc->port, desc->device, desc->index, desc->id, desc->description);
+            unsigned count = 0;
+            for (const struct retro_input_descriptor *d = desc; d->description != NULL; d++) {
+                count++;
             }
-            return false;
+            if (LibretroCore.inputDescriptors != NULL) {
+                MemFree(LibretroCore.inputDescriptors);
+                LibretroCore.inputDescriptors = NULL;
+                LibretroCore.inputDescriptorCount = 0;
+            }
+            if (count > 0) {
+                LibretroCore.inputDescriptors = (struct retro_input_descriptor *)MemAlloc(count * sizeof(struct retro_input_descriptor));
+                if (LibretroCore.inputDescriptors != NULL) {
+                    for (unsigned i = 0; i < count; i++) {
+                        LibretroCore.inputDescriptors[i] = desc[i];
+                        TraceLog(LOG_INFO, "LIBRETRO: Input port %u device %u index %u id %u: %s",
+                            desc[i].port, desc[i].device, desc[i].index, desc[i].id, desc[i].description);
+                    }
+                    LibretroCore.inputDescriptorCount = count;
+                }
+            }
+            return true;
         }
 
         case RETRO_ENVIRONMENT_SET_KEYBOARD_CALLBACK: {
@@ -870,14 +905,29 @@ static bool LibretroSetEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const struct retro_controller_info *info = (const struct retro_controller_info *)data;
+            if (LibretroCore.controllerInfo != NULL) {
+                MemFree(LibretroCore.controllerInfo);
+                LibretroCore.controllerInfo = NULL;
+                LibretroCore.controllerPortCount = 0;
+            }
+            unsigned portCount = 0;
             for (unsigned port = 0; info[port].types != NULL; port++) {
-                TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_CONTROLLER_INFO port %u (%u types)", port, info[port].num_types);
-                for (unsigned i = 0; i < info[port].num_types; i++) {
-                    TraceLog(LOG_INFO, "    > [%u] %s (id: %u)", i, info[port].types[i].desc, info[port].types[i].id);
+                portCount++;
+            }
+            if (portCount > 0) {
+                LibretroCore.controllerInfo = (struct retro_controller_info *)MemAlloc(portCount * sizeof(struct retro_controller_info));
+                if (LibretroCore.controllerInfo != NULL) {
+                    for (unsigned port = 0; port < portCount; port++) {
+                        LibretroCore.controllerInfo[port] = info[port];
+                        TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_CONTROLLER_INFO port %u (%u types)", port, info[port].num_types);
+                        for (unsigned i = 0; i < info[port].num_types; i++) {
+                            TraceLog(LOG_INFO, "    > [%u] %s (id: %u)", i, info[port].types[i].desc, info[port].types[i].id);
+                        }
+                    }
+                    LibretroCore.controllerPortCount = portCount;
                 }
             }
-            // TODO: Implement RETRO_ENVIRONMENT_SET_CONTROLLER_INFO
-            return false;
+            return true;
         }
 
         case RETRO_ENVIRONMENT_SET_MEMORY_MAPS: {
@@ -2231,6 +2281,18 @@ static void CloseLibretro() {
 
     CloseLibretroAudio();
     CloseLibretroVideo();
+
+    if (LibretroCore.inputDescriptors != NULL) {
+        MemFree(LibretroCore.inputDescriptors);
+        LibretroCore.inputDescriptors = NULL;
+        LibretroCore.inputDescriptorCount = 0;
+    }
+
+    if (LibretroCore.controllerInfo != NULL) {
+        MemFree(LibretroCore.controllerInfo);
+        LibretroCore.controllerInfo = NULL;
+        LibretroCore.controllerPortCount = 0;
+    }
 
     // Close the dynamically loaded handle.
     if (LibretroCore.handle != NULL) {


### PR DESCRIPTION
Implements `RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS` and `RETRO_ENVIRONMENT_SET_CONTROLLER_INFO`, storing descriptors and controller port data in the `LibretroCore` object with `MemAlloc`/`MemFree`, and exposes them via `GetLibretroInputDescriptors()` and `GetLibretroControllerInfo()`. Fixes #89