### PR TITLE
Add Reset Game menu button

### DIFF
--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -63,6 +63,7 @@ typedef struct LibretroMenu {
     nk_console* saveStateButton;
     nk_console* loadStateButton;
     nk_console* resumeButton;
+    nk_console* resetGameButton;
     //nk_console* closeGameButton;
     int shaderSelectedIndex;
     int textureFilterIndex;
@@ -309,6 +310,14 @@ static void MenuResumeClicked(nk_console* widget, void* user_data) {
     if (IsLibretroGameReady()) {
         menu.active = false;
     }
+}
+
+static void MenuResetGameClicked(nk_console* widget, void* user_data) {
+    NK_UNUSED(widget);
+    NK_UNUSED(user_data);
+    if (!IsLibretroGameReady()) return;
+    ResetLibretro();
+    menu.active = false;
 }
 
 // Fired when the user navigates back from Settings or Core Options. This is
@@ -782,6 +791,10 @@ LibretroMenu* InitLibretroMenu(void) {
         nk_console_button_set_symbol(menu.loadStateButton, NK_SYMBOL_RECT_OUTLINE);
         nk_console_row_end(saveStateRow);
     }
+
+    // Reset Game
+    menu.resetGameButton = nk_console_button_onclick(menu.console, "Reset Game", &MenuResetGameClicked);
+    nk_console_button_set_symbol(menu.resetGameButton, NK_SYMBOL_CIRCLE_SOLID);
 
     // Load Game
     menu.loadGameWidget = nk_console_file_action(menu.console, "Load Game", menu.loadGamePath, RAYLIB_LIBRETRO_VFS_MAX_PATH);
@@ -1357,6 +1370,7 @@ static void UpdateLibretroMenuVisibility(void) {
     }
     //if (menu.loadStateButton) menu.loadStateButton->visible = gameReady;
     if (menu.resumeButton) menu.resumeButton->visible = gameReady;
+    if (menu.resetGameButton) menu.resetGameButton->visible = gameReady;
     //if (menu.closeGameButton) menu.closeGameButton->visible = gameReady;
 }
 


### PR DESCRIPTION
Adds a Reset Game button to the menu that calls `ResetLibretro()` and closes the menu. The button is only visible when a game is currently loaded, matching the same visibility logic as Resume and Save/Load State.

Fixes #164