### PR TITLE
Auto-detect core from game extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 .vscode
+cores

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,4 +121,9 @@ elseif (APPLE)
             "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/snes9x_libretro.dylib.zip"
         )
     endif()
+elseif (CMAKE_SYSTEM_NAME STREQUAL "Android")
+    download_cores(
+        "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/fceumm_libretro_android.so.zip"
+        "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/snes9x_libretro_android.so.zip"
+    )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ add_subdirectory(lib)
 
 # Directory where cores are extracted
 if (NOT DEFINED CORES_DIR)
-    set(CORES_DIR "${CMAKE_SOURCE_DIR}/cores")
+    set(CORES_DIR "${CMAKE_BINARY_DIR}/cores")
 endif()
 
 # download_cores(<url> [<url> ...])

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,11 +83,42 @@ if ("${PLATFORM}" STREQUAL "Web")
     set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".html")
     download_cores(
         "https://cdn.jsdelivr.net/gh/arianrhodsandlot/retroarch-emscripten-build@v1.22.2/retroarch/fceumm_libretro.zip"
+        "https://cdn.jsdelivr.net/gh/arianrhodsandlot/retroarch-emscripten-build@v1.22.2/retroarch/snes9x_libretro.zip"
     )
     target_link_options(${PROJECT_NAME} PUBLIC
         -sUSE_GLFW=3
         -sMAIN_MODULE=1
         --preload-file "${CMAKE_SOURCE_DIR}/cores@/cores"
     )
