### PR TITLE
Hide window title in sub-menus

### DIFF
--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -1424,9 +1424,11 @@ void UpdateLibretroMenu(void) {
     nk_gamepad_update(nk_console_get_gamepads(menu.console));
     UpdateNuklear(menu.ctx);
 
-    // Render
+    // Render — only show the window title bar when at the top-level menu.
     struct nk_rect windowPos = nk_rect(0, 0, (float)GetScreenWidth()/scaling, (float)GetScreenHeight()/scaling);
-    nk_console_render_window(menu.console, "raylib-libretro", windowPos, NK_WINDOW_SCROLL_AUTO_HIDE | NK_WINDOW_TITLE);
+    nk_bool atTopLevel = (nk_console_active_parent(menu.console) == menu.console);
+    nk_uint windowFlags = NK_WINDOW_SCROLL_AUTO_HIDE | (atTopLevel ? NK_WINDOW_TITLE : 0);
+    nk_console_render_window(menu.console, "raylib-libretro", windowPos, windowFlags);
 }
 
 void DrawLibretroMenu(void) {

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -1424,7 +1424,7 @@ void UpdateLibretroMenu(void) {
     nk_gamepad_update(nk_console_get_gamepads(menu.console));
     UpdateNuklear(menu.ctx);
 
-    // Render — only show the window title bar when at the top-level menu.
+    // Render
     struct nk_rect windowPos = nk_rect(0, 0, (float)GetScreenWidth()/scaling, (float)GetScreenHeight()/scaling);
     nk_bool atTopLevel = (nk_console_active_parent(menu.console) == menu.console);
     nk_uint windowFlags = NK_WINDOW_SCROLL_AUTO_HIDE | (atTopLevel ? NK_WINDOW_TITLE : 0);

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -1426,10 +1426,10 @@ void UpdateLibretroMenu(void) {
 
     // Render
     struct nk_rect windowPos = nk_rect(0, 0, (float)GetScreenWidth()/scaling, (float)GetScreenHeight()/scaling);
-    nk_uint windowFlags = NK_WINDOW_SCROLL_AUTO_HIDE |
+    nk_console_render_window(menu.console, "raylib-libretro", windowPos,
+        NK_WINDOW_SCROLL_AUTO_HIDE |
         // Show the window title only on the top level.
-        ((nk_console_active_parent(menu.console) == menu.console) ? NK_WINDOW_TITLE : 0);
-    nk_console_render_window(menu.console, "raylib-libretro", windowPos, windowFlags);
+        ((nk_console_active_parent(menu.console) == menu.console) ? NK_WINDOW_TITLE : 0));
 }
 
 void DrawLibretroMenu(void) {

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -1426,8 +1426,9 @@ void UpdateLibretroMenu(void) {
 
     // Render
     struct nk_rect windowPos = nk_rect(0, 0, (float)GetScreenWidth()/scaling, (float)GetScreenHeight()/scaling);
-    nk_bool atTopLevel = (nk_console_active_parent(menu.console) == menu.console);
-    nk_uint windowFlags = NK_WINDOW_SCROLL_AUTO_HIDE | (atTopLevel ? NK_WINDOW_TITLE : 0);
+    nk_uint windowFlags = NK_WINDOW_SCROLL_AUTO_HIDE |
+        // Show the window title only on the top level.
+        ((nk_console_active_parent(menu.console) == menu.console) ? NK_WINDOW_TITLE : 0);
     nk_console_render_window(menu.console, "raylib-libretro", windowPos, windowFlags);
 }
 


### PR DESCRIPTION
The window title bar is now only shown when the menu is at the top level. When navigating into a sub-menu (Settings, Core Options, etc.), the title is hidden to give more space to the sub-menu content.

Fixes #162