### PR TITLE
Expose GetLibretroFPS() and GetLibretroAspectRatio()

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ const char* GetLibretroVersion();
 unsigned GetLibretroWidth();
 unsigned GetLibretroHeight();
 unsigned GetLibretroRotation();
+double GetLibretroFPS();
+float GetLibretroAspectRatio();
 Texture2D GetLibretroTexture();
 bool IsLibretroGameRequired();
 void ResetLibretro();

--- a/example/raylib-libretro-basic.c
+++ b/example/raylib-libretro-basic.c
@@ -61,6 +61,10 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // Match the window's refresh rate to the core's target FPS.
+    SetTargetFPS((int)GetLibretroFPS());
+    TraceLog(LOG_INFO, "LIBRETRO: Core FPS=%.2f AspectRatio=%.4f", GetLibretroFPS(), (double)GetLibretroAspectRatio());
+
     while (!WindowShouldClose() && !LibretroShouldClose()) {
         // Run a frame of the core.
         UpdateLibretro();

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -69,6 +69,8 @@ static const char* GetLibretroVersion(void);                 // Get the version 
 static unsigned GetLibretroWidth(void);                      // Get the desired width of the libretro core.
 static unsigned GetLibretroHeight(void);                     // Get the desired height of the libretro core.
 static unsigned GetLibretroRotation(void);                   // Get the current screen rotation (0=0°, 1=90°, 2=180°, 3=270°).
+static double GetLibretroFPS(void);                          // Get the target refresh rate reported by the core (default 60.0 if unavailable).
+static float GetLibretroAspectRatio(void);                   // Get the intended display aspect ratio reported by the core (0.0 if unavailable).
 static Texture2D GetLibretroTexture(void);                   // Retrieve the texture used to render the libretro state.
 static bool IsLibretroGameRequired(void);               // Determine whether or not the loaded core require content.
 static void ResetLibretro(void);                             // Reset the currently loaded libretro core.
@@ -2660,6 +2662,14 @@ static unsigned GetLibretroWidth(void) {
 }
 static unsigned GetLibretroHeight(void) {
     return LibretroCore.height;
+}
+
+static double GetLibretroFPS(void) {
+    return LibretroCore.fps > 0 ? (double)LibretroCore.fps : 60.0;
+}
+
+static float GetLibretroAspectRatio(void) {
+    return LibretroCore.aspectRatio;
 }
 
 static Texture2D GetLibretroTexture(void) {


### PR DESCRIPTION
Adds `GetLibretroFPS()` (returns the core's target refresh rate, defaulting to 60.0) and `GetLibretroAspectRatio()` (returns the intended display aspect ratio) to the public API. Both are declared in the header and documented in the README quick reference. The example now calls both after loading a game to set the window FPS and log the values.

Fixes #129