-
+elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    if (CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+        download_cores(
+            "https://buildbot.libretro.com/nightly/linux/aarch64/latest/fceumm_libretro.so.zip"
+            "https://buildbot.libretro.com/nightly/linux/aarch64/latest/snes9x_libretro.so.zip"
+        )
+    elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+        download_cores(
+            "https://buildbot.libretro.com/nightly/linux/x86_64/latest/fceumm_libretro.so.zip"
+            "https://buildbot.libretro.com/nightly/linux/x86_64/latest/snes9x_libretro.so.zip"
+        )
+    endif()
+elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    if (CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+        download_cores(
+            "https://buildbot.libretro.com/nightly/windows/x86_64/latest/fceumm_libretro.dll.zip"
+            "https://buildbot.libretro.com/nightly/windows/x86_64/latest/snes9x_libretro.dll.zip"
+        )
+    endif()
+elseif (APPLE)
+    if (CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+        download_cores(
+            "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/fceumm_libretro.dylib.zip"
+            "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/snes9x_libretro.dylib.zip"
+        )
+    else()
+        download_cores(
+            "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/fceumm_libretro.dylib.zip"
+            "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/snes9x_libretro.dylib.zip"
+        )
+    endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,46 +18,6 @@ endif()
 add_subdirectory(include)
 add_subdirectory(lib)
 
-# Directory where cores are extracted
-if (NOT DEFINED CORES_DIR)
-    set(CORES_DIR "${CMAKE_BINARY_DIR}/cores")
-endif()
-
-# download_cores(<url> [<url> ...])
-# Downloads each zip URL to the build directory and extracts it into CORES_DIR.
-# Already-downloaded archives are skipped on subsequent runs.
-function(download_cores)
-    file(MAKE_DIRECTORY "${CORES_DIR}")
-    foreach(URL IN LISTS ARGN)
-        get_filename_component(ARCHIVE_NAME "${URL}" NAME)
-        set(ARCHIVE_PATH "${CMAKE_BINARY_DIR}/${ARCHIVE_NAME}")
-
-        if (NOT EXISTS "${ARCHIVE_PATH}")
-            message(STATUS "Downloading ${URL}")
-            file(DOWNLOAD "${URL}" "${ARCHIVE_PATH}"
-                STATUS DOWNLOAD_STATUS
-                SHOW_PROGRESS
-            )
-            list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
-            list(GET DOWNLOAD_STATUS 1 STATUS_MSG)
-            if (NOT STATUS_CODE EQUAL 0)
-                message(WARNING "Failed to download ${URL}: ${STATUS_MSG}")
-                continue()
-            endif()
-        endif()
-
-        message(STATUS "Extracting ${ARCHIVE_NAME} to ${CORES_DIR}")
-        execute_process(
-            COMMAND ${CMAKE_COMMAND} -E tar xf "${ARCHIVE_PATH}"
-            WORKING_DIRECTORY "${CORES_DIR}"
-            RESULT_VARIABLE EXTRACT_RESULT
-        )
-        if (NOT EXTRACT_RESULT EQUAL 0)
-            message(WARNING "Failed to extract ${ARCHIVE_NAME}")
-        endif()
-    endforeach()
-endfunction()
-
 # Example
 option(BUILD_RAYLIB_LIBRETRO_EXAMPLE "Build Examples" ON)
 if (BUILD_RAYLIB_LIBRETRO_EXAMPLE)
@@ -75,55 +35,4 @@ if (APPLE)
     target_link_libraries(${PROJECT_NAME} "-framework IOKit")
     target_link_libraries(${PROJECT_NAME} "-framework Cocoa")
     target_link_libraries(${PROJECT_NAME} "-framework OpenGL")
-endif()
-
-# Web
-if ("${PLATFORM}" STREQUAL "Web")
-    set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "index")
-    set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".html")
-    download_cores(
-        "https://cdn.jsdelivr.net/gh/arianrhodsandlot/retroarch-emscripten-build@v1.22.2/retroarch/fceumm_libretro.zip"
-        "https://cdn.jsdelivr.net/gh/arianrhodsandlot/retroarch-emscripten-build@v1.22.2/retroarch/snes9x_libretro.zip"
-    )
-    target_link_options(${PROJECT_NAME} PUBLIC
-        -sUSE_GLFW=3
-        -sMAIN_MODULE=1
-        --preload-file "${CORES_DIR}@/cores"
-    )
-elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    if (CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
-        download_cores(
-            "https://buildbot.libretro.com/nightly/linux/aarch64/latest/fceumm_libretro.so.zip"
-            "https://buildbot.libretro.com/nightly/linux/aarch64/latest/snes9x_libretro.so.zip"
-        )
-    elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-        download_cores(
-            "https://buildbot.libretro.com/nightly/linux/x86_64/latest/fceumm_libretro.so.zip"
-            "https://buildbot.libretro.com/nightly/linux/x86_64/latest/snes9x_libretro.so.zip"
-        )
-    endif()
-elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    if (CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-        download_cores(
-            "https://buildbot.libretro.com/nightly/windows/x86_64/latest/fceumm_libretro.dll.zip"
-            "https://buildbot.libretro.com/nightly/windows/x86_64/latest/snes9x_libretro.dll.zip"
-        )
-    endif()
-elseif (APPLE)
-    if (CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-        download_cores(
-            "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/fceumm_libretro.dylib.zip"
-            "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/snes9x_libretro.dylib.zip"
-        )
-    else()
-        download_cores(
-            "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/fceumm_libretro.dylib.zip"
-            "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/snes9x_libretro.dylib.zip"
-        )
-    endif()
-elseif (CMAKE_SYSTEM_NAME STREQUAL "Android")
-    download_cores(
-        "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/fceumm_libretro_android.so.zip"
-        "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/snes9x_libretro_android.so.zip"
-    )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ if ("${PLATFORM}" STREQUAL "Web")
     target_link_options(${PROJECT_NAME} PUBLIC
         -sUSE_GLFW=3
         -sMAIN_MODULE=1
-        --preload-file "${CMAKE_SOURCE_DIR}/cores@/cores"
+        --preload-file "${CORES_DIR}@/cores"
     )
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     if (CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,16 +18,16 @@ endif()
 add_subdirectory(include)
 add_subdirectory(lib)
 
-# Directory where downloaded resources are extracted
-if (NOT DEFINED RESOURCES_DIR)
-    set(RESOURCES_DIR "${CMAKE_BINARY_DIR}/resources")
+# Directory where cores are extracted
+if (NOT DEFINED CORES_DIR)
+    set(CORES_DIR "${CMAKE_SOURCE_DIR}/cores")
 endif()
 
-# download_resources(<url> [<url> ...])
-# Downloads each zip URL to the build directory and extracts it into RESOURCES_DIR.
+# download_cores(<url> [<url> ...])
+# Downloads each zip URL to the build directory and extracts it into CORES_DIR.
 # Already-downloaded archives are skipped on subsequent runs.
-function(download_resources)
-    file(MAKE_DIRECTORY "${RESOURCES_DIR}")
+function(download_cores)
+    file(MAKE_DIRECTORY "${CORES_DIR}")
     foreach(URL IN LISTS ARGN)
         get_filename_component(ARCHIVE_NAME "${URL}" NAME)
         set(ARCHIVE_PATH "${CMAKE_BINARY_DIR}/${ARCHIVE_NAME}")
@@ -46,10 +46,10 @@ function(download_resources)
             endif()
         endif()
 
-        message(STATUS "Extracting ${ARCHIVE_NAME} to ${RESOURCES_DIR}")
+        message(STATUS "Extracting ${ARCHIVE_NAME} to ${CORES_DIR}")
         execute_process(
             COMMAND ${CMAKE_COMMAND} -E tar xf "${ARCHIVE_PATH}"
-            WORKING_DIRECTORY "${RESOURCES_DIR}"
+            WORKING_DIRECTORY "${CORES_DIR}"
             RESULT_VARIABLE EXTRACT_RESULT
         )
         if (NOT EXTRACT_RESULT EQUAL 0)
@@ -81,8 +81,7 @@ endif()
 if ("${PLATFORM}" STREQUAL "Web")
     set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "index")
     set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".html")
-    set(RESOURCES_DIR "${CMAKE_SOURCE_DIR}/cores")
-    download_resources(
+    download_cores(
         "https://cdn.jsdelivr.net/gh/arianrhodsandlot/retroarch-emscripten-build@v1.22.2/retroarch/fceumm_libretro.zip"
     )
     target_link_options(${PROJECT_NAME} PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,10 @@ endif()
 if ("${PLATFORM}" STREQUAL "Web")
     set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "index")
     set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".html")
-    file(MAKE_DIRECTORY "${CMAKE_SOURCE_DIR}/cores")
+    set(RESOURCES_DIR "${CMAKE_SOURCE_DIR}/cores")
+    download_resources(
+        "https://cdn.jsdelivr.net/gh/arianrhodsandlot/retroarch-emscripten-build@v1.22.2/retroarch/fceumm_libretro.zip"
+    )
     target_link_options(${PROJECT_NAME} PUBLIC
         -sUSE_GLFW=3
         -sMAIN_MODULE=1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,12 +81,11 @@ endif()
 if ("${PLATFORM}" STREQUAL "Web")
     set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "index")
     set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".html")
+    file(MAKE_DIRECTORY "${CMAKE_SOURCE_DIR}/cores")
     target_link_options(${PROJECT_NAME} PUBLIC
         -sUSE_GLFW=3
         -sMAIN_MODULE=1
-        --preload-file "${CMAKE_BINARY_DIR}/resources@/resources"
+        --preload-file "${CMAKE_SOURCE_DIR}/cores@/cores"
     )
-
-    download_resources("https://cdn.jsdelivr.net/gh/arianrhodsandlot/retroarch-emscripten-build@v1.22.2/retroarch/fceumm_libretro.zip")
 
 endif()

--- a/TASKS.md
+++ b/TASKS.md
@@ -2,14 +2,9 @@
 
 ## GUI
 
-- [x] Add nuklear_console with dependencies nuklear_gamepad, c-vector, nuklear
-- [x] Load Game button to load a file. Then select a Core for it if it doesn't detect.
-- [x] Core Options
 - [ ] Rebindable Inputs
 - [ ] History
 - [ ] Game library / ROM browser with box art thumbnails (RetroArch thumbnail packs)
-- [ ] Per-game core association (remember which core goes with which ROM)
-- [ ] Per-game settings overrides (core options, shaders, controls)
 - [ ] On-screen display (OSD) for notifications (state saved, shader changed, etc.) using nk_console_show_message()
 
 ## Tasks
@@ -26,8 +21,6 @@
 
 - [ ] Save state slots (multiple named saves per game)
 - [ ] SRAM / battery save auto-save on exit
-- [x] Rewind support (`retro_serialize` API)
-- [x] Fast-forward / slow-motion toggle
 - [ ] Turbo button support
 - [ ] Cheats support (libretro cheat interface)
 - [ ] RetroAchievements integration (rcheevos)
@@ -44,6 +37,4 @@
 ## Input
 
 - [ ] Gamepad auto-detection and mapping
-- [x] Analog stick support for cores that use it
 - [ ] Multi-player / multi-gamepad assignment
-- [x] Command-line ROM drag-and-drop onto window

--- a/TASKS.md
+++ b/TASKS.md
@@ -3,7 +3,7 @@
 ## GUI
 
 - [x] Add nuklear_console with dependencies nuklear_gamepad, c-vector, nuklear
-- [ ] Load Game button to load a file. Then select a Core for it if it doesn't detect.
+- [x] Load Game button to load a file. Then select a Core for it if it doesn't detect.
 - [x] Core Options
 - [ ] Rebindable Inputs
 - [ ] History
@@ -46,4 +46,4 @@
 - [ ] Gamepad auto-detection and mapping
 - [x] Analog stick support for cores that use it
 - [ ] Multi-player / multi-gamepad assignment
-- [ ] Command-line ROM drag-and-drop onto window
+- [x] Command-line ROM drag-and-drop onto window

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -10,6 +10,96 @@ target_include_directories(raylib-libretro PUBLIC
     ../vendor/raylib-app
 )
 
+# Directory where cores are extracted
+if (NOT DEFINED CORES_DIR)
+    set(CORES_DIR "${CMAKE_BINARY_DIR}/cores")
+endif()
+
+# download_cores(<url> [<url> ...])
+# Downloads each zip URL to the build directory and extracts it into CORES_DIR.
+# Already-downloaded archives are skipped on subsequent runs.
+function(download_cores)
+    file(MAKE_DIRECTORY "${CORES_DIR}")
+    foreach(URL IN LISTS ARGN)
+        get_filename_component(ARCHIVE_NAME "${URL}" NAME)
+        set(ARCHIVE_PATH "${CMAKE_BINARY_DIR}/${ARCHIVE_NAME}")
+
+        if (NOT EXISTS "${ARCHIVE_PATH}")
+            message(STATUS "Downloading ${URL}")
+            file(DOWNLOAD "${URL}" "${ARCHIVE_PATH}"
+                STATUS DOWNLOAD_STATUS
+                SHOW_PROGRESS
+            )
+            list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
+            list(GET DOWNLOAD_STATUS 1 STATUS_MSG)
+            if (NOT STATUS_CODE EQUAL 0)
+                message(WARNING "Failed to download ${URL}: ${STATUS_MSG}")
+                continue()
+            endif()
+        endif()
+
+        message(STATUS "Extracting ${ARCHIVE_NAME} to ${CORES_DIR}")
+        execute_process(
+            COMMAND ${CMAKE_COMMAND} -E tar xf "${ARCHIVE_PATH}"
+            WORKING_DIRECTORY "${CORES_DIR}"
+            RESULT_VARIABLE EXTRACT_RESULT
+        )
+        if (NOT EXTRACT_RESULT EQUAL 0)
+            message(WARNING "Failed to extract ${ARCHIVE_NAME}")
+        endif()
+    endforeach()
+endfunction()
+
+if ("${PLATFORM}" STREQUAL "Web")
+    set_target_properties(raylib-libretro PROPERTIES OUTPUT_NAME "index")
+    set_target_properties(raylib-libretro PROPERTIES SUFFIX ".html")
+    download_cores(
+        "https://cdn.jsdelivr.net/gh/arianrhodsandlot/retroarch-emscripten-build@v1.22.2/retroarch/fceumm_libretro.zip"
+        "https://cdn.jsdelivr.net/gh/arianrhodsandlot/retroarch-emscripten-build@v1.22.2/retroarch/snes9x_libretro.zip"
+    )
+    target_link_options(raylib-libretro PUBLIC
+        -sUSE_GLFW=3
+        -sMAIN_MODULE=1
+        --preload-file "${CORES_DIR}@/cores"
+    )
+elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    if (CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+        download_cores(
+            "https://buildbot.libretro.com/nightly/linux/aarch64/latest/fceumm_libretro.so.zip"
+            "https://buildbot.libretro.com/nightly/linux/aarch64/latest/snes9x_libretro.so.zip"
+        )
+    elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+        download_cores(
+            "https://buildbot.libretro.com/nightly/linux/x86_64/latest/fceumm_libretro.so.zip"
+            "https://buildbot.libretro.com/nightly/linux/x86_64/latest/snes9x_libretro.so.zip"
+        )
+    endif()
+elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    if (CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+        download_cores(
+            "https://buildbot.libretro.com/nightly/windows/x86_64/latest/fceumm_libretro.dll.zip"
+            "https://buildbot.libretro.com/nightly/windows/x86_64/latest/snes9x_libretro.dll.zip"
+        )
+    endif()
+elseif (APPLE)
+    if (CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+        download_cores(
+            "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/fceumm_libretro.dylib.zip"
+            "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/snes9x_libretro.dylib.zip"
+        )
+    else()
+        download_cores(
+            "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/fceumm_libretro.dylib.zip"
+            "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/snes9x_libretro.dylib.zip"
+        )
+    endif()
+elseif (CMAKE_SYSTEM_NAME STREQUAL "Android")
+    download_cores(
+        "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/fceumm_libretro_android.so.zip"
+        "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/snes9x_libretro_android.so.zip"
+    )
+endif()
+
 install(TARGETS raylib-libretro DESTINATION .)
 install(FILES ../README.md DESTINATION .)
 install(FILES ../LICENSE DESTINATION .)

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -13,6 +13,7 @@ target_include_directories(raylib-libretro PUBLIC
 install(TARGETS raylib-libretro DESTINATION .)
 install(FILES ../README.md DESTINATION .)
 install(FILES ../LICENSE DESTINATION .)
+install(DIRECTORY "${CORES_DIR}/" DESTINATION cores)
 
 # Web
 if ("${PLATFORM}" STREQUAL "Web")

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -217,6 +217,52 @@ bool UpdateDrawFrame(void* userData) {
 
     UpdateLibretroMenu();
 
+    // Handle drag-and-drop to load a game or core.
+    if (IsFileDropped()) {
+        FilePathList dropped = LoadDroppedFiles();
+        if (dropped.count > 0) {
+            const char* droppedPath = dropped.paths[0];
+            const char* ext = GetFileExtension(droppedPath);
+            bool isCore = TextIsEqual(ext, ".so") || TextIsEqual(ext, ".dll") || TextIsEqual(ext, ".dylib");
+
+            if (isCore) {
+                SaveLibretroAllSettings();
+                UnloadLibretroGame();
+                CloseLibretro();
+                if (InitLibretro(droppedPath)) {
+                    LoadLibretroCoreOptions();
+                    SetLibretroVolume(menu.volumeSelected);
+                    BuildLibretroMenuOptions(data->menu);
+                    data->menu->active = true;
+                }
+            } else {
+                bool coreReady = IsLibretroReady();
+                if (!coreReady) {
+                    const char* corePath = FindCoreForGame(droppedPath);
+                    if (corePath) {
+                        coreReady = InitLibretro(corePath);
+                        if (coreReady) {
+                            LoadLibretroCoreOptions();
+                            SetLibretroVolume(menu.volumeSelected);
+                        }
+                    }
+                } else if (IsLibretroGameReady()) {
+                    UnloadLibretroGame();
+                }
+
+                if (coreReady) {
+                    if (LoadLibretroGame(droppedPath)) {
+                        BuildLibretroMenuOptions(data->menu);
+                        data->menu->active = false;
+                    }
+                } else {
+                    ShowLibretroMessage("No core found for this file", 2.0f);
+                }
+            }
+        }
+        UnloadDroppedFiles(dropped);
+    }
+
     // Check if the core or menu asks to be shutdown.
     if (LibretroShouldClose()) {
         RewindBufferFree(&data->rewind);

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -227,7 +227,6 @@ bool UpdateDrawFrame(void* userData) {
             const char* droppedPath = dropped.paths[0];
             if (IsLibretroCoreFile(droppedPath)) {
                 SaveLibretroAllSettings();
-                UnloadLibretroGame();
                 CloseLibretro();
                 if (MenuInitCore(droppedPath)) {
                     BuildLibretroMenuOptions(data->menu);

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -106,17 +106,21 @@ static void AppLoadGame(AppData* data, const char* gamePath) {
     bool coreReady = IsLibretroReady();
     if (!coreReady) {
         const char* corePath = FindCoreForGame(gamePath);
-        if (corePath) coreReady = AppInitCore(data, corePath);
+        if (!corePath) {
+            ShowLibretroMessage("No core found for this file", 2.0f);
+            return;
+        }
+        coreReady = AppInitCore(data, corePath);
+        if (!coreReady) {
+            ShowLibretroMessage("Failed to load core", 2.0f);
+            return;
+        }
     } else if (IsLibretroGameReady()) {
         UnloadLibretroGame();
     }
-    if (coreReady) {
-        if (LoadLibretroGame(gamePath)) {
-            BuildLibretroMenuOptions(data->menu);
-            data->menu->active = false;
-        }
-    } else {
-        ShowLibretroMessage("No core found for this file", 2.0f);
+    if (LoadLibretroGame(gamePath)) {
+        BuildLibretroMenuOptions(data->menu);
+        data->menu->active = false;
     }
 }
 

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -280,16 +280,18 @@ bool UpdateDrawFrame(void* userData) {
     // Screenshot
     else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyScreenshot))) {
         const char* screenshotsDir = GetLibretroDirectory(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY);
-        const char* screenshotName = NULL;
+        bool taken = false;
         for (int i = 1; i < 1000; i++) {
-            screenshotName = TextFormat("%s/screenshot-%i.png", screenshotsDir, i);
+            const char* screenshotName = TextFormat("%s/screenshot-%i.png", screenshotsDir, i);
             if (!FileExists(screenshotName)) {
                 TakeScreenshot(screenshotName);
+                ShowLibretroMessage(TextFormat("Screenshot: %s", screenshotName), 2.0f);
+                taken = true;
                 break;
             }
         }
-        if (screenshotName) {
-            ShowLibretroMessage(TextFormat("Screenshot: %s", screenshotName), 2.0f);
+        if (!taken) {
+            ShowLibretroMessage("Screenshot slots full", 2.0f);
         }
     }
 

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -99,6 +99,16 @@ bool Init(void** userData, int argc, char** argv) {
     SetWindowMinSize(400, 300);
     SetExitKey(KEY_NULL);
 
+    BeginDrawing();
+        ClearBackground(BLACK);
+        const char* loadingText = "Loading";
+        int fontSize = 20;
+        DrawText(loadingText,
+            (GetScreenWidth()  - MeasureText(loadingText, fontSize)) / 2,
+            (GetScreenHeight() - fontSize) / 2,
+            fontSize, GRAY);
+    EndDrawing();
+
     AppData* data = (AppData*)MemAlloc(sizeof(AppData));
     memset(data, 0, sizeof(AppData));
     *userData = data;

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -95,35 +95,6 @@ typedef struct {
     float savedVolume;
 } AppData;
 
-static bool AppInitCore(AppData* data, const char* corePath) {
-    if (!InitLibretro(corePath)) return false;
-    LoadLibretroCoreOptions();
-    SetLibretroVolume(data->menu->volumeSelected);
-    return true;
-}
-
-static void AppLoadGame(AppData* data, const char* gamePath) {
-    bool coreReady = IsLibretroReady();
-    if (!coreReady) {
-        const char* corePath = FindCoreForGame(gamePath);
-        if (!corePath) {
-            ShowLibretroMessage("No core found for this file", 2.0f);
-            return;
-        }
-        coreReady = AppInitCore(data, corePath);
-        if (!coreReady) {
-            ShowLibretroMessage("Failed to load core", 2.0f);
-            return;
-        }
-    } else if (IsLibretroGameReady()) {
-        UnloadLibretroGame();
-    }
-    if (LoadLibretroGame(gamePath)) {
-        BuildLibretroMenuOptions(data->menu);
-        data->menu->active = false;
-    }
-}
-
 bool Init(void** userData, int argc, char** argv) {
     SetWindowMinSize(400, 300);
     SetExitKey(KEY_NULL);
@@ -149,12 +120,12 @@ bool Init(void** userData, int argc, char** argv) {
     const char* gameFile = (argc > 2) ? argv[2] : NULL;
 
     if (corePath) {
-        if (AppInitCore(data, corePath) && LoadLibretroGame(gameFile)) {
+        if (MenuInitCore(corePath) && LoadLibretroGame(gameFile)) {
             BuildLibretroMenuOptions(data->menu);
             data->menu->active = false;
         }
     } else if (gameFile) {
-        AppLoadGame(data, gameFile);
+        MenuLoadGame(gameFile);
     }
 
     return true;
@@ -240,12 +211,12 @@ bool UpdateDrawFrame(void* userData) {
                 SaveLibretroAllSettings();
                 UnloadLibretroGame();
                 CloseLibretro();
-                if (AppInitCore(data, droppedPath)) {
+                if (MenuInitCore(droppedPath)) {
                     BuildLibretroMenuOptions(data->menu);
                     data->menu->active = true;
                 }
             } else {
-                AppLoadGame(data, droppedPath);
+                MenuLoadGame(droppedPath);
             }
         }
         UnloadDroppedFiles(dropped);

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -118,11 +118,6 @@ bool Init(void** userData, int argc, char** argv) {
     // Parse the command line arguments.
     const char* corePath = (argc > 1) ? argv[1] : NULL;
     const char* gameFile = (argc > 2) ? argv[2] : NULL;
-#ifdef __EMSCRIPTEN__
-    if (!corePath) {
-        corePath = "/resources/fceumm_libretro.wasm";
-    }
-#endif
 
     // If only a game file is given, try to detect the core from the cache.
     if (gameFile && !corePath) {

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -95,6 +95,31 @@ typedef struct {
     float savedVolume;
 } AppData;
 
+static bool AppInitCore(AppData* data, const char* corePath) {
+    if (!InitLibretro(corePath)) return false;
+    LoadLibretroCoreOptions();
+    SetLibretroVolume(data->menu->volumeSelected);
+    return true;
+}
+
+static void AppLoadGame(AppData* data, const char* gamePath) {
+    bool coreReady = IsLibretroReady();
+    if (!coreReady) {
+        const char* corePath = FindCoreForGame(gamePath);
+        if (corePath) coreReady = AppInitCore(data, corePath);
+    } else if (IsLibretroGameReady()) {
+        UnloadLibretroGame();
+    }
+    if (coreReady) {
+        if (LoadLibretroGame(gamePath)) {
+            BuildLibretroMenuOptions(data->menu);
+            data->menu->active = false;
+        }
+    } else {
+        ShowLibretroMessage("No core found for this file", 2.0f);
+    }
+}
+
 bool Init(void** userData, int argc, char** argv) {
     SetWindowMinSize(400, 300);
     SetExitKey(KEY_NULL);
@@ -119,28 +144,13 @@ bool Init(void** userData, int argc, char** argv) {
     const char* corePath = (argc > 1) ? argv[1] : NULL;
     const char* gameFile = (argc > 2) ? argv[2] : NULL;
 
-    // If only a game file is given, try to detect the core from the cache.
-    if (gameFile && !corePath) {
-        corePath = FindCoreForGame(gameFile);
-        if (corePath) {
-            TraceLog(LOG_INFO, "LIBRETRO: Auto-detected core: %s", corePath);
-        } else {
-            TraceLog(LOG_WARNING, "LIBRETRO: No core found for game: %s", gameFile);
-        }
-    }
-
     if (corePath) {
-        // Initialize the given core.
-        if (InitLibretro(corePath)) {
-            // Apply any previously saved options before the game starts.
-            LoadLibretroCoreOptions();
-            SetLibretroVolume(data->menu->volumeSelected);
-
-            if (LoadLibretroGame(gameFile)) {
-                BuildLibretroMenuOptions(data->menu);
-                data->menu->active = false;
-            }
+        if (AppInitCore(data, corePath) && LoadLibretroGame(gameFile)) {
+            BuildLibretroMenuOptions(data->menu);
+            data->menu->active = false;
         }
+    } else if (gameFile) {
+        AppLoadGame(data, gameFile);
     }
 
     return true;
@@ -222,42 +232,16 @@ bool UpdateDrawFrame(void* userData) {
         FilePathList dropped = LoadDroppedFiles();
         if (dropped.count > 0) {
             const char* droppedPath = dropped.paths[0];
-            const char* ext = GetFileExtension(droppedPath);
-            bool isCore = TextIsEqual(ext, ".so") || TextIsEqual(ext, ".dll") || TextIsEqual(ext, ".dylib") || TextIsEqual(ext, ".wasm");
-
-            if (isCore) {
+            if (IsLibretroCoreFile(droppedPath)) {
                 SaveLibretroAllSettings();
                 UnloadLibretroGame();
                 CloseLibretro();
-                if (InitLibretro(droppedPath)) {
-                    LoadLibretroCoreOptions();
-                    SetLibretroVolume(menu.volumeSelected);
+                if (AppInitCore(data, droppedPath)) {
                     BuildLibretroMenuOptions(data->menu);
                     data->menu->active = true;
                 }
             } else {
-                bool coreReady = IsLibretroReady();
-                if (!coreReady) {
-                    const char* corePath = FindCoreForGame(droppedPath);
-                    if (corePath) {
-                        coreReady = InitLibretro(corePath);
-                        if (coreReady) {
-                            LoadLibretroCoreOptions();
-                            SetLibretroVolume(menu.volumeSelected);
-                        }
-                    }
-                } else if (IsLibretroGameReady()) {
-                    UnloadLibretroGame();
-                }
-
-                if (coreReady) {
-                    if (LoadLibretroGame(droppedPath)) {
-                        BuildLibretroMenuOptions(data->menu);
-                        data->menu->active = false;
-                    }
-                } else {
-                    ShowLibretroMessage("No core found for this file", 2.0f);
-                }
+                AppLoadGame(data, droppedPath);
             }
         }
         UnloadDroppedFiles(dropped);

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -126,8 +126,16 @@ bool Init(void** userData, int argc, char** argv) {
     }
 
     // Parse the command line arguments.
-    const char* corePath = (argc > 1) ? argv[1] : NULL;
-    const char* gameFile = (argc > 2) ? argv[2] : NULL;
+    // -L/--libretro <core> sets the core; the first non-flag argument is the game file.
+    const char* corePath = NULL;
+    const char* gameFile = NULL;
+    for (int i = 1; i < argc; i++) {
+        if ((TextIsEqual(argv[i], "-L") || TextIsEqual(argv[i], "--libretro")) && i + 1 < argc) {
+            corePath = argv[++i];
+        } else if (!gameFile) {
+            gameFile = argv[i];
+        }
+    }
 
     if (corePath) {
         if (MenuInitCore(corePath) && LoadLibretroGame(gameFile)) {

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -117,11 +117,23 @@ bool Init(void** userData, int argc, char** argv) {
 
     // Parse the command line arguments.
     const char* corePath = (argc > 1) ? argv[1] : NULL;
+    const char* gameFile = (argc > 2) ? argv[2] : NULL;
 #ifdef __EMSCRIPTEN__
     if (!corePath) {
         corePath = "/resources/fceumm_libretro.wasm";
     }
 #endif
+
+    // If only a game file is given, try to detect the core from the cache.
+    if (gameFile && !corePath) {
+        corePath = FindCoreForGame(gameFile);
+        if (corePath) {
+            TraceLog(LOG_INFO, "LIBRETRO: Auto-detected core: %s", corePath);
+        } else {
+            TraceLog(LOG_WARNING, "LIBRETRO: No core found for game: %s", gameFile);
+        }
+    }
+
     if (corePath) {
         // Initialize the given core.
         if (InitLibretro(corePath)) {
@@ -129,8 +141,6 @@ bool Init(void** userData, int argc, char** argv) {
             LoadLibretroCoreOptions();
             SetLibretroVolume(data->menu->volumeSelected);
 
-            // Load the given game.
-            const char* gameFile = (argc > 2) ? argv[2] : NULL;
             if (LoadLibretroGame(gameFile)) {
                 BuildLibretroMenuOptions(data->menu);
                 data->menu->active = false;

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -225,14 +225,15 @@ bool UpdateDrawFrame(void* userData) {
         FilePathList dropped = LoadDroppedFiles();
         if (dropped.count > 0) {
             const char* droppedPath = dropped.paths[0];
+            SaveLibretroAllSettings();
+            CloseLibretro();
             if (IsLibretroCoreFile(droppedPath)) {
-                SaveLibretroAllSettings();
-                CloseLibretro();
                 if (MenuInitCore(droppedPath)) {
                     BuildLibretroMenuOptions(data->menu);
                     data->menu->active = true;
                 }
             } else {
+                // MenuLoadGame autodetects a core for the dropped game via FindCoreForGame().
                 MenuLoadGame(droppedPath);
             }
         }

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -223,7 +223,7 @@ bool UpdateDrawFrame(void* userData) {
         if (dropped.count > 0) {
             const char* droppedPath = dropped.paths[0];
             const char* ext = GetFileExtension(droppedPath);
-            bool isCore = TextIsEqual(ext, ".so") || TextIsEqual(ext, ".dll") || TextIsEqual(ext, ".dylib");
+            bool isCore = TextIsEqual(ext, ".so") || TextIsEqual(ext, ".dll") || TextIsEqual(ext, ".dylib") || TextIsEqual(ext, ".wasm");
 
             if (isCore) {
                 SaveLibretroAllSettings();

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -282,21 +282,19 @@ static void MenuResumeClicked(nk_console* widget, void* user_data) {
     }
 }
 
-/*
 // Close Game has been removed for now, since it's not really needed.
-static void MenuCloseGameClicked(nk_console* widget, void* user_data) {
-    NK_UNUSED(widget);
-    NK_UNUSED(user_data);
-    if (!IsLibretroReady()) {
-        return;
-    }
-    if (IsLibretroGameReady()) {
-        UnloadLibretroGame();
-    }
-    CloseLibretro();
-    UpdateLibretroMenuVisibility();
-}
-*/
+// static void MenuCloseGameClicked(nk_console* widget, void* user_data) {
+//     NK_UNUSED(widget);
+//     NK_UNUSED(user_data);
+//     if (!IsLibretroReady()) {
+//         return;
+//     }
+//     if (IsLibretroGameReady()) {
+//         UnloadLibretroGame();
+//     }
+//     CloseLibretro();
+//     UpdateLibretroMenuVisibility();
+// }
 
 static void ScanLibretroCoreDirectory(void);
 

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -294,15 +294,17 @@ static void MenuLoadGameClicked(nk_console* widget, void* user_data) {
 
 #define LIBRETRO_CORE_CACHE_SECTION "core_cache"
 
+static bool IsLibretroCoreFile(const char* path) {
+    const char* ext = GetFileExtension(path);
+    return TextIsEqual(ext, ".so") || TextIsEqual(ext, ".dll") || TextIsEqual(ext, ".dylib") || TextIsEqual(ext, ".wasm");
+}
+
 static int LibretroCoreDirectoryFileCount(const char* dir) {
     if (!dir || !dir[0] || !DirectoryExists(dir)) return 0;
     FilePathList files = LoadDirectoryFiles(dir);
     int count = 0;
     for (unsigned int i = 0; i < files.count; i++) {
-        const char* ext = GetFileExtension(files.paths[i]);
-        if (TextIsEqual(ext, ".so") || TextIsEqual(ext, ".dll") || TextIsEqual(ext, ".dylib") || TextIsEqual(ext, ".wasm")) {
-            count++;
-        }
+        if (IsLibretroCoreFile(files.paths[i])) count++;
     }
     UnloadDirectoryFiles(files);
     return count;
@@ -335,9 +337,7 @@ static void ScanLibretroCoreDirectory(void) {
     int coreIndex = 0;
     for (unsigned int i = 0; i < files.count; i++) {
         const char* ext = GetFileExtension(files.paths[i]);
-        if (!TextIsEqual(ext, ".so") && !TextIsEqual(ext, ".dll") && !TextIsEqual(ext, ".dylib") && !TextIsEqual(ext, ".wasm")) {
-            continue;
-        }
+        if (!IsLibretroCoreFile(files.paths[i])) continue;
         if (!InitLibretroEx(files.paths[i], true)) continue;
         if (TextLength(LibretroCore.validExtensions) == 0) continue;
 

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -472,6 +472,7 @@ static void MenuGameFileChanged(nk_console* widget, void* user_data) {
     NK_UNUSED(widget);
     char* path = (char*)user_data;
     if (path && path[0]) {
+        SaveLibretroAllSettings();
         CloseLibretro();
         MenuLoadGame(path);
         path[0] = '\0';
@@ -719,6 +720,9 @@ LibretroMenu* InitLibretroMenu(void) {
     nk_console* quitButton = nk_console_button(menu.console, "Quit");
     nk_console_add_event(quitButton, NK_CONSOLE_EVENT_CLICKED, &LibretroMenuQuitClicked);
     nk_console_button_set_symbol(quitButton, NK_SYMBOL_X);
+    #ifdef __EMSCRIPTEN__ // Don't show quit on web.
+    quitButton->visible = false;
+    #endif
 
     menu.active = true;
     return &menu;

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -296,11 +296,6 @@ static void MenuCoreDirChanged(nk_console* widget, void* user_data) {
     ScanLibretroCoreDirectory();
 }
 
-static void MenuLoadGameClicked(nk_console* widget, void* user_data) {
-    NK_UNUSED(widget);
-    NK_UNUSED(user_data);
-}
-
 #define LIBRETRO_CORE_CACHE_SECTION "core_cache"
 
 static bool IsLibretroCoreFile(const char* path) {
@@ -408,6 +403,45 @@ static const char* FindCoreForGame(const char* gamePath) {
     return NULL;
 }
 
+static bool MenuInitCore(const char* corePath) {
+    if (!InitLibretro(corePath)) return false;
+    LoadLibretroCoreOptions();
+    SetLibretroVolume(menu.volumeSelected);
+    return true;
+}
+
+static void MenuLoadGame(const char* gamePath) {
+    bool coreReady = IsLibretroReady();
+    if (!coreReady) {
+        const char* corePath = FindCoreForGame(gamePath);
+        if (!corePath) {
+            ShowLibretroMessage("No core found for this file", 2.0f);
+            return;
+        }
+        coreReady = MenuInitCore(corePath);
+        if (!coreReady) {
+            ShowLibretroMessage("Failed to load core", 2.0f);
+            return;
+        }
+    } else if (IsLibretroGameReady()) {
+        UnloadLibretroGame();
+    }
+    if (LoadLibretroGame(gamePath)) {
+        BuildLibretroMenuOptions(&menu);
+        menu.active = false;
+    }
+}
+
+static char s_loadGamePath[RAYLIB_LIBRETRO_VFS_MAX_PATH] = {0};
+
+static void MenuGameFileChanged(nk_console* widget, void* user_data) {
+    NK_UNUSED(widget);
+    NK_UNUSED(user_data);
+    if (s_loadGamePath[0]) {
+        MenuLoadGame(s_loadGamePath);
+    }
+}
+
 static void LibretroMenuLoadStateClicked(nk_console* widget, void* user_data) {
     (void)widget;
     (void)user_data;
@@ -490,7 +524,8 @@ LibretroMenu* InitLibretroMenu(void) {
 
 
     // Load Game
-    nk_console_button_onclick(menu.console, "Load Game", &MenuLoadGameClicked);
+    nk_console* loadGame = nk_console_file_action(menu.console, "Load Game", s_loadGamePath, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+    nk_console_add_event_handler(loadGame, NK_CONSOLE_EVENT_CHANGED, &MenuGameFileChanged, NULL, NULL);
 
     // Close Game
     menu.closeGameButton = nk_console_button_onclick(menu.console, "Close Game", &MenuCloseGameClicked);

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -439,6 +439,7 @@ static void MenuGameFileChanged(nk_console* widget, void* user_data) {
     NK_UNUSED(user_data);
     if (s_loadGamePath[0]) {
         MenuLoadGame(s_loadGamePath);
+        s_loadGamePath[0] = '\0';
     }
 }
 

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -58,6 +58,7 @@ typedef struct LibretroMenu {
     bool shouldQuit;
     nk_bool fullscreen;
     nk_console* optionsMenu;              // "Core Options" submenu node
+    nk_console* loadGameWidget;
     nk_console* saveStateButton;
     nk_console* loadStateButton;
     nk_console* resumeButton;
@@ -315,6 +316,13 @@ static void MenuCoreDirChanged(nk_console* widget, void* user_data) {
     ScanLibretroCoreDirectory();
 }
 
+static void MenuContentDirChanged(nk_console* widget, void* user_data) {
+    MenuDirChanged(widget, user_data);
+    if (menu.loadGameWidget && menu.fileBrowserStartDirectory[0] != '\0') {
+        nk_console_file_set_directory(menu.loadGameWidget, menu.fileBrowserStartDirectory);
+    }
+}
+
 #define LIBRETRO_CORE_CACHE_SECTION "core_cache"
 
 static bool IsLibretroCoreFile(const char* path) {
@@ -543,10 +551,10 @@ LibretroMenu* InitLibretroMenu(void) {
 
 
     // Load Game
-    nk_console* loadGame = nk_console_file_action(menu.console, "Load Game", menu.loadGamePath, RAYLIB_LIBRETRO_VFS_MAX_PATH);
-    nk_console_add_event_handler(loadGame, NK_CONSOLE_EVENT_CHANGED, &MenuGameFileChanged, menu.loadGamePath, NULL);
+    menu.loadGameWidget = nk_console_file_action(menu.console, "Load Game", menu.loadGamePath, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+    nk_console_add_event_handler(menu.loadGameWidget, NK_CONSOLE_EVENT_CHANGED, &MenuGameFileChanged, menu.loadGamePath, NULL);
     if (menu.fileBrowserStartDirectory[0] != '\0') {
-        nk_console_file_set_directory(loadGame, menu.fileBrowserStartDirectory);
+        nk_console_file_set_directory(menu.loadGameWidget, menu.fileBrowserStartDirectory);
     }
 
     // Close Game
@@ -671,7 +679,7 @@ LibretroMenu* InitLibretroMenu(void) {
             nk_console_add_event_handler(playlistsDirectory, NK_CONSOLE_EVENT_CHANGED, &MenuDirChanged, NULL, NULL);
 
             nk_console* fileBrowserStartDirectory = nk_console_dir(directoryTree, "Content", menu.fileBrowserStartDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
-            nk_console_add_event_handler(fileBrowserStartDirectory, NK_CONSOLE_EVENT_CHANGED, &MenuDirChanged, NULL, NULL);
+            nk_console_add_event_handler(fileBrowserStartDirectory, NK_CONSOLE_EVENT_CHANGED, &MenuContentDirChanged, NULL, NULL);
         }
     }
 

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -438,42 +438,41 @@ static bool MenuInitCore(const char* corePath) {
     return true;
 }
 
-static void MenuLoadGame(const char* gamePath) {
+static bool MenuLoadGame(const char* gamePath) {
     // Unload the current game if it's a thing.
     if (IsLibretroGameReady()) {
         UnloadLibretroGame();
-    }
-    if (IsLibretroReady()) {
-        CloseLibretro();
     }
 
     // Detect a workable core.
     const char* corePath = FindCoreForGame(gamePath);
     if (!corePath) {
         ShowLibretroMessage("No core found for this file", 2.0f);
-        return;
+        return false;
     }
 
     // Load the core
     if (!MenuInitCore(corePath)) {
         ShowLibretroMessage("Failed to load core", 2.0f);
-        return;
+        return false;
     }
 
     // Load the game
-    if (LoadLibretroGame(gamePath)) {
-        BuildLibretroMenuOptions(&menu);
-        menu.active = false;
-    }
-    else {
+    if (!LoadLibretroGame(gamePath)) {
         ShowLibretroMessage("Failed to load game", 2.0f);
+        return false;
     }
+
+    BuildLibretroMenuOptions(&menu);
+    menu.active = false;
+    return true;
 }
 
 static void MenuGameFileChanged(nk_console* widget, void* user_data) {
     NK_UNUSED(widget);
     char* path = (char*)user_data;
     if (path && path[0]) {
+        CloseLibretro();
         MenuLoadGame(path);
         path[0] = '\0';
     }

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -300,7 +300,7 @@ static int LibretroCoreDirectoryFileCount(const char* dir) {
     int count = 0;
     for (unsigned int i = 0; i < files.count; i++) {
         const char* ext = GetFileExtension(files.paths[i]);
-        if (TextIsEqual(ext, ".so") || TextIsEqual(ext, ".dll") || TextIsEqual(ext, ".dylib")) {
+        if (TextIsEqual(ext, ".so") || TextIsEqual(ext, ".dll") || TextIsEqual(ext, ".dylib") || TextIsEqual(ext, ".wasm")) {
             count++;
         }
     }
@@ -335,7 +335,7 @@ static void ScanLibretroCoreDirectory(void) {
     int coreIndex = 0;
     for (unsigned int i = 0; i < files.count; i++) {
         const char* ext = GetFileExtension(files.paths[i]);
-        if (!TextIsEqual(ext, ".so") && !TextIsEqual(ext, ".dll") && !TextIsEqual(ext, ".dylib")) {
+        if (!TextIsEqual(ext, ".so") && !TextIsEqual(ext, ".dll") && !TextIsEqual(ext, ".dylib") && !TextIsEqual(ext, ".wasm")) {
             continue;
         }
         if (!InitLibretroEx(files.paths[i], true)) continue;

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -94,6 +94,7 @@ typedef struct LibretroMenu {
     char systemDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char playlistsDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char fileBrowserStartDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    char loadGamePath[RAYLIB_LIBRETRO_VFS_MAX_PATH];
 #ifdef RAYLIB_LIBRETRO_CONFIG_H
     RLibretroConfig* cfg;                 // persistent config, owned for the lifetime of the menu
 #endif
@@ -450,14 +451,12 @@ static void MenuLoadGame(const char* gamePath) {
     }
 }
 
-static char s_loadGamePath[RAYLIB_LIBRETRO_VFS_MAX_PATH] = {0};
-
 static void MenuGameFileChanged(nk_console* widget, void* user_data) {
     NK_UNUSED(widget);
-    NK_UNUSED(user_data);
-    if (s_loadGamePath[0]) {
-        MenuLoadGame(s_loadGamePath);
-        s_loadGamePath[0] = '\0';
+    char* path = (char*)user_data;
+    if (path && path[0]) {
+        MenuLoadGame(path);
+        path[0] = '\0';
     }
 }
 
@@ -544,8 +543,8 @@ LibretroMenu* InitLibretroMenu(void) {
 
 
     // Load Game
-    nk_console* loadGame = nk_console_file_action(menu.console, "Load Game", s_loadGamePath, RAYLIB_LIBRETRO_VFS_MAX_PATH);
-    nk_console_add_event_handler(loadGame, NK_CONSOLE_EVENT_CHANGED, &MenuGameFileChanged, NULL, NULL);
+    nk_console* loadGame = nk_console_file_action(menu.console, "Load Game", menu.loadGamePath, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+    nk_console_add_event_handler(loadGame, NK_CONSOLE_EVENT_CHANGED, &MenuGameFileChanged, menu.loadGamePath, NULL);
 
     // Close Game
     menu.closeGameButton = nk_console_button_onclick(menu.console, "Close Game", &MenuCloseGameClicked);

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -62,7 +62,7 @@ typedef struct LibretroMenu {
     nk_console* saveStateButton;
     nk_console* loadStateButton;
     nk_console* resumeButton;
-    nk_console* closeGameButton;
+    //nk_console* closeGameButton;
     int shaderSelectedIndex;
     int textureFilterIndex;
     int themeSelectedIndex;
@@ -282,6 +282,8 @@ static void MenuResumeClicked(nk_console* widget, void* user_data) {
     }
 }
 
+/*
+// Close Game has been removed for now, since it's not really needed.
 static void MenuCloseGameClicked(nk_console* widget, void* user_data) {
     NK_UNUSED(widget);
     NK_UNUSED(user_data);
@@ -294,6 +296,7 @@ static void MenuCloseGameClicked(nk_console* widget, void* user_data) {
     CloseLibretro();
     UpdateLibretroMenuVisibility();
 }
+*/
 
 static void ScanLibretroCoreDirectory(void);
 
@@ -438,24 +441,34 @@ static bool MenuInitCore(const char* corePath) {
 }
 
 static void MenuLoadGame(const char* gamePath) {
-    bool coreReady = IsLibretroReady();
-    if (!coreReady) {
-        const char* corePath = FindCoreForGame(gamePath);
-        if (!corePath) {
-            ShowLibretroMessage("No core found for this file", 2.0f);
-            return;
-        }
-        coreReady = MenuInitCore(corePath);
-        if (!coreReady) {
-            ShowLibretroMessage("Failed to load core", 2.0f);
-            return;
-        }
-    } else if (IsLibretroGameReady()) {
+    // Unload the current game if it's a thing.
+    if (IsLibretroGameReady()) {
         UnloadLibretroGame();
     }
+    if (IsLibretroReady()) {
+        CloseLibretro();
+    }
+
+    // Detect a workable core.
+    const char* corePath = FindCoreForGame(gamePath);
+    if (!corePath) {
+        ShowLibretroMessage("No core found for this file", 2.0f);
+        return;
+    }
+
+    // Load the core
+    if (!MenuInitCore(corePath)) {
+        ShowLibretroMessage("Failed to load core", 2.0f);
+        return;
+    }
+
+    // Load the game
     if (LoadLibretroGame(gamePath)) {
         BuildLibretroMenuOptions(&menu);
         menu.active = false;
+    }
+    else {
+        ShowLibretroMessage("Failed to load game", 2.0f);
     }
 }
 
@@ -558,8 +571,8 @@ LibretroMenu* InitLibretroMenu(void) {
     }
 
     // Close Game
-    menu.closeGameButton = nk_console_button_onclick(menu.console, "Close Game", &MenuCloseGameClicked);
-    nk_console_button_set_symbol(menu.resumeButton, NK_SYMBOL_X);
+    //menu.closeGameButton = nk_console_button_onclick(menu.console, "Close Game", &MenuCloseGameClicked);
+    //nk_console_button_set_symbol(menu.resumeButton, NK_SYMBOL_X);
 
     // Settings
     nk_console* settings = nk_console_button(menu.console, "Settings");
@@ -691,15 +704,19 @@ LibretroMenu* InitLibretroMenu(void) {
             NK_SYMBOL_TRIANGLE_LEFT);
     }
 
-    // Save State
-    menu.saveStateButton = nk_console_button(menu.console, "Save State");
-    nk_console_add_event(menu.saveStateButton, NK_CONSOLE_EVENT_CLICKED, &LibretroMenuSaveStateClicked);
-    nk_console_button_set_symbol(menu.saveStateButton, NK_SYMBOL_RECT_SOLID);
+    {
+        nk_console* saveStateRow = nk_console_row_begin(menu.console);
+        // Save State
+        menu.saveStateButton = nk_console_button(saveStateRow, "Save State");
+        nk_console_add_event(menu.saveStateButton, NK_CONSOLE_EVENT_CLICKED, &LibretroMenuSaveStateClicked);
+        nk_console_button_set_symbol(menu.saveStateButton, NK_SYMBOL_RECT_SOLID);
 
-    // Load State
-    menu.loadStateButton = nk_console_button(menu.console, "Load State");
-    nk_console_add_event(menu.loadStateButton, NK_CONSOLE_EVENT_CLICKED, &LibretroMenuLoadStateClicked);
-    nk_console_button_set_symbol(menu.loadStateButton, NK_SYMBOL_RECT_OUTLINE);
+        // Load State
+        menu.loadStateButton = nk_console_button(saveStateRow, "Load State");
+        nk_console_add_event(menu.loadStateButton, NK_CONSOLE_EVENT_CLICKED, &LibretroMenuLoadStateClicked);
+        nk_console_button_set_symbol(menu.loadStateButton, NK_SYMBOL_RECT_OUTLINE);
+        nk_console_row_end(saveStateRow);
+    }
 
     // Quit
     nk_console* quitButton = nk_console_button(menu.console, "Quit");
@@ -1051,10 +1068,13 @@ static void UpdateLibretroMenuVisibility(void) {
     // Disable game-dependent items when no game is loaded.
     nk_bool gameReady = (nk_bool)IsLibretroGameReady();
     if (menu.optionsMenu) menu.optionsMenu->visible = LibretroCore.variableCount > 0 && IsLibretroReady();
-    if (menu.saveStateButton) menu.saveStateButton->visible = gameReady;
-    if (menu.loadStateButton) menu.loadStateButton->visible = gameReady;
+    if (menu.saveStateButton) {
+        //menu.saveStateButton->visible = gameReady;
+        menu.saveStateButton->parent->visible = gameReady;
+    }
+    //if (menu.loadStateButton) menu.loadStateButton->visible = gameReady;
     if (menu.resumeButton) menu.resumeButton->visible = gameReady;
-    if (menu.closeGameButton) menu.closeGameButton->visible = gameReady;
+    //if (menu.closeGameButton) menu.closeGameButton->visible = gameReady;
 }
 
 void UpdateLibretroMenu(void) {
@@ -1095,9 +1115,9 @@ void DrawLibretroMenu(void) {
     if (menu.ctx == NULL) {
         return;
     }
-    if (!menu.active) {
-        return;
-    }
+    // Always draw when a context exists so nk_clear runs every frame nk_begin
+    // ran in UpdateLibretroMenu — otherwise a callback that toggles menu.active
+    // off mid-frame leaves win->seq == ctx->seq and trips the next nk_begin.
     DrawNuklear(menu.ctx);
 }
 

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -287,6 +287,15 @@ static void MenuCloseGameClicked(nk_console* widget, void* user_data) {
     UpdateLibretroMenuVisibility();
 }
 
+static void ScanLibretroCoreDirectory(void);
+
+static void MenuCoreDirChanged(nk_console* widget, void* user_data) {
+    NK_UNUSED(widget);
+    NK_UNUSED(user_data);
+    LibretroMenuSettingChanged(widget, user_data);
+    ScanLibretroCoreDirectory();
+}
+
 static void MenuLoadGameClicked(nk_console* widget, void* user_data) {
     NK_UNUSED(widget);
     NK_UNUSED(user_data);
@@ -316,9 +325,18 @@ static void ScanLibretroCoreDirectory(void) {
     const char* dir = LibretroCore.coreDirectory;
     if (!dir || !dir[0]) return;
 
+    // If a core is already loaded we can't peek at other cores; just invalidate
+    // so the next launch performs a full rescan.
+    if (IsLibretroReady()) {
+        rlconfig_set_int(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, "file_count", -1);
+        rlconfig_save(menu.cfg, RAYLIB_LIBRETRO_CFG_FILE);
+        return;
+    }
+
     int currentCount = LibretroCoreDirectoryFileCount(dir);
     int cachedCount = rlconfig_get_int(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, "file_count", -1);
-    if (cachedCount == currentCount) {
+    const char* cachedDir = rlconfig_get(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, "dir_path");
+    if (cachedCount == currentCount && cachedDir && TextIsEqual(cachedDir, dir)) {
         int cached = rlconfig_get_int(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, "count", 0);
         TraceLog(LOG_INFO, "LIBRETRO: Core cache valid (%d cores)", cached);
         return;
@@ -327,6 +345,7 @@ static void ScanLibretroCoreDirectory(void) {
     TraceLog(LOG_INFO, "LIBRETRO: Rescanning cores in %s", dir);
     rlconfig_clear_section(menu.cfg, LIBRETRO_CORE_CACHE_SECTION);
     rlconfig_set_int(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, "file_count", currentCount);
+    rlconfig_set(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, "dir_path", dir);
 
     if (!DirectoryExists(dir)) {
         rlconfig_save(menu.cfg, RAYLIB_LIBRETRO_CFG_FILE);
@@ -580,7 +599,7 @@ LibretroMenu* InitLibretroMenu(void) {
         nk_console* directoryTree = nk_console_tree(settings, "Directories", nk_false);
         {
             nk_console* coreDirectory = nk_console_dir(directoryTree, "Cores", LibretroCore.coreDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
-            nk_console_add_event_handler(coreDirectory, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+            nk_console_add_event_handler(coreDirectory, NK_CONSOLE_EVENT_CHANGED, &MenuCoreDirChanged, NULL, NULL);
 
             nk_console* saveDirectory = nk_console_dir(directoryTree, "Saves", LibretroCore.saveDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
             nk_console_add_event_handler(saveDirectory, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -88,6 +88,12 @@ typedef struct LibretroMenu {
     float slowMotionSpeed;
     int optionSelectedIndices[128];       // per-option combobox index (matches LIBRETRO_MAX_CORE_VARIABLES)
     nk_bool optionCheckboxValues[128];    // per-option checkbox state for enabled/disabled options
+    char coreDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    char saveDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    char coreAssetsDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    char systemDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    char playlistsDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    char fileBrowserStartDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
 #ifdef RAYLIB_LIBRETRO_CONFIG_H
     RLibretroConfig* cfg;                 // persistent config, owned for the lifetime of the menu
 #endif
@@ -289,10 +295,22 @@ static void MenuCloseGameClicked(nk_console* widget, void* user_data) {
 
 static void ScanLibretroCoreDirectory(void);
 
-static void MenuCoreDirChanged(nk_console* widget, void* user_data) {
-    NK_UNUSED(widget);
-    NK_UNUSED(user_data);
+static void LibretroApplyDirectories(void) {
+    TextCopy(LibretroCore.coreDirectory,            menu.coreDirectory);
+    TextCopy(LibretroCore.saveDirectory,            menu.saveDirectory);
+    TextCopy(LibretroCore.coreAssetsDirectory,      menu.coreAssetsDirectory);
+    TextCopy(LibretroCore.systemDirectory,          menu.systemDirectory);
+    TextCopy(LibretroCore.playlistsDirectory,       menu.playlistsDirectory);
+    TextCopy(LibretroCore.fileBrowserStartDirectory, menu.fileBrowserStartDirectory);
+}
+
+static void MenuDirChanged(nk_console* widget, void* user_data) {
     LibretroMenuSettingChanged(widget, user_data);
+    LibretroApplyDirectories();
+}
+
+static void MenuCoreDirChanged(nk_console* widget, void* user_data) {
+    MenuDirChanged(widget, user_data);
     ScanLibretroCoreDirectory();
 }
 
@@ -317,7 +335,7 @@ static int LibretroCoreDirectoryFileCount(const char* dir) {
 static void ScanLibretroCoreDirectory(void) {
 #ifdef RAYLIB_LIBRETRO_CONFIG_H
     if (!menu.cfg) return;
-    const char* dir = LibretroCore.coreDirectory;
+    const char* dir = menu.coreDirectory;
     if (!dir || !dir[0]) return;
 
     // If a core is already loaded we can't peek at other cores; just invalidate
@@ -404,6 +422,7 @@ static const char* FindCoreForGame(const char* gamePath) {
 }
 
 static bool MenuInitCore(const char* corePath) {
+    LibretroApplyDirectories();
     if (!InitLibretro(corePath)) return false;
     LoadLibretroCoreOptions();
     SetLibretroVolume(menu.volumeSelected);
@@ -514,8 +533,9 @@ LibretroMenu* InitLibretroMenu(void) {
 #ifdef RAYLIB_LIBRETRO_CONFIG_H
     menu.cfg = rlconfig_load(FileExists(RAYLIB_LIBRETRO_CFG_FILE) ? RAYLIB_LIBRETRO_CFG_FILE : NULL);
 #endif
-    TextCopy(LibretroCore.coreDirectory, "cores");
+    TextCopy(menu.coreDirectory, "cores");
     LoadLibretroMenuSettings();
+    LibretroApplyDirectories();
     ScanLibretroCoreDirectory();
 
     // Build the Menu
@@ -634,23 +654,23 @@ LibretroMenu* InitLibretroMenu(void) {
         // Directories
         nk_console* directoryTree = nk_console_tree(settings, "Directories", nk_false);
         {
-            nk_console* coreDirectory = nk_console_dir(directoryTree, "Cores", LibretroCore.coreDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+            nk_console* coreDirectory = nk_console_dir(directoryTree, "Cores", menu.coreDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
             nk_console_add_event_handler(coreDirectory, NK_CONSOLE_EVENT_CHANGED, &MenuCoreDirChanged, NULL, NULL);
 
-            nk_console* saveDirectory = nk_console_dir(directoryTree, "Saves", LibretroCore.saveDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
-            nk_console_add_event_handler(saveDirectory, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+            nk_console* saveDirectory = nk_console_dir(directoryTree, "Saves", menu.saveDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+            nk_console_add_event_handler(saveDirectory, NK_CONSOLE_EVENT_CHANGED, &MenuDirChanged, NULL, NULL);
 
-            nk_console* coreAssetsDirectory = nk_console_dir(directoryTree, "Assets", LibretroCore.coreAssetsDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
-            nk_console_add_event_handler(coreAssetsDirectory, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+            nk_console* coreAssetsDirectory = nk_console_dir(directoryTree, "Assets", menu.coreAssetsDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+            nk_console_add_event_handler(coreAssetsDirectory, NK_CONSOLE_EVENT_CHANGED, &MenuDirChanged, NULL, NULL);
 
-            nk_console* systemDirectory = nk_console_dir(directoryTree, "System", LibretroCore.systemDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
-            nk_console_add_event_handler(systemDirectory, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+            nk_console* systemDirectory = nk_console_dir(directoryTree, "System", menu.systemDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+            nk_console_add_event_handler(systemDirectory, NK_CONSOLE_EVENT_CHANGED, &MenuDirChanged, NULL, NULL);
 
-            nk_console* playlistsDirectory = nk_console_dir(directoryTree, "Playlists", LibretroCore.playlistsDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
-            nk_console_add_event_handler(playlistsDirectory, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+            nk_console* playlistsDirectory = nk_console_dir(directoryTree, "Playlists", menu.playlistsDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+            nk_console_add_event_handler(playlistsDirectory, NK_CONSOLE_EVENT_CHANGED, &MenuDirChanged, NULL, NULL);
 
-            nk_console* fileBrowserStartDirectory = nk_console_dir(directoryTree, "Content", LibretroCore.fileBrowserStartDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
-            nk_console_add_event_handler(fileBrowserStartDirectory, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+            nk_console* fileBrowserStartDirectory = nk_console_dir(directoryTree, "Content", menu.fileBrowserStartDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+            nk_console_add_event_handler(fileBrowserStartDirectory, NK_CONSOLE_EVENT_CHANGED, &MenuDirChanged, NULL, NULL);
         }
     }
 
@@ -833,12 +853,12 @@ static void LibretroMenuUpdateConfig(void) {
     rlconfig_set_int(menu.cfg, "raylib-libretro", "fastForwardSpeed", menu.fastForwardSpeed);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "keySlowMotion", (int)menu.keySlowMotion);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "slowMotionSpeed", (int)(menu.slowMotionSpeed * 10.0f));
-    rlconfig_set(menu.cfg, "raylib-libretro", "coreDirectory", LibretroResolveAbsoluteDirectory(LibretroCore.coreDirectory));
-    rlconfig_set(menu.cfg, "raylib-libretro", "saveDirectory", LibretroResolveAbsoluteDirectory(LibretroCore.saveDirectory));
-    rlconfig_set(menu.cfg, "raylib-libretro", "coreAssetsDirectory", LibretroResolveAbsoluteDirectory(LibretroCore.coreAssetsDirectory));
-    rlconfig_set(menu.cfg, "raylib-libretro", "systemDirectory", LibretroResolveAbsoluteDirectory(LibretroCore.systemDirectory));
-    rlconfig_set(menu.cfg, "raylib-libretro", "playlistsDirectory", LibretroResolveAbsoluteDirectory(LibretroCore.playlistsDirectory));
-    rlconfig_set(menu.cfg, "raylib-libretro", "fileBrowserStartDirectory", LibretroResolveAbsoluteDirectory(LibretroCore.fileBrowserStartDirectory));
+    rlconfig_set(menu.cfg, "raylib-libretro", "coreDirectory", LibretroResolveAbsoluteDirectory(menu.coreDirectory));
+    rlconfig_set(menu.cfg, "raylib-libretro", "saveDirectory", LibretroResolveAbsoluteDirectory(menu.saveDirectory));
+    rlconfig_set(menu.cfg, "raylib-libretro", "coreAssetsDirectory", LibretroResolveAbsoluteDirectory(menu.coreAssetsDirectory));
+    rlconfig_set(menu.cfg, "raylib-libretro", "systemDirectory", LibretroResolveAbsoluteDirectory(menu.systemDirectory));
+    rlconfig_set(menu.cfg, "raylib-libretro", "playlistsDirectory", LibretroResolveAbsoluteDirectory(menu.playlistsDirectory));
+    rlconfig_set(menu.cfg, "raylib-libretro", "fileBrowserStartDirectory", LibretroResolveAbsoluteDirectory(menu.fileBrowserStartDirectory));
 #endif
 }
 
@@ -967,17 +987,17 @@ static bool LoadLibretroMenuSettings(void) {
     if (menu.slowMotionSpeed > 0.9f) menu.slowMotionSpeed = 0.9f;
 
     const char* coreDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "coreDirectory");
-    if (coreDirectory) TextCopy(LibretroCore.coreDirectory, coreDirectory);
+    if (coreDirectory) TextCopy(menu.coreDirectory, coreDirectory);
     const char* saveDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "saveDirectory");
-    if (saveDirectory) TextCopy(LibretroCore.saveDirectory, saveDirectory);
+    if (saveDirectory) TextCopy(menu.saveDirectory, saveDirectory);
     const char* coreAssetsDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "coreAssetsDirectory");
-    if (coreAssetsDirectory) TextCopy(LibretroCore.coreAssetsDirectory, coreAssetsDirectory);
-    const char* systemDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "gamesDirectory");
-    if (systemDirectory) TextCopy(LibretroCore.systemDirectory, systemDirectory);
+    if (coreAssetsDirectory) TextCopy(menu.coreAssetsDirectory, coreAssetsDirectory);
+    const char* systemDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "systemDirectory");
+    if (systemDirectory) TextCopy(menu.systemDirectory, systemDirectory);
     const char* playlistsDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "playlistsDirectory");
-    if (playlistsDirectory) TextCopy(LibretroCore.playlistsDirectory, playlistsDirectory);
+    if (playlistsDirectory) TextCopy(menu.playlistsDirectory, playlistsDirectory);
     const char* fileBrowserStartDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "fileBrowserStartDirectory");
-    if (fileBrowserStartDirectory) TextCopy(LibretroCore.fileBrowserStartDirectory, fileBrowserStartDirectory);
+    if (fileBrowserStartDirectory) TextCopy(menu.fileBrowserStartDirectory, fileBrowserStartDirectory);
 
     TraceLog(LOG_INFO, "MENU: Loaded menu settings from %s", RAYLIB_LIBRETRO_CFG_FILE);
     return true;

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -368,7 +368,6 @@ static void ScanLibretroCoreDirectory(void) {
     FilePathList files = LoadDirectoryFiles(dir);
     int coreIndex = 0;
     for (unsigned int i = 0; i < files.count; i++) {
-        const char* ext = GetFileExtension(files.paths[i]);
         if (!IsLibretroCoreFile(files.paths[i])) continue;
         if (!InitLibretroEx(files.paths[i], true)) continue;
         if (TextLength(LibretroCore.validExtensions) == 0) continue;

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -292,6 +292,103 @@ static void MenuLoadGameClicked(nk_console* widget, void* user_data) {
     NK_UNUSED(user_data);
 }
 
+#define LIBRETRO_CORE_CACHE_SECTION "core_cache"
+
+static int LibretroCoreDirectoryFileCount(const char* dir) {
+    if (!dir || !dir[0] || !DirectoryExists(dir)) return 0;
+    FilePathList files = LoadDirectoryFiles(dir);
+    int count = 0;
+    for (unsigned int i = 0; i < files.count; i++) {
+        const char* ext = GetFileExtension(files.paths[i]);
+        if (TextIsEqual(ext, ".so") || TextIsEqual(ext, ".dll") || TextIsEqual(ext, ".dylib")) {
+            count++;
+        }
+    }
+    UnloadDirectoryFiles(files);
+    return count;
+}
+
+static void ScanLibretroCoreDirectory(void) {
+#ifdef RAYLIB_LIBRETRO_CONFIG_H
+    if (!menu.cfg) return;
+    const char* dir = LibretroCore.coreDirectory;
+    if (!dir || !dir[0]) return;
+
+    int currentCount = LibretroCoreDirectoryFileCount(dir);
+    int cachedCount = rlconfig_get_int(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, "file_count", -1);
+    if (cachedCount == currentCount) {
+        int cached = rlconfig_get_int(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, "count", 0);
+        TraceLog(LOG_INFO, "LIBRETRO: Core cache valid (%d cores)", cached);
+        return;
+    }
+
+    TraceLog(LOG_INFO, "LIBRETRO: Rescanning cores in %s", dir);
+    rlconfig_clear_section(menu.cfg, LIBRETRO_CORE_CACHE_SECTION);
+    rlconfig_set_int(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, "file_count", currentCount);
+
+    if (!DirectoryExists(dir)) {
+        rlconfig_save(menu.cfg, RAYLIB_LIBRETRO_CFG_FILE);
+        return;
+    }
+
+    FilePathList files = LoadDirectoryFiles(dir);
+    int coreIndex = 0;
+    for (unsigned int i = 0; i < files.count; i++) {
+        const char* ext = GetFileExtension(files.paths[i]);
+        if (!TextIsEqual(ext, ".so") && !TextIsEqual(ext, ".dll") && !TextIsEqual(ext, ".dylib")) {
+            continue;
+        }
+        if (!InitLibretroEx(files.paths[i], true)) continue;
+        if (TextLength(LibretroCore.validExtensions) == 0) continue;
+
+        char keyPath[64], keyExts[64];
+        TextCopy(keyPath, TextFormat("core_%d_path", coreIndex));
+        TextCopy(keyExts, TextFormat("core_%d_extensions", coreIndex));
+        rlconfig_set(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, keyPath, files.paths[i]);
+        rlconfig_set(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, keyExts, LibretroCore.validExtensions);
+        TraceLog(LOG_INFO, "LIBRETRO: Cached %s (%s)", LibretroCore.libraryName, LibretroCore.validExtensions);
+        coreIndex++;
+    }
+    UnloadDirectoryFiles(files);
+
+    rlconfig_set_int(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, "count", coreIndex);
+    rlconfig_save(menu.cfg, RAYLIB_LIBRETRO_CFG_FILE);
+    TraceLog(LOG_INFO, "LIBRETRO: Cached %d cores in %s", coreIndex, dir);
+#endif
+}
+
+static const char* FindCoreForGame(const char* gamePath) {
+#ifdef RAYLIB_LIBRETRO_CONFIG_H
+    if (!menu.cfg || !gamePath || !gamePath[0]) return NULL;
+
+    const char* gameExt = GetFileExtension(gamePath);
+    if (!gameExt || !gameExt[0]) return NULL;
+    if (gameExt[0] == '.') gameExt++;
+
+    char gameExtLower[32] = {0};
+    TextCopy(gameExtLower, TextToLower(gameExt));
+
+    int count = rlconfig_get_int(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, "count", 0);
+    for (int i = 0; i < count; i++) {
+        char keyExts[64], keyPath[64];
+        TextCopy(keyExts, TextFormat("core_%d_extensions", i));
+        TextCopy(keyPath, TextFormat("core_%d_path", i));
+
+        const char* extensions = rlconfig_get(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, keyExts);
+        if (!extensions) continue;
+
+        int extCount = 0;
+        char** extList = TextSplit(extensions, '|', &extCount);
+        for (int j = 0; j < extCount; j++) {
+            if (TextIsEqual(extList[j], gameExtLower)) {
+                return rlconfig_get(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, keyPath);
+            }
+        }
+    }
+#endif
+    return NULL;
+}
+
 static void LibretroMenuLoadStateClicked(nk_console* widget, void* user_data) {
     (void)widget;
     (void)user_data;
@@ -365,6 +462,7 @@ LibretroMenu* InitLibretroMenu(void) {
 #endif
     TextCopy(LibretroCore.coreDirectory, "cores");
     LoadLibretroMenuSettings();
+    ScanLibretroCoreDirectory();
 
     // Build the Menu
     menu.resumeButton = nk_console_button_onclick(menu.console, "Resume", &MenuResumeClicked);

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -545,6 +545,9 @@ LibretroMenu* InitLibretroMenu(void) {
     // Load Game
     nk_console* loadGame = nk_console_file_action(menu.console, "Load Game", menu.loadGamePath, RAYLIB_LIBRETRO_VFS_MAX_PATH);
     nk_console_add_event_handler(loadGame, NK_CONSOLE_EVENT_CHANGED, &MenuGameFileChanged, menu.loadGamePath, NULL);
+    if (menu.fileBrowserStartDirectory[0] != '\0') {
+        nk_console_file_set_directory(loadGame, menu.fileBrowserStartDirectory);
+    }
 
     // Close Game
     menu.closeGameButton = nk_console_button_onclick(menu.console, "Close Game", &MenuCloseGameClicked);

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -2392,6 +2392,14 @@ static void CloseLibretro() {
         memset(&LibretroCore.audio_callback, 0, sizeof(LibretroCore.audio_callback));
     }
 
+    // Drop any callbacks the core registered into its own .text — dylib_close()
+    // below invalidates those addresses, and a follow-up InitLibretro() with a
+    // different core that doesn't re-register them would call freed memory.
+    LibretroCore.keyboard_event = NULL;
+    LibretroCore.options_update_display_callback = NULL;
+    memset(&LibretroCore.runloop_frame_time, 0, sizeof(LibretroCore.runloop_frame_time));
+    LibretroCore.runloop_frame_time_last = 0;
+
     // Call retro_deinit() to deinitialize the core.
     if (LibretroCore.retro_deinit != NULL) {
         LibretroCore.retro_deinit();

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -361,7 +361,11 @@ static const char *GetLibretroCoreOption(const char *key) {
  * @return The directory that's currently configured for the libretro directory. The application directory by default, or NULL if it's an incorrect directory.
  */
 static const char* GetLibretroDirectory(int directory) {
-    static char cleaned[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    // Rotating buffer pool so multiple calls in one expression don't clobber each other.
+    #define RAYLIB_LIBRETRO_DIR_BUFFERS 4
+    static char buffers[RAYLIB_LIBRETRO_DIR_BUFFERS][RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    static int bufferIndex = 0;
+
     char* output = NULL;
     switch (directory) {
         case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY: output = LibretroCore.saveDirectory; break;
@@ -373,6 +377,9 @@ static const char* GetLibretroDirectory(int directory) {
     }
 
     const char* result = (output == NULL || output[0] == '\0') ? GetApplicationDirectory() : output;
+
+    char* cleaned = buffers[bufferIndex];
+    bufferIndex = (bufferIndex + 1) % RAYLIB_LIBRETRO_DIR_BUFFERS;
 
     // Strip trailing slash to prevent double slashes when building file paths.
     TextCopy(cleaned, result);
@@ -1482,7 +1489,9 @@ static void UpdateLibretro() {
         InitLibretroVideo();
     }
 
-    LibretroCore.gameTimeNSEC += (retro_perf_tick_t)((double)GetFrameTime() * 1000000000.0);
+    if (IsLibretroGameReady()) {
+        LibretroCore.gameTimeNSEC += (retro_perf_tick_t)((double)GetFrameTime() * 1000000000.0);
+    }
 
     // Update the game loop timer.
     if (LibretroCore.runloop_frame_time.callback) {
@@ -2029,6 +2038,11 @@ static bool LoadLibretroGame(const char* gameFile) {
     if (!IsLibretroReady()) {
         TraceLog(LOG_ERROR, "LIBRETRO: Core is required before loading a game");
         return false;
+    }
+
+    // Unload any prior game so the core sees a clean retro_load_game().
+    if (IsLibretroGameReady()) {
+        UnloadLibretroGame();
     }
 
     // Load empty game.

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -228,7 +228,6 @@ typedef struct rLibretro {
     retro_keyboard_event_t keyboard_event;
     retro_core_options_update_display_callback_t options_update_display_callback;
     struct retro_vfs_interface vfs_interface;
-    // struct retro_game_info_ext game_info_ext;
 
     // Input descriptors (RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS)
     struct retro_input_descriptor *inputDescriptors;
@@ -272,6 +271,14 @@ typedef struct rLibretro {
 
     // Loaded content path (empty if no content loaded).
     char contentPath[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+
+    // Backing storage and struct for RETRO_ENVIRONMENT_GET_GAME_INFO_EXT.
+    // Pointers in gameInfoExt reference these buffers (or are NULL).
+    char contentDir[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    char contentName[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    char contentExt[16];
+    struct retro_game_info_ext gameInfoExt;
+    bool gameInfoExtValid;
 
     // Directory configuration. Empty string means use GetApplicationDirectory().
     // TODO: Change this to be MemAlloc-ed?
@@ -386,15 +393,22 @@ static const struct retro_controller_info* GetLibretroControllerInfo(unsigned *c
     return LibretroCore.controllerInfo;
 }
 
+// Returns an absolute path for `path`. The result is either the input pointer
+// (already absolute) or a pointer into a non-reentrant static buffer; copy it
+// before calling again if you need to keep both values.
 static const char* LibretroResolveAbsoluteDirectory(const char* path) {
     if (!path || path[0] == '\0') return path;
+    if (path[0] == '/' || path[0] == '\\') return path;
 #if defined(_WIN32)
-    if (path[1] == ':' || path[0] == '\\') return path;
-#else
-    if (path[0] == '/') return path;
+    if (path[1] == ':') return path;
 #endif
     static char absPath[RAYLIB_LIBRETRO_VFS_MAX_PATH];
-    int n = snprintf(absPath, sizeof(absPath), "%s/%s", GetWorkingDirectory(), path);
+#if defined(_WIN32)
+    const char sep = '\\';
+#else
+    const char sep = '/';
+#endif
+    int n = snprintf(absPath, sizeof(absPath), "%s%c%s", GetWorkingDirectory(), sep, path);
     if (n < 0 || (size_t)n >= sizeof(absPath)) return path;
     return absPath;
 }
@@ -1270,12 +1284,9 @@ static bool LibretroSetEnvironment(unsigned cmd, void * data) {
         }
 
         case RETRO_ENVIRONMENT_GET_GAME_INFO_EXT: {
-            TraceLog(LOG_WARNING, "LIBRETRO: RETRO_ENVIRONMENT_GET_GAME_INFO_EXT not implemented");
-            // const struct retro_game_info_ext ** game_info_ext = (const struct retro_game_info_ext **)data;
-            // *game_info_ext = &LibretroCore.game_info_ext;
-            // LibretroCore.game_info_ext.archive_file
-
-            return false;
+            if (data == NULL || !LibretroCore.gameInfoExtValid) return false;
+            *(const struct retro_game_info_ext **)data = &LibretroCore.gameInfoExt;
+            return true;
         }
 
         case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2: {
@@ -1935,6 +1946,46 @@ static bool LibretroInitAudioVideo() {
     return true;
 }
 
+// Populate LibretroCore.gameInfoExt from LibretroCore.contentPath for
+// RETRO_ENVIRONMENT_GET_GAME_INFO_EXT. Caller must set contentPath first.
+// `data`/`size` are only valid while retro_load_game() is executing.
+static void LibretroPopulateGameInfoExt(const void *data, size_t size) {
+    memset(&LibretroCore.gameInfoExt, 0, sizeof(LibretroCore.gameInfoExt));
+    LibretroCore.contentDir[0]  = '\0';
+    LibretroCore.contentName[0] = '\0';
+    LibretroCore.contentExt[0]  = '\0';
+    LibretroCore.gameInfoExtValid = false;
+
+    if (LibretroCore.contentPath[0] == '\0') return;
+
+    TextCopy(LibretroCore.contentDir,  GetDirectoryPath(LibretroCore.contentPath));
+    TextCopy(LibretroCore.contentName, GetFileNameWithoutExt(LibretroCore.contentPath));
+
+    // Extension without leading dot, lower-cased.
+    const char *ext = GetFileExtension(LibretroCore.contentPath);
+    if (ext != NULL && ext[0] == '.') ext++;
+    if (ext != NULL) {
+        size_t i = 0;
+        for (; ext[i] != '\0' && i + 1 < sizeof(LibretroCore.contentExt); i++) {
+            char c = ext[i];
+            if (c >= 'A' && c <= 'Z') c = (char)(c - 'A' + 'a');
+            LibretroCore.contentExt[i] = c;
+        }
+        LibretroCore.contentExt[i] = '\0';
+    }
+
+    LibretroCore.gameInfoExt.full_path       = LibretroCore.contentPath;
+    LibretroCore.gameInfoExt.dir             = LibretroCore.contentDir;
+    LibretroCore.gameInfoExt.name            = LibretroCore.contentName;
+    LibretroCore.gameInfoExt.ext             = LibretroCore.contentExt;
+    LibretroCore.gameInfoExt.meta            = "";
+    LibretroCore.gameInfoExt.data            = data;
+    LibretroCore.gameInfoExt.size            = size;
+    LibretroCore.gameInfoExt.file_in_archive = false;
+    LibretroCore.gameInfoExt.persistent_data = false;
+    LibretroCore.gameInfoExtValid            = true;
+}
+
 static bool LoadLibretroGameFromMemory(const unsigned char *fileData, int dataSize) {
     if (!IsLibretroReady()) {
         TraceLog(LOG_ERROR, "LIBRETRO: Core is required before loading a game");
@@ -1958,6 +2009,7 @@ static bool LoadLibretroGameFromMemory(const unsigned char *fileData, int dataSi
     info.data = fileData;
     info.size = (size_t)dataSize;
     info.meta = "";
+    LibretroPopulateGameInfoExt(fileData, (size_t)dataSize);
     if (!LibretroCore.retro_load_game(&info)) {
         TraceLog(LOG_ERROR, "LIBRETRO: Failed to load game data with retro_load_game()");
         LibretroCore.loaded = false;
@@ -1986,10 +2038,11 @@ static bool LoadLibretroGame(const char* gameFile) {
         info.size = 0;
         info.path = NULL;
         info.meta = "";
+        LibretroCore.contentPath[0] = '\0';
+        LibretroPopulateGameInfoExt(NULL, 0);
         if (LibretroCore.retro_load_game(&info)) {
             TraceLog(LOG_INFO, "LIBRETRO: Loaded without content");
             LibretroCore.loaded = true;
-            LibretroCore.contentPath[0] = '\0';
             return LibretroInitAudioVideo();
         }
         TraceLog(LOG_ERROR, "LIBRETRO: Failed to load core without content");
@@ -2009,15 +2062,18 @@ static bool LoadLibretroGame(const char* gameFile) {
         info.data = NULL;
         info.size = 0;
         info.path = gameFile;
+        TextCopy(LibretroCore.contentPath, gameFile);
+        LibretroPopulateGameInfoExt(NULL, 0);
         if (LibretroCore.retro_load_game(&info)) {
             TraceLog(LOG_INFO, "LIBRETRO: Loaded content with full path");
             LibretroCore.loaded = true;
-            TextCopy(LibretroCore.contentPath, gameFile);
             return LibretroInitAudioVideo();
         }
         else {
             TraceLog(LOG_ERROR, "LIBRETRO: Failed to load full path");
             LibretroCore.loaded = false;
+            LibretroCore.contentPath[0] = '\0';
+            LibretroCore.gameInfoExtValid = false;
             return false;
         }
     }
@@ -2317,6 +2373,8 @@ static void UnloadLibretroGame() {
     LibretroCore.retro_run = NULL;
     LibretroCore.loaded = false;
     LibretroCore.contentPath[0] = '\0';
+    LibretroCore.gameInfoExtValid = false;
+    memset(&LibretroCore.gameInfoExt, 0, sizeof(LibretroCore.gameInfoExt));
 }
 
 /**


### PR DESCRIPTION
Closes #106

Scans the cores directory on startup, peeks each core via `retro_get_system_info()` to read `valid_extensions`, and caches the results in `raylib-libretro.cfg` under `[core_cache]`. Cache is invalidated when the core directory file count changes. When a game file is passed on the command line without a core, `FindCoreForGame()` matches the file extension against the cache and auto-loads the matching core.