### PR TITLE
Adopt raylib-zip for .zip file loading

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -36,3 +36,6 @@
 [submodule "vendor/hashmap"]
 	path = vendor/hashmap
 	url = git@github.com:RolandMarchand/hashmap.h.git
+[submodule "vendor/raylib-zip"]
+	path = vendor/raylib-zip
+	url = https://github.com/RobLoach/raylib-zip.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,16 +15,6 @@ if (NOT raylib_FOUND)
     add_subdirectory(vendor/raylib vendor/raylib)
 endif()
 
-# kuba--/zip (required by raylib-zip)
-include(FetchContent)
-FetchContent_Declare(
-    zip
-    GIT_REPOSITORY https://github.com/kuba--/zip.git
-    GIT_TAG v0.3.8
-)
-set(CMAKE_ENABLE_EXPORTS ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(zip)
-
 # raylib-zip
 add_subdirectory(vendor/raylib-zip vendor/raylib-zip)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,19 @@ if (NOT raylib_FOUND)
     add_subdirectory(vendor/raylib vendor/raylib)
 endif()
 
+# kuba--/zip (required by raylib-zip)
+include(FetchContent)
+FetchContent_Declare(
+    zip
+    GIT_REPOSITORY https://github.com/kuba--/zip.git
+    GIT_TAG v0.3.8
+)
+set(CMAKE_ENABLE_EXPORTS ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(zip)
+
+# raylib-zip
+add_subdirectory(vendor/raylib-zip vendor/raylib-zip)
+
 add_subdirectory(include)
 add_subdirectory(lib)
 

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -4,10 +4,12 @@ add_executable(raylib-libretro
 )
 target_link_libraries(raylib-libretro PUBLIC
     raylib-libretro-static
+    raylib_zip
 )
 target_include_directories(raylib-libretro PUBLIC
     ../vendor/raygui/src
     ../vendor/raylib-app
+    ../vendor/raylib-zip
 )
 install(TARGETS raylib-libretro DESTINATION bin)
 install(FILES ../README.md DESTINATION share/raylib-libretro)

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -34,6 +34,8 @@
 #define RAYLIB_LIBRETRO_CONFIG_IMPLEMENTATION
 #include "raylib-libretro-config.h"
 
+#include "raylib-zip.h"
+
 #define RAYLIB_LIBRETRO_IMPLEMENTATION
 #include "raylib-libretro.h"
 
@@ -94,6 +96,36 @@ typedef struct {
     RewindBuffer rewind;
 } AppData;
 
+static bool LoadGameFile(const char* gameFile) {
+    if (gameFile && IsFileExtension(gameFile, ".zip")) {
+        Zip archive = LoadZip(gameFile);
+        if (!IsZipValid(archive)) {
+            TraceLog(LOG_ERROR, "LIBRETRO: Failed to open zip: %s", gameFile);
+            UnloadZip(archive);
+            return false;
+        }
+        FilePathList files = LoadDirectoryFilesFromZip(archive, NULL);
+        if (files.count == 0) {
+            TraceLog(LOG_ERROR, "LIBRETRO: No files found in zip: %s", gameFile);
+            UnloadDirectoryFiles(files);
+            UnloadZip(archive);
+            return false;
+        }
+        int dataSize = 0;
+        unsigned char* gameData = LoadFileDataFromZip(archive, files.paths[0], &dataSize);
+        UnloadDirectoryFiles(files);
+        UnloadZip(archive);
+        if (gameData == NULL || dataSize == 0) {
+            TraceLog(LOG_ERROR, "LIBRETRO: Failed to extract content from zip: %s", gameFile);
+            return false;
+        }
+        bool result = LoadLibretroGameFromMemory(gameData, dataSize);
+        MemFree(gameData);
+        return result;
+    }
+    return LoadLibretroGame(gameFile);
+}
+
 bool Init(void** userData, int argc, char** argv) {
     SetWindowMinSize(400, 300);
     SetExitKey(KEY_NULL);
@@ -130,7 +162,7 @@ bool Init(void** userData, int argc, char** argv) {
 
             // Load the given game.
             const char* gameFile = (argc > 2) ? argv[2] : NULL;
-            if (LoadLibretroGame(gameFile)) {
+            if (LoadGameFile(gameFile)) {
                 BuildLibretroMenuOptions(data->menu);
                 data->menu->active = false;
             }

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -98,6 +98,9 @@ typedef struct {
 } AppData;
 
 static bool LoadGameFile(const char* gameFile) {
+    if (IsLibretroGameReady()) {
+        UnloadLibretroGame();
+    }
     if (gameFile && IsFileExtension(gameFile, ".zip")) {
         Zip archive = LoadZip(gameFile);
         if (!IsZipValid(archive)) {

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -104,35 +104,11 @@ static bool LoadGameFile(const char* gameFile) {
     if (IsLibretroGameReady()) {
         UnloadLibretroGame();
     }
+#ifdef RAYLIB_ZIP_H
     if (gameFile && IsFileExtension(gameFile, ".zip")) {
-        Zip archive = LoadZip(gameFile);
-        if (!IsZipValid(archive)) {
-            TraceLog(LOG_ERROR, "LIBRETRO: Failed to open zip: %s", gameFile);
-            UnloadZip(archive);
-            return false;
-        }
-        FilePathList files = LoadDirectoryFilesFromZip(archive, NULL);
-        if (files.count == 0) {
-            TraceLog(LOG_ERROR, "LIBRETRO: No files found in zip: %s", gameFile);
-            UnloadDirectoryFiles(files);
-            UnloadZip(archive);
-            return false;
-        }
-        int dataSize = 0;
-        unsigned char* gameData = LoadFileDataFromZip(archive, files.paths[0], &dataSize);
-        UnloadDirectoryFiles(files);
-        UnloadZip(archive);
-        if (gameData == NULL || dataSize == 0) {
-            TraceLog(LOG_ERROR, "LIBRETRO: Failed to extract content from zip: %s", gameFile);
-            return false;
-        }
-        bool result = LoadLibretroGameFromMemory(gameData, dataSize);
-        MemFree(gameData);
-        if (result) {
-            TextCopy(LibretroCore.contentPath, gameFile);
-        }
-        return result;
+        return MenuLoadGameFromZip(gameFile);
     }
+#endif
     return LoadLibretroGame(gameFile);
 }
 
@@ -177,12 +153,6 @@ bool Init(void** userData, int argc, char** argv) {
             gameFile = argv[i];
         }
     }
-#ifdef __EMSCRIPTEN__
-    if (!corePath) {
-        corePath = "/resources/fceumm_libretro.wasm";
-    }
-#endif
-
     if (corePath) {
         if (MenuInitCore(corePath) && LoadGameFile(gameFile)) {
             BuildLibretroMenuOptions(data->menu);

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -34,6 +34,7 @@
 #define RAYLIB_LIBRETRO_CONFIG_IMPLEMENTATION
 #include "raylib-libretro-config.h"
 
+#define RAYLIB_ZIP_IMPLEMENTATION
 #include "raylib-zip.h"
 
 #define RAYLIB_LIBRETRO_IMPLEMENTATION

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -126,6 +126,9 @@ static bool LoadGameFile(const char* gameFile) {
         }
         bool result = LoadLibretroGameFromMemory(gameData, dataSize);
         MemFree(gameData);
+        if (result) {
+            TextCopy(LibretroCore.contentPath, gameFile);
+        }
         return result;
     }
     return LoadLibretroGame(gameFile);

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -104,7 +104,7 @@ static bool LoadGameFile(const char* gameFile) {
     if (IsLibretroGameReady()) {
         UnloadLibretroGame();
     }
-#ifdef RAYLIB_ZIP_H
+#ifdef RAYLIB_ZIP_H_
     if (gameFile && IsFileExtension(gameFile, ".zip")) {
         return MenuLoadGameFromZip(gameFile);
     }

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -439,6 +439,39 @@ static bool MenuInitCore(const char* corePath) {
     return true;
 }
 
+#ifdef RAYLIB_ZIP_H
+static bool MenuLoadGameFromZip(const char* gamePath) {
+    if (LibretroCore.needFullpath) {
+        TraceLog(LOG_ERROR, "LIBRETRO: Core requires full path, cannot load from zip");
+        return false;
+    }
+    Zip archive = LoadZip(gamePath);
+    if (!IsZipValid(archive)) {
+        UnloadZip(archive);
+        return false;
+    }
+    FilePathList files = LoadDirectoryFilesFromZip(archive, NULL);
+    if (files.count == 0) {
+        UnloadDirectoryFiles(files);
+        UnloadZip(archive);
+        return false;
+    }
+    int dataSize = 0;
+    unsigned char* gameData = LoadFileDataFromZip(archive, files.paths[0], &dataSize);
+    UnloadDirectoryFiles(files);
+    UnloadZip(archive);
+    if (!gameData || dataSize == 0) {
+        return false;
+    }
+    bool result = LoadLibretroGameFromMemory(gameData, dataSize);
+    MemFree(gameData);
+    if (result) {
+        TextCopy(LibretroCore.contentPath, gamePath);
+    }
+    return result;
+}
+#endif
+
 static bool MenuLoadGame(const char* gamePath) {
     // Unload the current game if it's a thing.
     if (IsLibretroGameReady()) {
@@ -461,33 +494,13 @@ static bool MenuLoadGame(const char* gamePath) {
     // Load the game
 #ifdef RAYLIB_ZIP_H
     if (IsFileExtension(gamePath, ".zip")) {
-        Zip archive = LoadZip(gamePath);
-        if (IsZipValid(archive)) {
-            FilePathList files = LoadDirectoryFilesFromZip(archive, NULL);
-            if (files.count > 0) {
-                int dataSize = 0;
-                unsigned char* gameData = LoadFileDataFromZip(archive, files.paths[0], &dataSize);
-                UnloadDirectoryFiles(files);
-                UnloadZip(archive);
-                if (gameData && dataSize > 0) {
-                    bool result = LoadLibretroGameFromMemory(gameData, dataSize);
-                    MemFree(gameData);
-                    if (result) {
-                        TextCopy(LibretroCore.contentPath, gamePath);
-                        BuildLibretroMenuOptions(&menu);
-                        menu.active = false;
-                        return true;
-                    }
-                }
-            } else {
-                UnloadDirectoryFiles(files);
-                UnloadZip(archive);
-            }
-        } else {
-            UnloadZip(archive);
+        if (!MenuLoadGameFromZip(gamePath)) {
+            ShowLibretroMessage("Failed to load game from zip", 2.0f);
+            return false;
         }
-        ShowLibretroMessage("Failed to load game from zip", 2.0f);
-        return false;
+        BuildLibretroMenuOptions(&menu);
+        menu.active = false;
+        return true;
     }
 #endif
     if (!LoadLibretroGame(gamePath)) {

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -383,12 +383,14 @@ static void ScanLibretroCoreDirectory(void) {
         if (!InitLibretroEx(files.paths[i], true)) continue;
         if (TextLength(LibretroCore.validExtensions) == 0) continue;
 
-        char keyPath[64], keyExts[64];
-        TextCopy(keyPath, TextFormat("core_%d_path", coreIndex));
-        TextCopy(keyExts, TextFormat("core_%d_extensions", coreIndex));
-        rlconfig_set(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, keyPath, files.paths[i]);
-        rlconfig_set(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, keyExts, LibretroCore.validExtensions);
-        TraceLog(LOG_INFO, "LIBRETRO: Cached %s (%s)", LibretroCore.libraryName, LibretroCore.validExtensions);
+        rlconfig_set(menu.cfg, LIBRETRO_CORE_CACHE_SECTION,
+            TextFormat("core_%d_path", coreIndex), files.paths[i]);
+        rlconfig_set(menu.cfg, LIBRETRO_CORE_CACHE_SECTION,
+            TextFormat("core_%d_extensions", coreIndex), LibretroCore.validExtensions);
+        rlconfig_set_int(menu.cfg, LIBRETRO_CORE_CACHE_SECTION,
+            TextFormat("core_%d_need_fullpath", coreIndex), LibretroCore.needFullpath ? 1 : 0);
+        TraceLog(LOG_INFO, "LIBRETRO: Cached %s (%s) needFullpath=%d",
+            LibretroCore.libraryName, LibretroCore.validExtensions, (int)LibretroCore.needFullpath);
         coreIndex++;
     }
     UnloadDirectoryFiles(files);
@@ -399,36 +401,93 @@ static void ScanLibretroCoreDirectory(void) {
 #endif
 }
 
+// Writes the lowercased file extension (without the leading dot) into `out`.
+// Buffer must be at least 32 bytes. Empty string if no extension.
+static void LibretroFileExtensionLower(const char* path, char* out) {
+    out[0] = '\0';
+    const char* ext = GetFileExtension(path);
+    if (!ext || !ext[0]) return;
+    if (ext[0] == '.') ext++;
+    TextCopy(out, TextToLower(ext));
+}
+
+// True if `extLower` (no dot, lowercase) appears in libretro's pipe-separated extension list.
+static bool LibretroExtensionInList(const char* extLower, const char* list) {
+    if (!extLower || !extLower[0] || !list || !list[0]) return false;
+    int n = 0;
+    char** parts = TextSplit(list, '|', &n);
+    for (int i = 0; i < n; i++) {
+        if (TextIsEqual(parts[i], extLower)) return true;
+    }
+    return false;
+}
+
+#ifdef RAYLIB_ZIP_H_
+// Returns the index of the first entry whose extension matches `extensions`, or -1.
+static int LibretroFindZipEntryMatchingExtensions(FilePathList files, const char* extensions) {
+    for (unsigned int i = 0; i < files.count; i++) {
+        char ext[32];
+        LibretroFileExtensionLower(files.paths[i], ext);
+        if (LibretroExtensionInList(ext, extensions)) return (int)i;
+    }
+    return -1;
+}
+#endif
+
 static const char* FindCoreForGame(const char* gamePath) {
 #ifdef RAYLIB_LIBRETRO_CONFIG_H
     if (!menu.cfg || !gamePath || !gamePath[0]) return NULL;
 
-    const char* gameExt = GetFileExtension(gamePath);
-    if (!gameExt || !gameExt[0]) return NULL;
-    if (gameExt[0] == '.') gameExt++;
+    char gameExt[32];
+    LibretroFileExtensionLower(gamePath, gameExt);
+    if (!gameExt[0]) return NULL;
 
-    char gameExtLower[32] = {0};
-    TextCopy(gameExtLower, TextToLower(gameExt));
-
-    int count = rlconfig_get_int(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, "count", 0);
-    for (int i = 0; i < count; i++) {
-        char keyExts[64], keyPath[64];
-        TextCopy(keyExts, TextFormat("core_%d_extensions", i));
-        TextCopy(keyPath, TextFormat("core_%d_path", i));
-
-        const char* extensions = rlconfig_get(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, keyExts);
-        if (!extensions) continue;
-
-        int extCount = 0;
-        char** extList = TextSplit(extensions, '|', &extCount);
-        for (int j = 0; j < extCount; j++) {
-            if (TextIsEqual(extList[j], gameExtLower)) {
-                return rlconfig_get(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, keyPath);
-            }
+#ifdef RAYLIB_ZIP_H_
+    // For zip archives, match cores against the contained file's extension instead of ".zip".
+    const bool isZip = TextIsEqual(gameExt, "zip");
+    Zip archive = {0};
+    FilePathList zipFiles = {0};
+    if (isZip) {
+        archive = LoadZip(gamePath);
+        if (IsZipValid(archive)) {
+            zipFiles = LoadDirectoryFilesFromZip(archive, NULL);
         }
     }
 #endif
+
+    const char* result = NULL;
+    int count = rlconfig_get_int(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, "count", 0);
+    for (int i = 0; i < count && !result; i++) {
+        const char* extensions = rlconfig_get(menu.cfg, LIBRETRO_CORE_CACHE_SECTION,
+            TextFormat("core_%d_extensions", i));
+        if (!extensions) continue;
+
+        bool match;
+#ifdef RAYLIB_ZIP_H_
+        if (isZip) {
+            match = LibretroFindZipEntryMatchingExtensions(zipFiles, extensions) >= 0;
+        } else
+#endif
+        {
+            match = LibretroExtensionInList(gameExt, extensions);
+        }
+
+        if (match) {
+            result = rlconfig_get(menu.cfg, LIBRETRO_CORE_CACHE_SECTION,
+                TextFormat("core_%d_path", i));
+        }
+    }
+
+#ifdef RAYLIB_ZIP_H_
+    if (isZip) {
+        UnloadDirectoryFiles(zipFiles);
+        UnloadZip(archive);
+    }
+#endif
+    return result;
+#else
     return NULL;
+#endif
 }
 
 static bool MenuInitCore(const char* corePath) {
@@ -439,12 +498,30 @@ static bool MenuInitCore(const char* corePath) {
     return true;
 }
 
-#ifdef RAYLIB_ZIP_H
-static bool MenuLoadGameFromZip(const char* gamePath) {
-    if (LibretroCore.needFullpath) {
-        TraceLog(LOG_ERROR, "LIBRETRO: Core requires full path, cannot load from zip");
-        return false;
+#ifdef RAYLIB_ZIP_H_
+// Path of the most recently extracted zip entry. Tracked so it can be deleted
+// when the next game loads or the menu shuts down.
+static char menuExtractedZipPath[1024] = {0};
+
+static const char* LibretroSystemTempDir(void) {
+#if defined(_WIN32)
+    const char* t = getenv("TEMP");
+    if (!t || !t[0]) t = getenv("TMP");
+    return (t && t[0]) ? t : ".";
+#else
+    const char* t = getenv("TMPDIR");
+    return (t && t[0]) ? t : "/tmp";
+#endif
+}
+
+static void MenuDeleteExtractedZipFile(void) {
+    if (menuExtractedZipPath[0] && FileExists(menuExtractedZipPath)) {
+        remove(menuExtractedZipPath);
     }
+    menuExtractedZipPath[0] = '\0';
+}
+
+static bool MenuLoadGameFromZip(const char* gamePath) {
     Zip archive = LoadZip(gamePath);
     if (!IsZipValid(archive)) {
         UnloadZip(archive);
@@ -456,16 +533,37 @@ static bool MenuLoadGameFromZip(const char* gamePath) {
         UnloadZip(archive);
         return false;
     }
+    int index = LibretroFindZipEntryMatchingExtensions(files, LibretroCore.validExtensions);
+    if (index < 0) index = 0;
     int dataSize = 0;
-    unsigned char* gameData = LoadFileDataFromZip(archive, files.paths[0], &dataSize);
+    unsigned char* gameData = LoadFileDataFromZip(archive, files.paths[index], &dataSize);
+
+    bool result = false;
+    if (gameData && dataSize > 0) {
+        if (LibretroCore.needFullpath) {
+            // Core needs a path on disk: extract the entry to a temp file and load that.
+            MenuDeleteExtractedZipFile();
+            char tempDir[1024];
+            TextCopy(tempDir, TextFormat("%s/raylib-libretro", LibretroSystemTempDir()));
+            if (!DirectoryExists(tempDir)) MakeDirectory(tempDir);
+            TextCopy(menuExtractedZipPath,
+                TextFormat("%s/%s", tempDir, GetFileName(files.paths[index])));
+            if (SaveFileData(menuExtractedZipPath, gameData, dataSize)) {
+                result = LoadLibretroGame(menuExtractedZipPath);
+            }
+            if (!result) {
+                MenuDeleteExtractedZipFile();
+            }
+        } else {
+            result = LoadLibretroGameFromMemory(gameData, dataSize);
+        }
+    }
+    if (gameData) MemFree(gameData);
     UnloadDirectoryFiles(files);
     UnloadZip(archive);
-    if (!gameData || dataSize == 0) {
-        return false;
-    }
-    bool result = LoadLibretroGameFromMemory(gameData, dataSize);
-    MemFree(gameData);
+
     if (result) {
+        // Report the user-visible zip path as the content path, not the temp file.
         TextCopy(LibretroCore.contentPath, gamePath);
     }
     return result;
@@ -492,7 +590,7 @@ static bool MenuLoadGame(const char* gamePath) {
     }
 
     // Load the game
-#ifdef RAYLIB_ZIP_H
+#ifdef RAYLIB_ZIP_H_
     if (IsFileExtension(gamePath, ".zip")) {
         if (!MenuLoadGameFromZip(gamePath)) {
             ShowLibretroMessage("Failed to load game from zip", 2.0f);
@@ -1108,6 +1206,10 @@ void CloseLibretroMenu(void) {
 #ifdef RAYLIB_LIBRETRO_CONFIG_H
     rlconfig_free(menu.cfg);
     menu.cfg = NULL;
+#endif
+
+#ifdef RAYLIB_ZIP_H_
+    MenuDeleteExtractedZipFile();
 #endif
 }
 

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -1967,6 +1967,39 @@ static bool LoadLibretroGame(const char* gameFile) {
         return false;
     }
 
+#ifdef RAYLIB_ZIP_H_
+    // Load from .zip: extract the first file and load it.
+    if (IsFileExtension(gameFile, ".zip")) {
+        Zip archive = LoadZip(gameFile);
+        if (!IsZipValid(archive)) {
+            TraceLog(LOG_ERROR, "LIBRETRO: Failed to open zip: %s", gameFile);
+            UnloadZip(archive);
+            LibretroCore.loaded = false;
+            return false;
+        }
+        FilePathList files = LoadDirectoryFilesFromZip(archive, NULL);
+        if (files.count == 0) {
+            TraceLog(LOG_ERROR, "LIBRETRO: No files found in zip: %s", gameFile);
+            UnloadDirectoryFiles(files);
+            UnloadZip(archive);
+            LibretroCore.loaded = false;
+            return false;
+        }
+        int dataSize = 0;
+        unsigned char* gameData = LoadFileDataFromZip(archive, files.paths[0], &dataSize);
+        UnloadDirectoryFiles(files);
+        UnloadZip(archive);
+        if (gameData == NULL || dataSize == 0) {
+            TraceLog(LOG_ERROR, "LIBRETRO: Failed to extract content from zip: %s", gameFile);
+            LibretroCore.loaded = false;
+            return false;
+        }
+        bool output = LoadLibretroGameFromMemory(gameData, dataSize);
+        MemFree(gameData);
+        return output;
+    }
+#endif
+
     // See if we just need the full path.
     if (LibretroCore.needFullpath) {
         struct retro_game_info info;

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -2183,7 +2183,7 @@ static bool InitLibretroEx(const char* core, bool peek) {
 
     // Retrieve the libretro core system information.
     LoadLibretroMethod(retro_get_system_info);
-    struct retro_system_info systemInfo;
+    struct retro_system_info systemInfo = {0};
     LibretroCore.retro_get_system_info(&systemInfo);
     TextCopy(LibretroCore.libraryName, systemInfo.library_name);
     TextCopy(LibretroCore.libraryVersion, systemInfo.library_version);

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -1967,39 +1967,6 @@ static bool LoadLibretroGame(const char* gameFile) {
         return false;
     }
 
-#ifdef RAYLIB_ZIP_H_
-    // Load from .zip: extract the first file and load it.
-    if (IsFileExtension(gameFile, ".zip")) {
-        Zip archive = LoadZip(gameFile);
-        if (!IsZipValid(archive)) {
-            TraceLog(LOG_ERROR, "LIBRETRO: Failed to open zip: %s", gameFile);
-            UnloadZip(archive);
-            LibretroCore.loaded = false;
-            return false;
-        }
-        FilePathList files = LoadDirectoryFilesFromZip(archive, NULL);
-        if (files.count == 0) {
-            TraceLog(LOG_ERROR, "LIBRETRO: No files found in zip: %s", gameFile);
-            UnloadDirectoryFiles(files);
-            UnloadZip(archive);
-            LibretroCore.loaded = false;
-            return false;
-        }
-        int dataSize = 0;
-        unsigned char* gameData = LoadFileDataFromZip(archive, files.paths[0], &dataSize);
-        UnloadDirectoryFiles(files);
-        UnloadZip(archive);
-        if (gameData == NULL || dataSize == 0) {
-            TraceLog(LOG_ERROR, "LIBRETRO: Failed to extract content from zip: %s", gameFile);
-            LibretroCore.loaded = false;
-            return false;
-        }
-        bool output = LoadLibretroGameFromMemory(gameData, dataSize);
-        MemFree(gameData);
-        return output;
-    }
-#endif
-
     // See if we just need the full path.
     if (LibretroCore.needFullpath) {
         struct retro_game_info info;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -17,10 +17,13 @@ add_library(raylib-libretro-static STATIC
 target_link_libraries(raylib-libretro-static PUBLIC
     raylib
     raylib-libretro-h
+    raylib_zip
+    zip
     ${CMAKE_DL_LIBS}
 )
 target_include_directories(raylib-libretro-static PUBLIC
     ../vendor/libretro-common/include
+    ../vendor/raylib-zip
 )
 target_compile_definitions(raylib-libretro-static PUBLIC
     HAVE_DYNAMIC=1

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -18,7 +18,6 @@ target_link_libraries(raylib-libretro-static PUBLIC
     raylib
     raylib-libretro-h
     raylib_zip
-    zip
     ${CMAKE_DL_LIBS}
 )
 target_include_directories(raylib-libretro-static PUBLIC

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -17,12 +17,10 @@ add_library(raylib-libretro-static STATIC
 target_link_libraries(raylib-libretro-static PUBLIC
     raylib
     raylib-libretro-h
-    raylib_zip
     ${CMAKE_DL_LIBS}
 )
 target_include_directories(raylib-libretro-static PUBLIC
     ../vendor/libretro-common/include
-    ../vendor/raylib-zip
 )
 target_compile_definitions(raylib-libretro-static PUBLIC
     HAVE_DYNAMIC=1

--- a/lib/raylib-libretro-static.c
+++ b/lib/raylib-libretro-static.c
@@ -33,8 +33,5 @@
 *
 **********************************************************************************************/
 
-#define RAYLIB_ZIP_IMPLEMENTATION
-#include "raylib-zip.h"
-
 #define RAYLIB_LIBRETRO_IMPLEMENTATION
 #include "raylib-libretro.h"

--- a/lib/raylib-libretro-static.c
+++ b/lib/raylib-libretro-static.c
@@ -33,5 +33,8 @@
 *
 **********************************************************************************************/
 
+#define RAYLIB_ZIP_IMPLEMENTATION
+#include "raylib-zip.h"
+
 #define RAYLIB_LIBRETRO_IMPLEMENTATION
 #include "raylib-libretro.h"


### PR DESCRIPTION
Adds raylib-zip as a dependency and uses it in LoadLibretroGame() to detect .zip files, extract the first entry, and load it into the core via LoadLibretroGameFromMemory().

Fixes #9