### PR TITLE
cmake: fix Mac framework linking errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,3 @@ if(BUILD_RAYLIB_LIBRETRO)
     add_subdirectory(bin)
 endif()
 
-# OSX
-if (APPLE)
-    target_link_libraries(${PROJECT_NAME} "-framework IOKit")
-    target_link_libraries(${PROJECT_NAME} "-framework Cocoa")
-    target_link_libraries(${PROJECT_NAME} "-framework OpenGL")
-endif()

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -82,6 +82,11 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
         )
     endif()
 elseif (APPLE)
+    target_link_libraries(raylib-libretro PUBLIC
+        "-framework IOKit"
+        "-framework Cocoa"
+        "-framework OpenGL"
+    )
     if (CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
         download_cores(
             "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/fceumm_libretro.dylib.zip"


### PR DESCRIPTION
Moves the Apple framework target_link_libraries calls from the root CMakeLists.txt into bin/CMakeLists.txt where the target is defined, resolving the mixed keyword/plain signature error and CMP0079 policy violation. Fixes #119