### PR TITLE
cmake: stop shipping include and lib in releases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if (NOT raylib_FOUND)
     set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
     set(BUILD_GAMES    OFF CACHE BOOL "" FORCE)
     set(BUILD_TESTING  OFF CACHE BOOL "" FORCE)
-    add_subdirectory(vendor/raylib vendor/raylib)
+    add_subdirectory(vendor/raylib vendor/raylib EXCLUDE_FROM_ALL)
 endif()
 
 add_subdirectory(include)


### PR DESCRIPTION
Adds EXCLUDE_FROM_ALL to the vendor/raylib add_subdirectory call so raylib's install rules (which write to include/ and lib/) are skipped during cmake --install, while raylib still builds correctly as a dependency. Fixes #118