### PR TITLE
Mark analog stick support as done

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -44,6 +44,6 @@
 ## Input
 
 - [ ] Gamepad auto-detection and mapping
-- [ ] Analog stick support for cores that use it
+- [x] Analog stick support for cores that use it
 - [ ] Multi-player / multi-gamepad assignment
 - [ ] Command-line ROM drag-and-drop onto window


### PR DESCRIPTION
Analog stick input via RETRO_DEVICE_ANALOG is already implemented in LibretroInputState() and listed in device capabilities — marks it complete in TASKS.md. Fixes #88