### PR TITLE
Default system directory to "system" and create on install

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -283,6 +283,7 @@ install(FILES ../README.md DESTINATION .)
 install(FILES ../LICENSE DESTINATION .)
 install(DIRECTORY "${CORES_DIR}/" DESTINATION cores)
 install(CODE "file(MAKE_DIRECTORY \"\${CMAKE_INSTALL_PREFIX}/saves\")")
+install(CODE "file(MAKE_DIRECTORY \"\${CMAKE_INSTALL_PREFIX}/system\")")
 
 # Web
 if ("${PLATFORM}" STREQUAL "Web")

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -762,12 +762,13 @@ LibretroMenu* InitLibretroMenu(void) {
 #endif
     TextCopy(menu.coreDirectory, "cores");
     TextCopy(menu.saveDirectory, "saves");
+    TextCopy(menu.systemDirectory, "system");
 #ifdef __EMSCRIPTEN__
     // Default save/system directories point at the IDBFS mount so they
     // persist across page reloads. The user can still override via the
     // Settings menu; saved values take precedence on subsequent runs.
     TextCopy(menu.saveDirectory,   "/userdata/saves");
-    if (menu.systemDirectory[0] == '\0') TextCopy(menu.systemDirectory, "/userdata/system");
+    TextCopy(menu.systemDirectory, "/userdata/system");
 #endif
     LoadLibretroMenuSettings();
     LibretroApplyDirectories();


### PR DESCRIPTION
Defaults `systemDirectory` to `"system"` alongside the existing `"cores"` and `"saves"` defaults, and creates the directory on `cmake --install`.

Fixes #171