### PR TITLE
Add Dynamic Rate Control (DRC) for audio/video sync

### DIFF
--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -101,6 +101,7 @@ typedef struct LibretroMenu {
     char loadGamePath[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     bool touchControls;
     bool touchHapticsEnabled;
+    bool drcEnabled;
     nk_rune keyboardP1[16]; // Indexed by RETRO_DEVICE_ID_JOYPAD_*
 #ifdef RAYLIB_LIBRETRO_CONFIG_H
     RLibretroConfig* cfg;                 // persistent config, owned for the lifetime of the menu
@@ -194,6 +195,7 @@ static void LibretroMenuSettingChanged(nk_console* widget, void* user_data) {
     SetActiveLibretroShader((LibretroShaderType)menu.shaderSelectedIndex);
     SetLibretroMenuStyle((LibretroMenuStyle)menu.themeSelectedIndex);
     SetLibretroVolume(menu.volumeSelected);
+    SetLibretroDynamicRateControl(menu.drcEnabled);
     if (LibretroCore.textureFilter != menu.textureFilterIndex) {
         LibretroCore.textureFilter = menu.textureFilterIndex;
         InitLibretroVideo();
@@ -861,6 +863,13 @@ LibretroMenu* InitLibretroMenu(void) {
         nk_console_checkbox(settings, "Touch Controls", &menu.touchControls);
         nk_console_checkbox(settings, "Touch Haptics", &menu.touchHapticsEnabled);
 
+        // Dynamic Rate Control
+        {
+            nk_console* drc = nk_console_checkbox(settings, "Dynamic Rate Control", &menu.drcEnabled);
+            nk_console_set_tooltip(drc, "Adjust audio pitch to keep audio/video in sync");
+            nk_console_add_event_handler(drc, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+        }
+
         // Rewind
         nk_console* rewind = nk_console_checkbox(settings, "Rewind", &menu.rewindEnabled);
 
@@ -1112,6 +1121,7 @@ static void LibretroMenuUpdateConfig(void) {
     rlconfig_set_int(menu.cfg, "raylib-libretro", "rewind", menu.rewindEnabled ? 1 : 0);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "touchControls", menu.touchControls ? 1 : 0);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "touchHaptics", menu.touchHapticsEnabled ? 1 : 0);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "drc", menu.drcEnabled ? 1 : 0);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "keyScreenshot", (int)menu.keyScreenshot);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "keyRewind", (int)menu.keyRewind);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "keyMenu", (int)menu.keyMenu);
@@ -1251,6 +1261,8 @@ static bool LoadLibretroMenuSettings(void) {
     SetLibretroVolume(menu.volumeSelected);
 
     menu.rewindEnabled = rlconfig_get_int(menu.cfg, "raylib-libretro", "rewind", 0) > 0;
+    menu.drcEnabled = rlconfig_get_int(menu.cfg, "raylib-libretro", "drc", 1) > 0;
+    SetLibretroDynamicRateControl(menu.drcEnabled);
 #if defined(PLATFORM_WEB)
     menu.touchControls = rlconfig_get_int(menu.cfg, "raylib-libretro", "touchControls", 1) > 0;
 #else

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -101,7 +101,6 @@ typedef struct LibretroMenu {
     char loadGamePath[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     bool touchControls;
     bool touchHapticsEnabled;
-    bool drcEnabled;
     nk_rune keyboardP1[16]; // Indexed by RETRO_DEVICE_ID_JOYPAD_*
 #ifdef RAYLIB_LIBRETRO_CONFIG_H
     RLibretroConfig* cfg;                 // persistent config, owned for the lifetime of the menu
@@ -195,7 +194,6 @@ static void LibretroMenuSettingChanged(nk_console* widget, void* user_data) {
     SetActiveLibretroShader((LibretroShaderType)menu.shaderSelectedIndex);
     SetLibretroMenuStyle((LibretroMenuStyle)menu.themeSelectedIndex);
     SetLibretroVolume(menu.volumeSelected);
-    SetLibretroDynamicRateControl(menu.drcEnabled);
     if (LibretroCore.textureFilter != menu.textureFilterIndex) {
         LibretroCore.textureFilter = menu.textureFilterIndex;
         InitLibretroVideo();
@@ -863,13 +861,6 @@ LibretroMenu* InitLibretroMenu(void) {
         nk_console_checkbox(settings, "Touch Controls", &menu.touchControls);
         nk_console_checkbox(settings, "Touch Haptics", &menu.touchHapticsEnabled);
 
-        // Dynamic Rate Control
-        {
-            nk_console* drc = nk_console_checkbox(settings, "Dynamic Rate Control", &menu.drcEnabled);
-            nk_console_set_tooltip(drc, "Adjust audio pitch to keep audio/video in sync");
-            nk_console_add_event_handler(drc, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
-        }
-
         // Rewind
         nk_console* rewind = nk_console_checkbox(settings, "Rewind", &menu.rewindEnabled);
 
@@ -1121,7 +1112,6 @@ static void LibretroMenuUpdateConfig(void) {
     rlconfig_set_int(menu.cfg, "raylib-libretro", "rewind", menu.rewindEnabled ? 1 : 0);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "touchControls", menu.touchControls ? 1 : 0);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "touchHaptics", menu.touchHapticsEnabled ? 1 : 0);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "drc", menu.drcEnabled ? 1 : 0);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "keyScreenshot", (int)menu.keyScreenshot);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "keyRewind", (int)menu.keyRewind);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "keyMenu", (int)menu.keyMenu);
@@ -1261,8 +1251,6 @@ static bool LoadLibretroMenuSettings(void) {
     SetLibretroVolume(menu.volumeSelected);
 
     menu.rewindEnabled = rlconfig_get_int(menu.cfg, "raylib-libretro", "rewind", 0) > 0;
-    menu.drcEnabled = rlconfig_get_int(menu.cfg, "raylib-libretro", "drc", 1) > 0;
-    SetLibretroDynamicRateControl(menu.drcEnabled);
 #if defined(PLATFORM_WEB)
     menu.touchControls = rlconfig_get_int(menu.cfg, "raylib-libretro", "touchControls", 1) > 0;
 #else

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -74,6 +74,8 @@ static bool IsLibretroGameRequired(void);               // Determine whether or 
 static void ResetLibretro(void);                             // Reset the currently loaded libretro core.
 static void UnloadLibretroGame(void);                        // Unload the game that's currently loaded.
 static void CloseLibretro(void);                             // Close the initialized libretro core.
+static void SetLibretroDynamicRateControl(bool enabled); // Enable or disable Dynamic Rate Control (DRC) for audio/video sync.
+static bool IsLibretroDynamicRateControlEnabled(void);   // Check whether Dynamic Rate Control is currently enabled.
 static void SetLibretroVolume(float volume);             // Set the audio volume (0.0 - 1.0).
 static float GetLibretroVolume(void);                        // Get the current audio volume.
 static void SetLibretroSpeed(float speed);               // Set playback speed (1.0 = normal, >1.0 = fast-forward, <1.0 = slow-motion).
@@ -241,6 +243,8 @@ typedef struct rLibretro {
     size_t audioRingAvailable;
     unsigned minimumAudioLatencyMs; // RETRO_ENVIRONMENT_SET_MINIMUM_AUDIO_LATENCY
     struct retro_audio_buffer_status_callback audio_buffer_status_callback; // RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK
+    float drcAdjustment;  // DRC pitch multiplier, clamped to [0.995, 1.005]
+    bool drcEnabled;      // Whether Dynamic Rate Control is active
 
     // Callbacks
     retro_keyboard_event_t keyboard_event;
@@ -1741,6 +1745,16 @@ static void UpdateLibretro(void) {
 
         LibretroCore.retro_run();
 
+        // Dynamic Rate Control: nudge audio pitch to steer ring-buffer occupancy
+        // toward 50 % so the host soundcard and emulated clock stay in sync.
+        if (LibretroCore.drcEnabled && LibretroCore.audioRingBufferSize > 0 && IsAudioStreamValid(LibretroCore.audioStream)) {
+            float drift = 0.5f - ((float)LibretroCore.audioRingAvailable / (float)LibretroCore.audioRingBufferSize);
+            LibretroCore.drcAdjustment += drift * 0.0001f;
+            if (LibretroCore.drcAdjustment < 0.995f) LibretroCore.drcAdjustment = 0.995f;
+            if (LibretroCore.drcAdjustment > 1.005f) LibretroCore.drcAdjustment = 1.005f;
+            SetAudioStreamPitch(LibretroCore.audioStream, LibretroCore.drcAdjustment);
+        }
+
         // Some cores (notably mgba GB/GBC) defer the actual core reset until
         // the first retro_run, so retro_get_system_av_info called pre-run
         // returns sample_rate=0. Once we have a frame, re-query AV info and
@@ -2178,6 +2192,7 @@ static void InitLibretroAudio(void) {
     LibretroCore.audioStream = LoadAudioStream((unsigned int)LibretroCore.sampleRate, sampleSize, channels);
     SetAudioStreamCallback(LibretroCore.audioStream, LibretroAudioStreamCallback);
     SetAudioStreamVolume(LibretroCore.audioStream, LibretroCore.volume);
+    LibretroCore.drcAdjustment = 1.0f;
     PlayAudioStream(LibretroCore.audioStream);
 
     // Let the core know that the audio device has been initialized.
@@ -2741,6 +2756,18 @@ static void SetLibretroSpeed(float speed) {
 
 static float GetLibretroSpeed(void) {
     return LibretroCore.speed;
+}
+
+static void SetLibretroDynamicRateControl(bool enabled) {
+    LibretroCore.drcEnabled = enabled;
+    if (!enabled && IsAudioStreamValid(LibretroCore.audioStream)) {
+        LibretroCore.drcAdjustment = 1.0f;
+        SetAudioStreamPitch(LibretroCore.audioStream, 1.0f);
+    }
+}
+
+static bool IsLibretroDynamicRateControlEnabled(void) {
+    return LibretroCore.drcEnabled;
 }
 
 static unsigned GetLibretroRotation(void) {

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -2855,6 +2855,13 @@ static float GetLibretroSpeed(void) {
     return LibretroCore.speed;
 }
 
+/**
+ * Enable or disable Dynamic Rate Control (DRC). When enabled, the audio
+ * stream pitch is nudged up or down (within ±0.5 %) to drain the ring
+ * buffer at exactly the rate it is filled, keeping audio and video in sync.
+ *
+ * @param enabled true to enable DRC, false to disable and restore unity pitch.
+ */
 static void SetLibretroDynamicRateControl(bool enabled) {
     LibretroCore.drcEnabled = enabled;
     if (!enabled && IsAudioStreamValid(LibretroCore.audioStream)) {
@@ -2863,6 +2870,11 @@ static void SetLibretroDynamicRateControl(bool enabled) {
     }
 }
 
+/**
+ * Query whether Dynamic Rate Control is currently active.
+ *
+ * @return true if DRC is enabled, false otherwise.
+ */
 static bool IsLibretroDynamicRateControlEnabled(void) {
     return LibretroCore.drcEnabled;
 }
@@ -3047,6 +3059,8 @@ static void LibretroResetCoreState(void) {
 
     memset(LibretroCore.osdMessage, 0, sizeof(LibretroCore.osdMessage));
     LibretroCore.osdEndTime = 0.0;
+
+    LibretroCore.drcAdjustment = 1.0f;
 
     UnloadLibretroMemoryMaps();
 }

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -561,6 +561,7 @@ static void LibretroLogger(enum retro_log_level level, const char *fmt, ...) {
 }
 
 static void InitLibretroAudio(void);  // Forward declaration.
+static size_t LibretroAudioSampleBatch(const int16_t *data, size_t frames);  // Forward declaration.
 
 static void CloseLibretroVideo(void) {
     // Unload the existing texture if it exists already.
@@ -1414,7 +1415,6 @@ static bool LibretroSetEnvironment(unsigned cmd, void * data) {
         }
 
         case RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK: {
-            // NULL data is the core asking to disable buffer-status reporting.
             if (data == NULL) {
                 LibretroCore.audio_buffer_status_callback.callback = NULL;
                 TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK disabled");
@@ -1772,11 +1772,20 @@ static void UpdateLibretro(void) {
 
         LibretroCore.retro_run();
 
+        // Flush any single-sample accumulator left over from retro_run so
+        // samples arrive in the ring buffer within the same frame.
+        if (LibretroCore.singleSampleCount > 0) {
+            LibretroAudioSampleBatch(LibretroCore.singleSampleBuffer, LibretroCore.singleSampleCount);
+            LibretroCore.singleSampleCount = 0;
+        }
+
         // Dynamic Rate Control: nudge audio pitch to steer ring-buffer occupancy
-        // toward 50 % so the host soundcard and emulated clock stay in sync.
+        // toward 50% so the audio stays in sync.
         if (LibretroCore.drcEnabled && LibretroCore.audioRingBufferSize > 0 && IsAudioStreamValid(LibretroCore.audioStream)) {
-            float drift = 0.5f - ((float)LibretroCore.audioRingAvailable / (float)LibretroCore.audioRingBufferSize);
-            LibretroCore.drcAdjustment += drift * 0.0001f;
+            // Positive drift when buffer is full (consume faster).
+            // Negative drift when buffer is empty (consume slower).
+            float drift = ((float)LibretroCore.audioRingAvailable / (float)LibretroCore.audioRingBufferSize) - 0.5f;
+            LibretroCore.drcAdjustment += drift * 0.001f;
             if (LibretroCore.drcAdjustment < 0.995f) LibretroCore.drcAdjustment = 0.995f;
             if (LibretroCore.drcAdjustment > 1.005f) LibretroCore.drcAdjustment = 1.005f;
             SetAudioStreamPitch(LibretroCore.audioStream, LibretroCore.drcAdjustment);
@@ -2221,6 +2230,8 @@ static void InitLibretroAudio(void) {
     SetAudioStreamCallback(LibretroCore.audioStream, LibretroAudioStreamCallback);
     SetAudioStreamVolume(LibretroCore.audioStream, LibretroCore.volume);
     LibretroCore.drcAdjustment = 1.0f;
+    LibretroCore.drcEnabled = true;
+    LibretroCore.audioDropWarnCount = 0;
     PlayAudioStream(LibretroCore.audioStream);
 
     // Let the core know that the audio device has been initialized.
@@ -2857,8 +2868,14 @@ static float GetLibretroSpeed(void) {
 
 /**
  * Enable or disable Dynamic Rate Control (DRC). When enabled, the audio
- * stream pitch is nudged up or down (within ±0.5 %) to drain the ring
- * buffer at exactly the rate it is filled, keeping audio and video in sync.
+ * stream pitch is nudged up or down (within ±0.5 %) each frame to steer
+ * ring-buffer occupancy toward 50 %, keeping audio and video in sync.
+ *
+ * DRC is always enabled by default on audio initialisation. It works
+ * alongside RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK: that callback
+ * lets the frontend inform the core of buffer occupancy so the core can
+ * frameskip; DRC simultaneously adjusts pitch for long-term clock alignment.
+ * The two mechanisms are complementary and do not conflict.
  *
  * @param enabled true to enable DRC, false to disable and restore unity pitch.
  */
@@ -3061,6 +3078,7 @@ static void LibretroResetCoreState(void) {
     LibretroCore.osdEndTime = 0.0;
 
     LibretroCore.drcAdjustment = 1.0f;
+    LibretroCore.drcEnabled = true;
 
     UnloadLibretroMemoryMaps();
 }


### PR DESCRIPTION
Implements Dynamic Rate Control to keep audio and video continuously in sync by nudging the audio stream pitch slightly based on ring buffer occupancy. At steady state the pitch adjustment stays within ±0.5 %. DRC can be toggled via `SetLibretroDynamicRateControl(bool)` and queried with `IsLibretroDynamicRateControlEnabled()`.

Fixes #160