### PR TITLE
Implement RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE

### DIFF
--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -570,9 +570,6 @@ static void LibretroPerfLog() {
 }
 
 static bool LibretroSetRumbleState(unsigned port, enum retro_rumble_effect effect, uint16_t strength) {
-    if (port >= 4) {
-        return false;
-    }
     float normalized = (float)strength / 65535.0f;
     if (effect == RETRO_RUMBLE_STRONG) {
         LibretroCore.rumbleStrong[port] = normalized;

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -288,6 +288,10 @@ typedef struct rLibretro {
     char systemDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char playlistsDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char fileBrowserStartDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+
+    // Rumble state per port (RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE)
+    float rumbleStrong[4];
+    float rumbleWeak[4];
 } rLibretro;
 
 #if defined(__cplusplus)
@@ -565,6 +569,20 @@ static void LibretroPerfLog() {
     TraceLog(LOG_INFO, "LIBRETRO: Timer %s: %i - %i", LibretroCore.perf_counter_last->ident, LibretroCore.perf_counter_last->start, LibretroCore.perf_counter_last->total);
 }
 
+static bool LibretroSetRumbleState(unsigned port, enum retro_rumble_effect effect, uint16_t strength) {
+    if (port >= 4) {
+        return false;
+    }
+    float normalized = (float)strength / 65535.0f;
+    if (effect == RETRO_RUMBLE_STRONG) {
+        LibretroCore.rumbleStrong[port] = normalized;
+    } else {
+        LibretroCore.rumbleWeak[port] = normalized;
+    }
+    SetGamepadVibration((int)port, LibretroCore.rumbleStrong[port], LibretroCore.rumbleWeak[port], 3600.0f);
+    return true;
+}
+
 static bool LibretroSetEnvironment(unsigned cmd, void * data) {
     switch (cmd) {
         case RETRO_ENVIRONMENT_SET_ROTATION: {
@@ -817,8 +835,11 @@ static bool LibretroSetEnvironment(unsigned cmd, void * data) {
         }
 
         case RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE: {
-            TraceLog(LOG_WARNING, "LIBRETRO: RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE not implemented");
-            return false;
+            struct retro_rumble_interface *rumble = (struct retro_rumble_interface*)data;
+            if (rumble != NULL) {
+                rumble->set_rumble_state = LibretroSetRumbleState;
+            }
+            return true;
         }
 
         case RETRO_ENVIRONMENT_GET_INPUT_DEVICE_CAPABILITIES: {

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -139,6 +139,9 @@ static int LibretroMapRetroLogLevelToTraceLogType(int level);
 // Shared config file used by SaveLibretroCoreOptions / LoadLibretroCoreOptions.
 // Keys are prefixed with the core name: "CoreName.key=value"
 #define RAYLIB_LIBRETRO_CFG_FILE "raylib-libretro.cfg"
+/**
+ * The amount of controller ports with rumble support.
+ */
 #define RAYLIB_LIBRETRO_RUMBLE_PORTS 4
 
 // Dynamic loading methods.

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -570,6 +570,9 @@ static void LibretroPerfLog() {
 }
 
 static bool LibretroSetRumbleState(unsigned port, enum retro_rumble_effect effect, uint16_t strength) {
+    if (port >= 4) {
+        return false;
+    }
     float normalized = (float)strength / 65535.0f;
     if (effect == RETRO_RUMBLE_STRONG) {
         LibretroCore.rumbleStrong[port] = normalized;

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -139,6 +139,7 @@ static int LibretroMapRetroLogLevelToTraceLogType(int level);
 // Shared config file used by SaveLibretroCoreOptions / LoadLibretroCoreOptions.
 // Keys are prefixed with the core name: "CoreName.key=value"
 #define RAYLIB_LIBRETRO_CFG_FILE "raylib-libretro.cfg"
+#define RAYLIB_LIBRETRO_RUMBLE_PORTS 4
 
 // Dynamic loading methods.
 #define LoadLibretroMethodHandle(V, S) do {\
@@ -289,9 +290,8 @@ typedef struct rLibretro {
     char playlistsDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char fileBrowserStartDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
 
-    // Rumble state per port (RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE)
-    float rumbleStrong[4];
-    float rumbleWeak[4];
+    float rumbleStrong[RAYLIB_LIBRETRO_RUMBLE_PORTS];
+    float rumbleWeak[RAYLIB_LIBRETRO_RUMBLE_PORTS];
 } rLibretro;
 
 #if defined(__cplusplus)
@@ -570,7 +570,7 @@ static void LibretroPerfLog() {
 }
 
 static bool LibretroSetRumbleState(unsigned port, enum retro_rumble_effect effect, uint16_t strength) {
-    if (port >= 4) {
+    if (port >= RAYLIB_LIBRETRO_RUMBLE_PORTS) {
         return false;
     }
     float normalized = (float)strength / 65535.0f;
@@ -836,9 +836,10 @@ static bool LibretroSetEnvironment(unsigned cmd, void * data) {
 
         case RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE: {
             struct retro_rumble_interface *rumble = (struct retro_rumble_interface*)data;
-            if (rumble != NULL) {
-                rumble->set_rumble_state = LibretroSetRumbleState;
+            if (rumble == NULL) {
+                return false;
             }
+            rumble->set_rumble_state = LibretroSetRumbleState;
             return true;
         }
 


### PR DESCRIPTION
Wires up retro_rumble_interface::set_rumble_state to SetGamepadVibration, tracking per-port strong/weak motor state so both motors can be set independently. Fixes #108