### PR TITLE
Add --help flag and fix CLI usage docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,13 +185,13 @@ CMake first calls `find_package(raylib QUIET)`. If not found on the system, it f
 
 ```sh
 # General usage
-raylib-libretro <core.so> [game_file]
+raylib-libretro [-L <core>] [game]
 
 # Linux example
-bin/raylib-libretro ~/.config/retroarch/cores/fceumm_libretro.so smb.nes
+bin/raylib-libretro -L ~/.config/retroarch/cores/fceumm_libretro.so smb.nes
 
 # macOS example
-bin/raylib-libretro ~/Library/Application\ Support/RetroArch/cores/fceumm_libretro.dylib smb.nes
+bin/raylib-libretro -L ~/Library/Application\ Support/RetroArch/cores/fceumm_libretro.dylib smb.nes
 ```
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 ## Usage
 
 ``` sh
-raylib-libretro [game] -L [core]
+raylib-libretro [-L <core>] [game]
 ```
 
 - `[game]` can be a loose ROM file or a `.zip` archive
-- `[core]` is optional, and is a path to which libretro core to use
+- `-L <core>` is optional — path to the libretro core (`.so`/`.dll`/`.dylib`)
 
 ### Example
 ```

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -175,7 +175,17 @@ bool Init(void** userData, int argc, char** argv) {
     const char* corePath = NULL;
     const char* gameFile = NULL;
     for (int i = 1; i < argc; i++) {
-        if ((TextIsEqual(argv[i], "-L") || TextIsEqual(argv[i], "--libretro")) && i + 1 < argc) {
+        if (TextIsEqual(argv[i], "-h") || TextIsEqual(argv[i], "--help")) {
+            printf("Usage: %s [-L <core>] [game]\n\n", argv[0]);
+            printf("Options:\n");
+            printf("  -L, --libretro <core>   Path to the libretro core (.so/.dll/.dylib)\n");
+            printf("  -h, --help              Show this help message\n\n");
+            printf("Examples:\n");
+            printf("  %s -L fceumm_libretro.so smb.nes\n", argv[0]);
+            printf("  %s -L fceumm_libretro.so smb.zip\n", argv[0]);
+            printf("  %s smb.nes\n", argv[0]);
+            return false;
+        } else if ((TextIsEqual(argv[i], "-L") || TextIsEqual(argv[i], "--libretro")) && i + 1 < argc) {
             corePath = argv[++i];
         } else if (!gameFile) {
             gameFile = argv[i];


### PR DESCRIPTION
Picks a canonical usage form `raylib-libretro [-L <core>] [game]`, updates README and CLAUDE.md to match, and adds `-h`/`--help` support to the binary. Fixes #127