### PR TITLE
Add release build workflow

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -22,15 +22,15 @@ jobs:
       - name: Package
         run: |
           cd install
-          zip -r ../raylib-libretro-linux-x86_64.zip .
+          zip -r ../raylib-libretro-linux-amd64.zip .
       - name: Upload
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: raylib-libretro-linux-x86_64.zip
-          asset_name: raylib-libretro-linux-x86_64.zip
+          asset_path: raylib-libretro-linux-amd64.zip
+          asset_name: raylib-libretro-linux-amd64.zip
           asset_content_type: application/zip
 
   build-windows:
@@ -46,15 +46,15 @@ jobs:
       - name: Install
         run: cmake --install build --config Release
       - name: Package
-        run: Compress-Archive -Path install\* -DestinationPath raylib-libretro-windows-x86_64.zip
+        run: Compress-Archive -Path install\* -DestinationPath raylib-libretro-windows-amd64.zip
       - name: Upload
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: raylib-libretro-windows-x86_64.zip
-          asset_name: raylib-libretro-windows-x86_64.zip
+          asset_path: raylib-libretro-windows-amd64.zip
+          asset_name: raylib-libretro-windows-amd64.zip
           asset_content_type: application/zip
 
   build-macos:
@@ -72,15 +72,15 @@ jobs:
       - name: Package
         run: |
           cd install
-          zip -r ../raylib-libretro-macos.zip .
+          zip -r ../raylib-libretro-macos-arm64.zip .
       - name: Upload
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: raylib-libretro-macos.zip
-          asset_name: raylib-libretro-macos.zip
+          asset_path: raylib-libretro-macos-arm64.zip
+          asset_name: raylib-libretro-macos-arm64.zip
           asset_content_type: application/zip
 
   build-android:
@@ -118,4 +118,32 @@ jobs:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: raylib-libretro-android-arm64.zip
           asset_name: raylib-libretro-android-arm64.zip
+          asset_content_type: application/zip
+
+  build-web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+      - name: Configure
+        run: emcmake cmake -B build -DPLATFORM=Web -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install
+      - name: Build
+        run: cmake --build build --parallel
+      - name: Install
+        run: cmake --install build
+      - name: Package
+        run: |
+          cd install
+          zip -r ../raylib-libretro-web-wasm32.zip .
+      - name: Upload
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: raylib-libretro-web-wasm32.zip
+          asset_name: raylib-libretro-web-wasm32.zip
           asset_content_type: application/zip

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -122,6 +122,10 @@ jobs:
 
   build-web:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -138,7 +142,7 @@ jobs:
         run: |
           cd install
           zip -r ../raylib-libretro-web-wasm32.zip .
-      - name: Upload
+      - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -147,3 +151,8 @@ jobs:
           asset_path: raylib-libretro-web-wasm32.zip
           asset_name: raylib-libretro-web-wasm32.zip
           asset_content_type: application/zip
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./install

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,0 +1,121 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install Dependencies
+        run: sudo apt-get update && sudo apt-get install -y xorg-dev libglu1-mesa-dev
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install
+      - name: Build
+        run: cmake --build build --parallel
+      - name: Install
+        run: cmake --install build
+      - name: Package
+        run: |
+          cd install
+          zip -r ../raylib-libretro-linux-x86_64.zip .
+      - name: Upload
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: raylib-libretro-linux-x86_64.zip
+          asset_name: raylib-libretro-linux-x86_64.zip
+          asset_content_type: application/zip
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install
+      - name: Build
+        run: cmake --build build --config Release --parallel
+      - name: Install
+        run: cmake --install build --config Release
+      - name: Package
+        run: Compress-Archive -Path install\* -DestinationPath raylib-libretro-windows-x86_64.zip
+      - name: Upload
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: raylib-libretro-windows-x86_64.zip
+          asset_name: raylib-libretro-windows-x86_64.zip
+          asset_content_type: application/zip
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install
+      - name: Build
+        run: cmake --build build --parallel
+      - name: Install
+        run: cmake --install build
+      - name: Package
+        run: |
+          cd install
+          zip -r ../raylib-libretro-macos.zip .
+      - name: Upload
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: raylib-libretro-macos.zip
+          asset_name: raylib-libretro-macos.zip
+          asset_content_type: application/zip
+
+  build-android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Setup Android NDK
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r26d
+      - name: Configure
+        run: |
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake \
+            -DANDROID_ABI=arm64-v8a \
+            -DANDROID_PLATFORM=android-24 \
+            -DPLATFORM=Android \
+            -DCMAKE_INSTALL_PREFIX=install
+      - name: Build
+        run: cmake --build build --parallel
+      - name: Install
+        run: cmake --install build
+      - name: Package
+        run: |
+          cd install
+          zip -r ../raylib-libretro-android-arm64.zip .
+      - name: Upload
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: raylib-libretro-android-arm64.zip
+          asset_name: raylib-libretro-android-arm64.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
Adds a GitHub Actions release workflow that builds for Linux, Windows, macOS, and Android, uploading binaries as assets when a release is published. Fixes #54