### PR TITLE
Split rLibretro into rLibretroCore + rLibretro

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Other files include the headers without the `_IMPLEMENTATION` define.
 The library holds all state in a single static global:
 
 ```c
-static rLibretro LibretroCore = {0};
+static LibretroData LIBRETRO = {0};
 ```
 
 There is no explicit context object passed around — all functions operate on this global. This matches raylib's own design pattern.
@@ -77,7 +77,7 @@ There is no explicit context object passed around — all functions operate on t
 Cores (emulators) are shared libraries (`.so`/`.dll`/`.dylib`) loaded at runtime using `dylib.h` from libretro-common. The macro pattern for loading symbols is:
 
 ```c
-#define LoadLibretroMethod(S) LoadLibretroMethodHandle(LibretroCore.S, S)
+#define LoadLibretroMethod(S) LoadLibretroMethodHandle(LIBRETRO.core.S, S)
 ```
 
 ## Core API Lifecycle

--- a/TASKS.md
+++ b/TASKS.md
@@ -7,7 +7,7 @@ A roadmap of some interesting features to consider.
 - [ ] Within raylib-libretro-touch.h, there is a LibretroTouchJoypadGamepad() function. Isn't there a function like this directly withing raylib-libretro.h we could use instead? Would save some function definitions.
 - [ ] Within raylib-libretro-touch.h, there's a LibretroTouchFadeColor() function. Isn't there a raylib function we could use for this instead?
 - [x] Is there a way to have the Emscripten Fullscreen capabilities be handled through the Settings>Graphics>Fullscreen toggle widget?
-- [ ] Anything that should be persistent across LibretroCore loading, move to a Libretro structure instead. This would mean we have two different structures (LibretroCore and Libretro). coreDirectory is an example of a value that should persist across LibretroCore loads. This will make reseting the LibretroCore contents a lot easier since it should be able to just do a memset(0) on the object. The structure names should be "rLibretro", and "rLibretroCore". The objects should be named "Libretro", and "LibretroCore".
+- [x] Anything that should be persistent across LibretroCore loading, move to a Libretro structure instead. Split into `LibretroData` (persistent: directories, volume, speed) and `LibretroCoreData` (per-load state, reset with `memset(0)`). Global renamed to `LIBRETRO`.
 
 ## Project & Documentation
 

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -211,7 +211,7 @@ bool Update(void* userData) {
                 data->pendingMenuOpen = true;
             }
         } else {
-            memset(Libretro.core.virtualJoypadState, 0, sizeof(Libretro.core.virtualJoypadState));
+            memset(LIBRETRO.core.virtualJoypadState, 0, sizeof(LIBRETRO.core.virtualJoypadState));
         }
     }
 

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -211,7 +211,7 @@ bool Update(void* userData) {
                 data->pendingMenuOpen = true;
             }
         } else {
-            memset(LibretroCore.virtualJoypadState, 0, sizeof(LibretroCore.virtualJoypadState));
+            memset(Libretro.core.virtualJoypadState, 0, sizeof(Libretro.core.virtualJoypadState));
         }
     }
 

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -11,7 +11,7 @@
 *
 *   LICENSE: zlib/libpng
 *
-*   rLibretro is licensed under an unmodified zlib/libpng license, which is an OSI-certified,
+*   LibretroData is licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software:
 *
 *   Copyright (c) 2020 Rob Loach (@RobLoach)
@@ -195,8 +195,8 @@ static void LibretroMenuSettingChanged(nk_console* widget, void* user_data) {
     SetActiveLibretroShader((LibretroShaderType)menu.shaderSelectedIndex);
     SetLibretroMenuStyle((LibretroMenuStyle)menu.themeSelectedIndex);
     SetLibretroVolume(menu.volumeSelected);
-    if (Libretro.textureFilter != menu.textureFilterIndex) {
-        Libretro.textureFilter = menu.textureFilterIndex;
+    if (LIBRETRO.textureFilter != menu.textureFilterIndex) {
+        LIBRETRO.textureFilter = menu.textureFilterIndex;
         InitLibretroVideo();
     }
     SetExitKey(NuklearKeyToKeyboardKey(menu.keyQuit));
@@ -361,12 +361,12 @@ static void MenuCommitSettings(nk_console* widget, void* user_data) {
 static void ScanLibretroCoreDirectory(void);
 
 static void LibretroApplyDirectories(void) {
-    TextCopy(Libretro.coreDirectory,            menu.coreDirectory);
-    TextCopy(Libretro.saveDirectory,            menu.saveDirectory);
-    TextCopy(Libretro.coreAssetsDirectory,      menu.coreAssetsDirectory);
-    TextCopy(Libretro.systemDirectory,          menu.systemDirectory);
-    TextCopy(Libretro.playlistsDirectory,       menu.playlistsDirectory);
-    TextCopy(Libretro.fileBrowserStartDirectory, menu.fileBrowserStartDirectory);
+    TextCopy(LIBRETRO.coreDirectory,            menu.coreDirectory);
+    TextCopy(LIBRETRO.saveDirectory,            menu.saveDirectory);
+    TextCopy(LIBRETRO.coreAssetsDirectory,      menu.coreAssetsDirectory);
+    TextCopy(LIBRETRO.systemDirectory,          menu.systemDirectory);
+    TextCopy(LIBRETRO.playlistsDirectory,       menu.playlistsDirectory);
+    TextCopy(LIBRETRO.fileBrowserStartDirectory, menu.fileBrowserStartDirectory);
     if (menu.saveDirectory[0] != '\0' && !DirectoryExists(menu.saveDirectory)) {
         MakeDirectory(menu.saveDirectory);
     }
@@ -445,7 +445,7 @@ static void ScanLibretroCoreDirectory(void) {
     for (unsigned int i = 0; i < files.count; i++) {
         if (!IsLibretroCoreFile(files.paths[i])) continue;
         if (!InitLibretroEx(files.paths[i], true)) continue;
-        if (TextLength(Libretro.core.validExtensions) == 0) {
+        if (TextLength(LIBRETRO.core.validExtensions) == 0) {
             CloseLibretro();
             continue;
         }
@@ -454,8 +454,8 @@ static void ScanLibretroCoreDirectory(void) {
         TextCopy(keyPath, TextFormat("core_%d_path", coreIndex));
         TextCopy(keyExts, TextFormat("core_%d_extensions", coreIndex));
         rlconfig_set(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, keyPath, files.paths[i]);
-        rlconfig_set(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, keyExts, Libretro.core.validExtensions);
-        TraceLog(LOG_INFO, "LIBRETRO: Cached %s (%s)", Libretro.core.libraryName, Libretro.core.validExtensions);
+        rlconfig_set(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, keyExts, LIBRETRO.core.validExtensions);
+        TraceLog(LOG_INFO, "LIBRETRO: Cached %s (%s)", LIBRETRO.core.libraryName, LIBRETRO.core.validExtensions);
         CloseLibretro();
         coreIndex++;
     }
@@ -1030,11 +1030,11 @@ static void LibretroMenuOptionChanged(nk_console* widget, void* user_data) {
     (void)widget;
     unsigned i = (unsigned)(uintptr_t)user_data;
     char value[LIBRETRO_CORE_VARIABLE_VALUE_LEN] = {0};
-    LibretroMenuGetNthToken(Libretro.core.variableValuesList[i],
+    LibretroMenuGetNthToken(LIBRETRO.core.variableValuesList[i],
                             menu.optionSelectedIndices[i],
                             value, LIBRETRO_CORE_VARIABLE_VALUE_LEN);
     if (TextLength(value) > 0) {
-        SetLibretroCoreOption(Libretro.core.variableKeys[i], value);
+        SetLibretroCoreOption(LIBRETRO.core.variableKeys[i], value);
     }
 }
 
@@ -1044,7 +1044,7 @@ static void LibretroMenuOptionCheckboxChanged(nk_console* widget, void* user_dat
     (void)widget;
     unsigned i = (unsigned)(uintptr_t)user_data;
     const char* value = menu.optionCheckboxValues[i] ? "enabled" : "disabled";
-    SetLibretroCoreOption(Libretro.core.variableKeys[i], value);
+    SetLibretroCoreOption(LIBRETRO.core.variableKeys[i], value);
 }
 
 static int LibretroMenuFindTokenIndex(const char* str, const char* value) {
@@ -1077,12 +1077,12 @@ void BuildLibretroMenuOptions(LibretroMenu* m) {
 
     // The menu now reflects the current option set; clear the dirty flag so
     // the lazy-rebuild trigger in UpdateLibretroMenu doesn't fire redundantly.
-    Libretro.core.variablesVisibilityDirty = false;
+    LIBRETRO.core.variablesVisibilityDirty = false;
 
     // Clear any previously built option children and restore Back button
     nk_console_free_children(m->optionsMenu);
 
-    if (Libretro.core.variableCount == 0) {
+    if (LIBRETRO.core.variableCount == 0) {
         m->optionsMenu->visible = nk_false;
         return;
     }
@@ -1091,8 +1091,8 @@ void BuildLibretroMenuOptions(LibretroMenu* m) {
     // (e.g. all hidden by options_update_display_callback), hide the button
     // rather than showing an empty submenu.
     int shownCount = 0;
-    for (unsigned i = 0; i < Libretro.core.variableCount; i++) {
-        if (TextLength(Libretro.core.variableValuesList[i]) > 0 && Libretro.core.variableVisible[i]) {
+    for (unsigned i = 0; i < LIBRETRO.core.variableCount; i++) {
+        if (TextLength(LIBRETRO.core.variableValuesList[i]) > 0 && LIBRETRO.core.variableVisible[i]) {
             shownCount++;
         }
     }
@@ -1107,29 +1107,29 @@ void BuildLibretroMenuOptions(LibretroMenu* m) {
         nk_console_button_onclick(m->optionsMenu, "Core Options", &nk_console_button_back),
         NK_SYMBOL_X);
 
-    for (unsigned i = 0; i < Libretro.core.variableCount; i++) {
-        if (TextLength(Libretro.core.variableValuesList[i]) == 0) continue;
-        if (!Libretro.core.variableVisible[i]) continue;
+    for (unsigned i = 0; i < LIBRETRO.core.variableCount; i++) {
+        if (TextLength(LIBRETRO.core.variableValuesList[i]) == 0) continue;
+        if (!LIBRETRO.core.variableVisible[i]) continue;
 
-        const char* label = TextLength(Libretro.core.variableLabels[i]) > 0
-            ? Libretro.core.variableLabels[i]
-            : Libretro.core.variableKeys[i];
+        const char* label = TextLength(LIBRETRO.core.variableLabels[i]) > 0
+            ? LIBRETRO.core.variableLabels[i]
+            : LIBRETRO.core.variableKeys[i];
 
         nk_console* widget;
 
-        if (LibretroMenuIsEnabledDisabledOption(Libretro.core.variableValuesList[i])) {
-            m->optionCheckboxValues[i] = (nk_bool)TextIsEqual(Libretro.core.variableValues[i], "enabled");
+        if (LibretroMenuIsEnabledDisabledOption(LIBRETRO.core.variableValuesList[i])) {
+            m->optionCheckboxValues[i] = (nk_bool)TextIsEqual(LIBRETRO.core.variableValues[i], "enabled");
             widget = nk_console_checkbox(m->optionsMenu, label, &m->optionCheckboxValues[i]);
             nk_console_add_event_handler(widget, NK_CONSOLE_EVENT_CHANGED,
                                          LibretroMenuOptionCheckboxChanged,
                                          (void*)(uintptr_t)i, NULL);
         } else {
             m->optionSelectedIndices[i] = LibretroMenuFindTokenIndex(
-                Libretro.core.variableValuesList[i], Libretro.core.variableValues[i]);
+                LIBRETRO.core.variableValuesList[i], LIBRETRO.core.variableValues[i]);
 
-            const char* displayStr = TextLength(Libretro.core.variableDisplayList[i]) > 0
-                ? Libretro.core.variableDisplayList[i]
-                : Libretro.core.variableValuesList[i];
+            const char* displayStr = TextLength(LIBRETRO.core.variableDisplayList[i]) > 0
+                ? LIBRETRO.core.variableDisplayList[i]
+                : LIBRETRO.core.variableValuesList[i];
 
             widget = nk_console_combobox(m->optionsMenu, label,
                                          displayStr, '|',
@@ -1139,8 +1139,8 @@ void BuildLibretroMenuOptions(LibretroMenu* m) {
                                          (void*)(uintptr_t)i, NULL);
         }
 
-        if (TextLength(Libretro.core.variableTooltips[i]) > 0) {
-            widget->tooltip = Libretro.core.variableTooltips[i];
+        if (TextLength(LIBRETRO.core.variableTooltips[i]) > 0) {
+            widget->tooltip = LIBRETRO.core.variableTooltips[i];
         }
     }
 }
@@ -1190,7 +1190,7 @@ static void LibretroMenuUpdateConfig(void) {
 
 static void LibretroMenuApplyKeyboardPlayer1(void) {
     for (int i = 0; i < 16; i++) {
-        Libretro.keyboardPlayer1[i] = (int)NuklearKeyToKeyboardKey(menu.keyboardP1[i]);
+        LIBRETRO.keyboardPlayer1[i] = (int)NuklearKeyToKeyboardKey(menu.keyboardP1[i]);
     }
 }
 
@@ -1208,12 +1208,12 @@ static bool SaveLibretroMenuSettings(void) {
 
 static bool SaveLibretroCoreOptions(void) {
 #ifdef RAYLIB_LIBRETRO_CONFIG_H
-    if (!menu.cfg || Libretro.core.variableCount == 0) return false;
-    const char *coreName = Libretro.core.libraryName;
+    if (!menu.cfg || LIBRETRO.core.variableCount == 0) return false;
+    const char *coreName = LIBRETRO.core.libraryName;
     if (!coreName || !coreName[0]) return false;
     rlconfig_clear_section(menu.cfg, coreName);
-    for (unsigned i = 0; i < Libretro.core.variableCount; i++) {
-        rlconfig_set(menu.cfg, coreName, Libretro.core.variableKeys[i], Libretro.core.variableValues[i]);
+    for (unsigned i = 0; i < LIBRETRO.core.variableCount; i++) {
+        rlconfig_set(menu.cfg, coreName, LIBRETRO.core.variableKeys[i], LIBRETRO.core.variableValues[i]);
     }
     bool ok = rlconfig_save(menu.cfg, RAYLIB_LIBRETRO_CFG_FILE);
     TraceLog(LOG_INFO, "LIBRETRO: Saved core options to %s", RAYLIB_LIBRETRO_CFG_FILE);
@@ -1226,12 +1226,12 @@ static bool SaveLibretroCoreOptions(void) {
 bool LoadLibretroCoreOptions(void) {
 #ifdef RAYLIB_LIBRETRO_CONFIG_H
     if (!menu.cfg) return false;
-    const char *coreName = Libretro.core.libraryName;
+    const char *coreName = LIBRETRO.core.libraryName;
     if (!coreName || !coreName[0]) return false;
     int loaded = 0;
-    for (unsigned i = 0; i < Libretro.core.variableCount; i++) {
-        const char *val = rlconfig_get(menu.cfg, coreName, Libretro.core.variableKeys[i]);
-        if (val && SetLibretroCoreOption(Libretro.core.variableKeys[i], val)) loaded++;
+    for (unsigned i = 0; i < LIBRETRO.core.variableCount; i++) {
+        const char *val = rlconfig_get(menu.cfg, coreName, LIBRETRO.core.variableKeys[i]);
+        if (val && SetLibretroCoreOption(LIBRETRO.core.variableKeys[i], val)) loaded++;
     }
     TraceLog(LOG_INFO, "LIBRETRO: Loaded %d core option(s) from %s", loaded, RAYLIB_LIBRETRO_CFG_FILE);
     return loaded > 0;
@@ -1247,11 +1247,11 @@ bool SaveLibretroAllSettings(void) {
 #ifdef RAYLIB_LIBRETRO_CONFIG_H
     if (!menu.cfg) return false;
     LibretroMenuUpdateConfig();
-    const char *coreName = Libretro.core.libraryName;
-    if (coreName && coreName[0] && Libretro.core.variableCount > 0) {
+    const char *coreName = LIBRETRO.core.libraryName;
+    if (coreName && coreName[0] && LIBRETRO.core.variableCount > 0) {
         rlconfig_clear_section(menu.cfg, coreName);
-        for (unsigned i = 0; i < Libretro.core.variableCount; i++) {
-            rlconfig_set(menu.cfg, coreName, Libretro.core.variableKeys[i], Libretro.core.variableValues[i]);
+        for (unsigned i = 0; i < LIBRETRO.core.variableCount; i++) {
+            rlconfig_set(menu.cfg, coreName, LIBRETRO.core.variableKeys[i], LIBRETRO.core.variableValues[i]);
         }
     }
     bool ok = rlconfig_save(menu.cfg, RAYLIB_LIBRETRO_CFG_FILE);
@@ -1289,7 +1289,7 @@ static bool LoadLibretroMenuSettings(void) {
     menu.textureFilterIndex = rlconfig_get_int(menu.cfg, "raylib-libretro", "textureFilter", 0);
     if (menu.textureFilterIndex < 0 || menu.textureFilterIndex > TEXTURE_FILTER_ANISOTROPIC_16X)
         menu.textureFilterIndex = 0;
-    Libretro.textureFilter = menu.textureFilterIndex;
+    LIBRETRO.textureFilter = menu.textureFilterIndex;
 
     menu.themeSelectedIndex = rlconfig_get_int(menu.cfg, "raylib-libretro", "theme", LIBRETRO_MENU_STYLE_DRACULA);
     if (menu.themeSelectedIndex < 0 || menu.themeSelectedIndex >= LIBRETRO_MENU_STYLE_COUNT)
@@ -1410,8 +1410,8 @@ static void UpdateLibretroMenuVisibility(void) {
     // options until visibility is resolved after the first retro_run frame).
     if (menu.optionsMenu && IsLibretroReady()) {
         int visibleOptions = 0;
-        for (unsigned i = 0; i < Libretro.core.variableCount; i++) {
-            if (TextLength(Libretro.core.variableValuesList[i]) > 0 && Libretro.core.variableVisible[i]) {
+        for (unsigned i = 0; i < LIBRETRO.core.variableCount; i++) {
+            if (TextLength(LIBRETRO.core.variableValuesList[i]) > 0 && LIBRETRO.core.variableVisible[i]) {
                 visibleOptions++;
                 break;
             }
@@ -1466,24 +1466,24 @@ void UpdateLibretroMenu(void) {
     //   * library name changed (core swap; same count but different options)
     //   * the menu just transitioned from closed to open (fresh-state guard)
     static unsigned lastBuiltVariableCount = 0;
-    static char lastBuiltCoreName[sizeof(Libretro.core.libraryName)] = {0};
-    bool countChanged = (lastBuiltVariableCount != Libretro.core.variableCount);
-    bool coreChanged  = !TextIsEqual(lastBuiltCoreName, Libretro.core.libraryName);
+    static char lastBuiltCoreName[sizeof(LIBRETRO.core.libraryName)] = {0};
+    bool countChanged = (lastBuiltVariableCount != LIBRETRO.core.variableCount);
+    bool coreChanged  = !TextIsEqual(lastBuiltCoreName, LIBRETRO.core.libraryName);
 
-    if (Libretro.core.variablesVisibilityDirty || countChanged || coreChanged || menuJustOpened) {
+    if (LIBRETRO.core.variablesVisibilityDirty || countChanged || coreChanged || menuJustOpened) {
         // When the menu first opens and the game is running, invoke the display
         // callback to get the latest visibility state. Cores like PicoDrive call
         // SET_CORE_OPTIONS_DISPLAY during retro_load_game to set initial
         // visibility, but the callback may resolve it differently after the
         // first retro_run frame. Invoking it here ensures the menu always opens
         // with up-to-date option visibility even if no frames have run yet.
-        if (menuJustOpened && Libretro.core.options_update_display_callback && IsLibretroGameReady()) {
-            Libretro.core.options_update_display_callback();
+        if (menuJustOpened && LIBRETRO.core.options_update_display_callback && IsLibretroGameReady()) {
+            LIBRETRO.core.options_update_display_callback();
         }
         BuildLibretroMenuOptions(&menu);
-        Libretro.core.variablesVisibilityDirty = false;
-        lastBuiltVariableCount = Libretro.core.variableCount;
-        TextCopy(lastBuiltCoreName, Libretro.core.libraryName);
+        LIBRETRO.core.variablesVisibilityDirty = false;
+        lastBuiltVariableCount = LIBRETRO.core.variableCount;
+        TextCopy(lastBuiltCoreName, LIBRETRO.core.libraryName);
     }
 
     UpdateLibretroMenuVisibility();

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -445,7 +445,10 @@ static void ScanLibretroCoreDirectory(void) {
     for (unsigned int i = 0; i < files.count; i++) {
         if (!IsLibretroCoreFile(files.paths[i])) continue;
         if (!InitLibretroEx(files.paths[i], true)) continue;
-        if (TextLength(Libretro.core.validExtensions) == 0) continue;
+        if (TextLength(Libretro.core.validExtensions) == 0) {
+            CloseLibretro();
+            continue;
+        }
 
         char keyPath[64], keyExts[64];
         TextCopy(keyPath, TextFormat("core_%d_path", coreIndex));
@@ -453,6 +456,7 @@ static void ScanLibretroCoreDirectory(void) {
         rlconfig_set(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, keyPath, files.paths[i]);
         rlconfig_set(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, keyExts, Libretro.core.validExtensions);
         TraceLog(LOG_INFO, "LIBRETRO: Cached %s (%s)", Libretro.core.libraryName, Libretro.core.validExtensions);
+        CloseLibretro();
         coreIndex++;
     }
     UnloadDirectoryFiles(files);

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -195,8 +195,8 @@ static void LibretroMenuSettingChanged(nk_console* widget, void* user_data) {
     SetActiveLibretroShader((LibretroShaderType)menu.shaderSelectedIndex);
     SetLibretroMenuStyle((LibretroMenuStyle)menu.themeSelectedIndex);
     SetLibretroVolume(menu.volumeSelected);
-    if (LibretroCore.textureFilter != menu.textureFilterIndex) {
-        LibretroCore.textureFilter = menu.textureFilterIndex;
+    if (Libretro.textureFilter != menu.textureFilterIndex) {
+        Libretro.textureFilter = menu.textureFilterIndex;
         InitLibretroVideo();
     }
     SetExitKey(NuklearKeyToKeyboardKey(menu.keyQuit));
@@ -361,12 +361,12 @@ static void MenuCommitSettings(nk_console* widget, void* user_data) {
 static void ScanLibretroCoreDirectory(void);
 
 static void LibretroApplyDirectories(void) {
-    TextCopy(LibretroCore.coreDirectory,            menu.coreDirectory);
-    TextCopy(LibretroCore.saveDirectory,            menu.saveDirectory);
-    TextCopy(LibretroCore.coreAssetsDirectory,      menu.coreAssetsDirectory);
-    TextCopy(LibretroCore.systemDirectory,          menu.systemDirectory);
-    TextCopy(LibretroCore.playlistsDirectory,       menu.playlistsDirectory);
-    TextCopy(LibretroCore.fileBrowserStartDirectory, menu.fileBrowserStartDirectory);
+    TextCopy(Libretro.coreDirectory,            menu.coreDirectory);
+    TextCopy(Libretro.saveDirectory,            menu.saveDirectory);
+    TextCopy(Libretro.coreAssetsDirectory,      menu.coreAssetsDirectory);
+    TextCopy(Libretro.systemDirectory,          menu.systemDirectory);
+    TextCopy(Libretro.playlistsDirectory,       menu.playlistsDirectory);
+    TextCopy(Libretro.fileBrowserStartDirectory, menu.fileBrowserStartDirectory);
     if (menu.saveDirectory[0] != '\0' && !DirectoryExists(menu.saveDirectory)) {
         MakeDirectory(menu.saveDirectory);
     }
@@ -445,14 +445,14 @@ static void ScanLibretroCoreDirectory(void) {
     for (unsigned int i = 0; i < files.count; i++) {
         if (!IsLibretroCoreFile(files.paths[i])) continue;
         if (!InitLibretroEx(files.paths[i], true)) continue;
-        if (TextLength(LibretroCore.validExtensions) == 0) continue;
+        if (TextLength(Libretro.core.validExtensions) == 0) continue;
 
         char keyPath[64], keyExts[64];
         TextCopy(keyPath, TextFormat("core_%d_path", coreIndex));
         TextCopy(keyExts, TextFormat("core_%d_extensions", coreIndex));
         rlconfig_set(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, keyPath, files.paths[i]);
-        rlconfig_set(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, keyExts, LibretroCore.validExtensions);
-        TraceLog(LOG_INFO, "LIBRETRO: Cached %s (%s)", LibretroCore.libraryName, LibretroCore.validExtensions);
+        rlconfig_set(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, keyExts, Libretro.core.validExtensions);
+        TraceLog(LOG_INFO, "LIBRETRO: Cached %s (%s)", Libretro.core.libraryName, Libretro.core.validExtensions);
         coreIndex++;
     }
     UnloadDirectoryFiles(files);
@@ -1026,11 +1026,11 @@ static void LibretroMenuOptionChanged(nk_console* widget, void* user_data) {
     (void)widget;
     unsigned i = (unsigned)(uintptr_t)user_data;
     char value[LIBRETRO_CORE_VARIABLE_VALUE_LEN] = {0};
-    LibretroMenuGetNthToken(LibretroCore.variableValuesList[i],
+    LibretroMenuGetNthToken(Libretro.core.variableValuesList[i],
                             menu.optionSelectedIndices[i],
                             value, LIBRETRO_CORE_VARIABLE_VALUE_LEN);
     if (TextLength(value) > 0) {
-        SetLibretroCoreOption(LibretroCore.variableKeys[i], value);
+        SetLibretroCoreOption(Libretro.core.variableKeys[i], value);
     }
 }
 
@@ -1040,7 +1040,7 @@ static void LibretroMenuOptionCheckboxChanged(nk_console* widget, void* user_dat
     (void)widget;
     unsigned i = (unsigned)(uintptr_t)user_data;
     const char* value = menu.optionCheckboxValues[i] ? "enabled" : "disabled";
-    SetLibretroCoreOption(LibretroCore.variableKeys[i], value);
+    SetLibretroCoreOption(Libretro.core.variableKeys[i], value);
 }
 
 static int LibretroMenuFindTokenIndex(const char* str, const char* value) {
@@ -1073,12 +1073,12 @@ void BuildLibretroMenuOptions(LibretroMenu* m) {
 
     // The menu now reflects the current option set; clear the dirty flag so
     // the lazy-rebuild trigger in UpdateLibretroMenu doesn't fire redundantly.
-    LibretroCore.variablesVisibilityDirty = false;
+    Libretro.core.variablesVisibilityDirty = false;
 
     // Clear any previously built option children and restore Back button
     nk_console_free_children(m->optionsMenu);
 
-    if (LibretroCore.variableCount == 0) {
+    if (Libretro.core.variableCount == 0) {
         m->optionsMenu->visible = nk_false;
         return;
     }
@@ -1087,8 +1087,8 @@ void BuildLibretroMenuOptions(LibretroMenu* m) {
     // (e.g. all hidden by options_update_display_callback), hide the button
     // rather than showing an empty submenu.
     int shownCount = 0;
-    for (unsigned i = 0; i < LibretroCore.variableCount; i++) {
-        if (TextLength(LibretroCore.variableValuesList[i]) > 0 && LibretroCore.variableVisible[i]) {
+    for (unsigned i = 0; i < Libretro.core.variableCount; i++) {
+        if (TextLength(Libretro.core.variableValuesList[i]) > 0 && Libretro.core.variableVisible[i]) {
             shownCount++;
         }
     }
@@ -1103,29 +1103,29 @@ void BuildLibretroMenuOptions(LibretroMenu* m) {
         nk_console_button_onclick(m->optionsMenu, "Core Options", &nk_console_button_back),
         NK_SYMBOL_X);
 
-    for (unsigned i = 0; i < LibretroCore.variableCount; i++) {
-        if (TextLength(LibretroCore.variableValuesList[i]) == 0) continue;
-        if (!LibretroCore.variableVisible[i]) continue;
+    for (unsigned i = 0; i < Libretro.core.variableCount; i++) {
+        if (TextLength(Libretro.core.variableValuesList[i]) == 0) continue;
+        if (!Libretro.core.variableVisible[i]) continue;
 
-        const char* label = TextLength(LibretroCore.variableLabels[i]) > 0
-            ? LibretroCore.variableLabels[i]
-            : LibretroCore.variableKeys[i];
+        const char* label = TextLength(Libretro.core.variableLabels[i]) > 0
+            ? Libretro.core.variableLabels[i]
+            : Libretro.core.variableKeys[i];
 
         nk_console* widget;
 
-        if (LibretroMenuIsEnabledDisabledOption(LibretroCore.variableValuesList[i])) {
-            m->optionCheckboxValues[i] = (nk_bool)TextIsEqual(LibretroCore.variableValues[i], "enabled");
+        if (LibretroMenuIsEnabledDisabledOption(Libretro.core.variableValuesList[i])) {
+            m->optionCheckboxValues[i] = (nk_bool)TextIsEqual(Libretro.core.variableValues[i], "enabled");
             widget = nk_console_checkbox(m->optionsMenu, label, &m->optionCheckboxValues[i]);
             nk_console_add_event_handler(widget, NK_CONSOLE_EVENT_CHANGED,
                                          LibretroMenuOptionCheckboxChanged,
                                          (void*)(uintptr_t)i, NULL);
         } else {
             m->optionSelectedIndices[i] = LibretroMenuFindTokenIndex(
-                LibretroCore.variableValuesList[i], LibretroCore.variableValues[i]);
+                Libretro.core.variableValuesList[i], Libretro.core.variableValues[i]);
 
-            const char* displayStr = TextLength(LibretroCore.variableDisplayList[i]) > 0
-                ? LibretroCore.variableDisplayList[i]
-                : LibretroCore.variableValuesList[i];
+            const char* displayStr = TextLength(Libretro.core.variableDisplayList[i]) > 0
+                ? Libretro.core.variableDisplayList[i]
+                : Libretro.core.variableValuesList[i];
 
             widget = nk_console_combobox(m->optionsMenu, label,
                                          displayStr, '|',
@@ -1135,8 +1135,8 @@ void BuildLibretroMenuOptions(LibretroMenu* m) {
                                          (void*)(uintptr_t)i, NULL);
         }
 
-        if (TextLength(LibretroCore.variableTooltips[i]) > 0) {
-            widget->tooltip = LibretroCore.variableTooltips[i];
+        if (TextLength(Libretro.core.variableTooltips[i]) > 0) {
+            widget->tooltip = Libretro.core.variableTooltips[i];
         }
     }
 }
@@ -1186,7 +1186,7 @@ static void LibretroMenuUpdateConfig(void) {
 
 static void LibretroMenuApplyKeyboardPlayer1(void) {
     for (int i = 0; i < 16; i++) {
-        LibretroCore.keyboardPlayer1[i] = (int)NuklearKeyToKeyboardKey(menu.keyboardP1[i]);
+        Libretro.keyboardPlayer1[i] = (int)NuklearKeyToKeyboardKey(menu.keyboardP1[i]);
     }
 }
 
@@ -1204,12 +1204,12 @@ static bool SaveLibretroMenuSettings(void) {
 
 static bool SaveLibretroCoreOptions(void) {
 #ifdef RAYLIB_LIBRETRO_CONFIG_H
-    if (!menu.cfg || LibretroCore.variableCount == 0) return false;
-    const char *coreName = LibretroCore.libraryName;
+    if (!menu.cfg || Libretro.core.variableCount == 0) return false;
+    const char *coreName = Libretro.core.libraryName;
     if (!coreName || !coreName[0]) return false;
     rlconfig_clear_section(menu.cfg, coreName);
-    for (unsigned i = 0; i < LibretroCore.variableCount; i++) {
-        rlconfig_set(menu.cfg, coreName, LibretroCore.variableKeys[i], LibretroCore.variableValues[i]);
+    for (unsigned i = 0; i < Libretro.core.variableCount; i++) {
+        rlconfig_set(menu.cfg, coreName, Libretro.core.variableKeys[i], Libretro.core.variableValues[i]);
     }
     bool ok = rlconfig_save(menu.cfg, RAYLIB_LIBRETRO_CFG_FILE);
     TraceLog(LOG_INFO, "LIBRETRO: Saved core options to %s", RAYLIB_LIBRETRO_CFG_FILE);
@@ -1222,12 +1222,12 @@ static bool SaveLibretroCoreOptions(void) {
 bool LoadLibretroCoreOptions(void) {
 #ifdef RAYLIB_LIBRETRO_CONFIG_H
     if (!menu.cfg) return false;
-    const char *coreName = LibretroCore.libraryName;
+    const char *coreName = Libretro.core.libraryName;
     if (!coreName || !coreName[0]) return false;
     int loaded = 0;
-    for (unsigned i = 0; i < LibretroCore.variableCount; i++) {
-        const char *val = rlconfig_get(menu.cfg, coreName, LibretroCore.variableKeys[i]);
-        if (val && SetLibretroCoreOption(LibretroCore.variableKeys[i], val)) loaded++;
+    for (unsigned i = 0; i < Libretro.core.variableCount; i++) {
+        const char *val = rlconfig_get(menu.cfg, coreName, Libretro.core.variableKeys[i]);
+        if (val && SetLibretroCoreOption(Libretro.core.variableKeys[i], val)) loaded++;
     }
     TraceLog(LOG_INFO, "LIBRETRO: Loaded %d core option(s) from %s", loaded, RAYLIB_LIBRETRO_CFG_FILE);
     return loaded > 0;
@@ -1243,11 +1243,11 @@ bool SaveLibretroAllSettings(void) {
 #ifdef RAYLIB_LIBRETRO_CONFIG_H
     if (!menu.cfg) return false;
     LibretroMenuUpdateConfig();
-    const char *coreName = LibretroCore.libraryName;
-    if (coreName && coreName[0] && LibretroCore.variableCount > 0) {
+    const char *coreName = Libretro.core.libraryName;
+    if (coreName && coreName[0] && Libretro.core.variableCount > 0) {
         rlconfig_clear_section(menu.cfg, coreName);
-        for (unsigned i = 0; i < LibretroCore.variableCount; i++) {
-            rlconfig_set(menu.cfg, coreName, LibretroCore.variableKeys[i], LibretroCore.variableValues[i]);
+        for (unsigned i = 0; i < Libretro.core.variableCount; i++) {
+            rlconfig_set(menu.cfg, coreName, Libretro.core.variableKeys[i], Libretro.core.variableValues[i]);
         }
     }
     bool ok = rlconfig_save(menu.cfg, RAYLIB_LIBRETRO_CFG_FILE);
@@ -1285,7 +1285,7 @@ static bool LoadLibretroMenuSettings(void) {
     menu.textureFilterIndex = rlconfig_get_int(menu.cfg, "raylib-libretro", "textureFilter", 0);
     if (menu.textureFilterIndex < 0 || menu.textureFilterIndex > TEXTURE_FILTER_ANISOTROPIC_16X)
         menu.textureFilterIndex = 0;
-    LibretroCore.textureFilter = menu.textureFilterIndex;
+    Libretro.textureFilter = menu.textureFilterIndex;
 
     menu.themeSelectedIndex = rlconfig_get_int(menu.cfg, "raylib-libretro", "theme", LIBRETRO_MENU_STYLE_DRACULA);
     if (menu.themeSelectedIndex < 0 || menu.themeSelectedIndex >= LIBRETRO_MENU_STYLE_COUNT)
@@ -1406,8 +1406,8 @@ static void UpdateLibretroMenuVisibility(void) {
     // options until visibility is resolved after the first retro_run frame).
     if (menu.optionsMenu && IsLibretroReady()) {
         int visibleOptions = 0;
-        for (unsigned i = 0; i < LibretroCore.variableCount; i++) {
-            if (TextLength(LibretroCore.variableValuesList[i]) > 0 && LibretroCore.variableVisible[i]) {
+        for (unsigned i = 0; i < Libretro.core.variableCount; i++) {
+            if (TextLength(Libretro.core.variableValuesList[i]) > 0 && Libretro.core.variableVisible[i]) {
                 visibleOptions++;
                 break;
             }
@@ -1462,24 +1462,24 @@ void UpdateLibretroMenu(void) {
     //   * library name changed (core swap; same count but different options)
     //   * the menu just transitioned from closed to open (fresh-state guard)
     static unsigned lastBuiltVariableCount = 0;
-    static char lastBuiltCoreName[sizeof(LibretroCore.libraryName)] = {0};
-    bool countChanged = (lastBuiltVariableCount != LibretroCore.variableCount);
-    bool coreChanged  = !TextIsEqual(lastBuiltCoreName, LibretroCore.libraryName);
+    static char lastBuiltCoreName[sizeof(Libretro.core.libraryName)] = {0};
+    bool countChanged = (lastBuiltVariableCount != Libretro.core.variableCount);
+    bool coreChanged  = !TextIsEqual(lastBuiltCoreName, Libretro.core.libraryName);
 
-    if (LibretroCore.variablesVisibilityDirty || countChanged || coreChanged || menuJustOpened) {
+    if (Libretro.core.variablesVisibilityDirty || countChanged || coreChanged || menuJustOpened) {
         // When the menu first opens and the game is running, invoke the display
         // callback to get the latest visibility state. Cores like PicoDrive call
         // SET_CORE_OPTIONS_DISPLAY during retro_load_game to set initial
         // visibility, but the callback may resolve it differently after the
         // first retro_run frame. Invoking it here ensures the menu always opens
         // with up-to-date option visibility even if no frames have run yet.
-        if (menuJustOpened && LibretroCore.options_update_display_callback && IsLibretroGameReady()) {
-            LibretroCore.options_update_display_callback();
+        if (menuJustOpened && Libretro.core.options_update_display_callback && IsLibretroGameReady()) {
+            Libretro.core.options_update_display_callback();
         }
         BuildLibretroMenuOptions(&menu);
-        LibretroCore.variablesVisibilityDirty = false;
-        lastBuiltVariableCount = LibretroCore.variableCount;
-        TextCopy(lastBuiltCoreName, LibretroCore.libraryName);
+        Libretro.core.variablesVisibilityDirty = false;
+        lastBuiltVariableCount = Libretro.core.variableCount;
+        TextCopy(lastBuiltCoreName, Libretro.core.libraryName);
     }
 
     UpdateLibretroMenuVisibility();

--- a/include/raylib-libretro-touch.h
+++ b/include/raylib-libretro-touch.h
@@ -7,7 +7,7 @@
 *       #include "raylib-libretro-touch.h"
 *
 *   Renders a virtual gamepad (D-pad, face buttons, Select/Start, Menu) and
-*   feeds presses into LibretroCore.virtualJoypadState. Sizing is derived
+*   feeds presses into Libretro.core.virtualJoypadState. Sizing is derived
 *   from the smaller screen dimension so buttons stay square and consistent
 *   regardless of aspect ratio or window size.
 *
@@ -151,7 +151,7 @@ static Rectangle GetLibretroTouchMenuRect(int w, int h) {
 static int LibretroTouchJoypadKeyboard(int buttonId) {
 #ifdef RAYLIB_LIBRETRO_MENU_H
     if (buttonId >= 0 && buttonId < 16) {
-        return LibretroCore.keyboardPlayer1[buttonId];
+        return Libretro.keyboardPlayer1[buttonId];
     }
     return KEY_NULL;
 #else
@@ -284,10 +284,10 @@ void UpdateLibretroTouchControls(void) {
     LibretroTouchEnsureLayout();
 
     bool prevState[16] = {0};
-    for (int i = 0; i < 16; i++) prevState[i] = LibretroCore.virtualJoypadState[i];
+    for (int i = 0; i < 16; i++) prevState[i] = Libretro.core.virtualJoypadState[i];
     bool prevMenuArmed = LibretroTouchMenuArmed;
 
-    memset(LibretroCore.virtualJoypadState, 0, sizeof(LibretroCore.virtualJoypadState));
+    memset(Libretro.core.virtualJoypadState, 0, sizeof(Libretro.core.virtualJoypadState));
 
     Vector2 points[10];
     int nPoints = 0;
@@ -344,14 +344,14 @@ void UpdateLibretroTouchControls(void) {
                 float ddx = pos.x - dc.x, ddy = pos.y - dc.y;
                 if (Vector2Length((Vector2){ddx, ddy}) > dr * 0.15f) {  // dead zone
                     float angle = atan2f(ddy, ddx);
-                    if      (angle >= -PI8   && angle <  PI8)    LibretroCore.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_RIGHT] = true;
-                    else if (angle >=  PI8   && angle <  3*PI8)  { LibretroCore.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_DOWN]  = true; LibretroCore.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_RIGHT] = true; }
-                    else if (angle >=  3*PI8 && angle <  5*PI8)  LibretroCore.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_DOWN]  = true;
-                    else if (angle >=  5*PI8 && angle <  7*PI8)  { LibretroCore.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_DOWN]  = true; LibretroCore.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_LEFT]  = true; }
-                    else if (angle >= -7*PI8 && angle < -5*PI8)  { LibretroCore.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_UP]   = true; LibretroCore.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_LEFT]  = true; }
-                    else if (angle >= -5*PI8 && angle < -3*PI8)  LibretroCore.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_UP]   = true;
-                    else if (angle >= -3*PI8 && angle < -PI8)    { LibretroCore.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_UP]   = true; LibretroCore.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_RIGHT] = true; }
-                    else                                          LibretroCore.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_LEFT]  = true;
+                    if      (angle >= -PI8   && angle <  PI8)    Libretro.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_RIGHT] = true;
+                    else if (angle >=  PI8   && angle <  3*PI8)  { Libretro.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_DOWN]  = true; Libretro.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_RIGHT] = true; }
+                    else if (angle >=  3*PI8 && angle <  5*PI8)  Libretro.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_DOWN]  = true;
+                    else if (angle >=  5*PI8 && angle <  7*PI8)  { Libretro.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_DOWN]  = true; Libretro.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_LEFT]  = true; }
+                    else if (angle >= -7*PI8 && angle < -5*PI8)  { Libretro.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_UP]   = true; Libretro.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_LEFT]  = true; }
+                    else if (angle >= -5*PI8 && angle < -3*PI8)  Libretro.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_UP]   = true;
+                    else if (angle >= -3*PI8 && angle < -PI8)    { Libretro.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_UP]   = true; Libretro.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_RIGHT] = true; }
+                    else                                          Libretro.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_LEFT]  = true;
                 }
             }
         }
@@ -362,7 +362,7 @@ void UpdateLibretroTouchControls(void) {
         if (IsLibretroTouchDpadButton(LibretroTouchButtons[i].buttonId)) continue;
         for (int p = 0; p < nPoints; p++) {
             if (CheckCollisionPointRec(points[p], LibretroTouchButtons[i].rect)) {
-                LibretroCore.virtualJoypadState[LibretroTouchButtons[i].buttonId] = true;
+                Libretro.core.virtualJoypadState[LibretroTouchButtons[i].buttonId] = true;
                 break;
             }
         }
@@ -396,7 +396,7 @@ void UpdateLibretroTouchControls(void) {
         bool fired = false;
         for (int i = 0; i < LibretroTouchButtonsCount && !fired; i++) {
             int id = LibretroTouchButtons[i].buttonId;
-            if (LibretroCore.virtualJoypadState[id] && !prevState[id]) {
+            if (Libretro.core.virtualJoypadState[id] && !prevState[id]) {
                 LibretroTouchTriggerHaptic();
                 fired = true;
             }
@@ -410,7 +410,7 @@ void UpdateLibretroTouchControls(void) {
     bool anyTouchActive = LibretroTouchDpadLocked || LibretroTouchMenuArmed;
     if (!anyTouchActive) {
         for (int i = 0; i < 16; i++) {
-            if (LibretroCore.virtualJoypadState[i]) { anyTouchActive = true; break; }
+            if (Libretro.core.virtualJoypadState[i]) { anyTouchActive = true; break; }
         }
     }
     if (anyTouchActive) LibretroTouchLastActiveTime = GetTime();
@@ -461,8 +461,8 @@ void DrawLibretroTouchControls(void) {
         float arrowSize = dr * 0.22f;
 
         for (int d = 0; d < 8; d++) {
-            bool b1 = LibretroCore.virtualJoypadState[dirs[d].b1] || LibretroTouchIsPhysicalButtonDown(dirs[d].b1);
-            bool b2 = (dirs[d].b2 < 0) || LibretroCore.virtualJoypadState[dirs[d].b2] || LibretroTouchIsPhysicalButtonDown(dirs[d].b2);
+            bool b1 = Libretro.core.virtualJoypadState[dirs[d].b1] || LibretroTouchIsPhysicalButtonDown(dirs[d].b1);
+            bool b2 = (dirs[d].b2 < 0) || Libretro.core.virtualJoypadState[dirs[d].b2] || LibretroTouchIsPhysicalButtonDown(dirs[d].b2);
             Color arrowColor = LibretroTouchFadeColor(
                 (b1 && b2) ? (Color){ 255, 255, 255, 230 } : (Color){ 180, 180, 180, 100 }, alpha);
             float ca = cosf(dirs[d].angle), sa = sinf(dirs[d].angle);
@@ -494,7 +494,7 @@ void DrawLibretroTouchControls(void) {
         int id = btns[i].buttonId;
         if (IsLibretroTouchDpadButton(id)) continue;  // drawn separately as circular D-pad
         bool isMenuLike = (id == RETRO_DEVICE_ID_JOYPAD_SELECT || id == RETRO_DEVICE_ID_JOYPAD_START);
-        bool touchHeld    = LibretroCore.virtualJoypadState[id];
+        bool touchHeld    = Libretro.core.virtualJoypadState[id];
         bool physicalHeld = LibretroTouchIsPhysicalButtonDown(id);
         Color c = btns[i].color;
         unsigned char restA = isMenuLike ? 70 : 140;

--- a/include/raylib-libretro-touch.h
+++ b/include/raylib-libretro-touch.h
@@ -7,7 +7,7 @@
 *       #include "raylib-libretro-touch.h"
 *
 *   Renders a virtual gamepad (D-pad, face buttons, Select/Start, Menu) and
-*   feeds presses into Libretro.core.virtualJoypadState. Sizing is derived
+*   feeds presses into LIBRETRO.core.virtualJoypadState. Sizing is derived
 *   from the smaller screen dimension so buttons stay square and consistent
 *   regardless of aspect ratio or window size.
 *
@@ -151,7 +151,7 @@ static Rectangle GetLibretroTouchMenuRect(int w, int h) {
 static int LibretroTouchJoypadKeyboard(int buttonId) {
 #ifdef RAYLIB_LIBRETRO_MENU_H
     if (buttonId >= 0 && buttonId < 16) {
-        return Libretro.keyboardPlayer1[buttonId];
+        return LIBRETRO.keyboardPlayer1[buttonId];
     }
     return KEY_NULL;
 #else
@@ -284,10 +284,10 @@ void UpdateLibretroTouchControls(void) {
     LibretroTouchEnsureLayout();
 
     bool prevState[16] = {0};
-    for (int i = 0; i < 16; i++) prevState[i] = Libretro.core.virtualJoypadState[i];
+    for (int i = 0; i < 16; i++) prevState[i] = LIBRETRO.core.virtualJoypadState[i];
     bool prevMenuArmed = LibretroTouchMenuArmed;
 
-    memset(Libretro.core.virtualJoypadState, 0, sizeof(Libretro.core.virtualJoypadState));
+    memset(LIBRETRO.core.virtualJoypadState, 0, sizeof(LIBRETRO.core.virtualJoypadState));
 
     Vector2 points[10];
     int nPoints = 0;
@@ -344,14 +344,14 @@ void UpdateLibretroTouchControls(void) {
                 float ddx = pos.x - dc.x, ddy = pos.y - dc.y;
                 if (Vector2Length((Vector2){ddx, ddy}) > dr * 0.15f) {  // dead zone
                     float angle = atan2f(ddy, ddx);
-                    if      (angle >= -PI8   && angle <  PI8)    Libretro.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_RIGHT] = true;
-                    else if (angle >=  PI8   && angle <  3*PI8)  { Libretro.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_DOWN]  = true; Libretro.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_RIGHT] = true; }
-                    else if (angle >=  3*PI8 && angle <  5*PI8)  Libretro.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_DOWN]  = true;
-                    else if (angle >=  5*PI8 && angle <  7*PI8)  { Libretro.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_DOWN]  = true; Libretro.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_LEFT]  = true; }
-                    else if (angle >= -7*PI8 && angle < -5*PI8)  { Libretro.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_UP]   = true; Libretro.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_LEFT]  = true; }
-                    else if (angle >= -5*PI8 && angle < -3*PI8)  Libretro.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_UP]   = true;
-                    else if (angle >= -3*PI8 && angle < -PI8)    { Libretro.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_UP]   = true; Libretro.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_RIGHT] = true; }
-                    else                                          Libretro.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_LEFT]  = true;
+                    if      (angle >= -PI8   && angle <  PI8)    LIBRETRO.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_RIGHT] = true;
+                    else if (angle >=  PI8   && angle <  3*PI8)  { LIBRETRO.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_DOWN]  = true; LIBRETRO.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_RIGHT] = true; }
+                    else if (angle >=  3*PI8 && angle <  5*PI8)  LIBRETRO.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_DOWN]  = true;
+                    else if (angle >=  5*PI8 && angle <  7*PI8)  { LIBRETRO.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_DOWN]  = true; LIBRETRO.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_LEFT]  = true; }
+                    else if (angle >= -7*PI8 && angle < -5*PI8)  { LIBRETRO.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_UP]   = true; LIBRETRO.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_LEFT]  = true; }
+                    else if (angle >= -5*PI8 && angle < -3*PI8)  LIBRETRO.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_UP]   = true;
+                    else if (angle >= -3*PI8 && angle < -PI8)    { LIBRETRO.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_UP]   = true; LIBRETRO.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_RIGHT] = true; }
+                    else                                          LIBRETRO.core.virtualJoypadState[RETRO_DEVICE_ID_JOYPAD_LEFT]  = true;
                 }
             }
         }
@@ -362,7 +362,7 @@ void UpdateLibretroTouchControls(void) {
         if (IsLibretroTouchDpadButton(LibretroTouchButtons[i].buttonId)) continue;
         for (int p = 0; p < nPoints; p++) {
             if (CheckCollisionPointRec(points[p], LibretroTouchButtons[i].rect)) {
-                Libretro.core.virtualJoypadState[LibretroTouchButtons[i].buttonId] = true;
+                LIBRETRO.core.virtualJoypadState[LibretroTouchButtons[i].buttonId] = true;
                 break;
             }
         }
@@ -396,7 +396,7 @@ void UpdateLibretroTouchControls(void) {
         bool fired = false;
         for (int i = 0; i < LibretroTouchButtonsCount && !fired; i++) {
             int id = LibretroTouchButtons[i].buttonId;
-            if (Libretro.core.virtualJoypadState[id] && !prevState[id]) {
+            if (LIBRETRO.core.virtualJoypadState[id] && !prevState[id]) {
                 LibretroTouchTriggerHaptic();
                 fired = true;
             }
@@ -410,7 +410,7 @@ void UpdateLibretroTouchControls(void) {
     bool anyTouchActive = LibretroTouchDpadLocked || LibretroTouchMenuArmed;
     if (!anyTouchActive) {
         for (int i = 0; i < 16; i++) {
-            if (Libretro.core.virtualJoypadState[i]) { anyTouchActive = true; break; }
+            if (LIBRETRO.core.virtualJoypadState[i]) { anyTouchActive = true; break; }
         }
     }
     if (anyTouchActive) LibretroTouchLastActiveTime = GetTime();
@@ -461,8 +461,8 @@ void DrawLibretroTouchControls(void) {
         float arrowSize = dr * 0.22f;
 
         for (int d = 0; d < 8; d++) {
-            bool b1 = Libretro.core.virtualJoypadState[dirs[d].b1] || LibretroTouchIsPhysicalButtonDown(dirs[d].b1);
-            bool b2 = (dirs[d].b2 < 0) || Libretro.core.virtualJoypadState[dirs[d].b2] || LibretroTouchIsPhysicalButtonDown(dirs[d].b2);
+            bool b1 = LIBRETRO.core.virtualJoypadState[dirs[d].b1] || LibretroTouchIsPhysicalButtonDown(dirs[d].b1);
+            bool b2 = (dirs[d].b2 < 0) || LIBRETRO.core.virtualJoypadState[dirs[d].b2] || LibretroTouchIsPhysicalButtonDown(dirs[d].b2);
             Color arrowColor = LibretroTouchFadeColor(
                 (b1 && b2) ? (Color){ 255, 255, 255, 230 } : (Color){ 180, 180, 180, 100 }, alpha);
             float ca = cosf(dirs[d].angle), sa = sinf(dirs[d].angle);
@@ -494,7 +494,7 @@ void DrawLibretroTouchControls(void) {
         int id = btns[i].buttonId;
         if (IsLibretroTouchDpadButton(id)) continue;  // drawn separately as circular D-pad
         bool isMenuLike = (id == RETRO_DEVICE_ID_JOYPAD_SELECT || id == RETRO_DEVICE_ID_JOYPAD_START);
-        bool touchHeld    = Libretro.core.virtualJoypadState[id];
+        bool touchHeld    = LIBRETRO.core.virtualJoypadState[id];
         bool physicalHeld = LibretroTouchIsPhysicalButtonDown(id);
         Color c = btns[i].color;
         unsigned char restA = isMenuLike ? 70 : 140;

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -2654,7 +2654,6 @@ static bool InitLibretroEx(const char* core, bool peek) {
     LoadLibretroMethod(retro_get_memory_data);
     LoadLibretroMethod(retro_get_memory_size);
 
-    // Initialize the core.
     TextCopy(Libretro.core.corePath, core);
 
     // Set up the callbacks.

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -2587,23 +2587,6 @@ static bool InitLibretroEx(const char* core, bool peek) {
         return false;
     }
 
-    // Freshen identity / capability fields before touching the new core, so
-    // a partially-failed load (e.g. dylib_load succeeds but retro_get_system_info
-    // never runs) can't leave the previous core's identity visible. These
-    // fields are intentionally not reset in ResetLibretroCoreState so that
-    // the peek path can populate them and CloseLibretro doesn't wipe them
-    // before ScanLibretroCoreDirectory reads them.
-    Libretro.core.corePath[0]        = '\0';
-    Libretro.core.libraryName[0]     = '\0';
-    Libretro.core.libraryVersion[0]  = '\0';
-    Libretro.core.validExtensions[0] = '\0';
-    Libretro.core.needFullpath       = false;
-    Libretro.core.blockExtract       = false;
-    Libretro.core.supportNoGame      = false;
-    Libretro.core.apiVersion         = 0;
-    Libretro.core.performanceLevel   = 0;
-    Libretro.core.pixelFormat        = RETRO_PIXEL_FORMAT_0RGB1555;
-
     // Open the dynamic library.
     Libretro.core.handle = dylib_load(core);
     if (!Libretro.core.handle) {
@@ -2638,7 +2621,8 @@ static bool InitLibretroEx(const char* core, bool peek) {
     }
 
     if (peek) {
-        CloseLibretro();
+        // Leave the dylib open so the caller can read identity fields off
+        // Libretro.core. The caller is responsible for CloseLibretro().
         return true;
     }
 
@@ -3026,73 +3010,16 @@ static void UnloadLibretroGame(void) {
  * with a clean slate. Must be called after the dylib is closed.
  */
 static void ResetLibretroCoreState(void) {
-    // Core Variables
-    memset(Libretro.core.variableKeys,        0, sizeof(Libretro.core.variableKeys));
-    memset(Libretro.core.variableValues,      0, sizeof(Libretro.core.variableValues));
-    memset(Libretro.core.variableLabels,      0, sizeof(Libretro.core.variableLabels));
-    memset(Libretro.core.variableValuesList,  0, sizeof(Libretro.core.variableValuesList));
-    memset(Libretro.core.variableDisplayList, 0, sizeof(Libretro.core.variableDisplayList));
-    memset(Libretro.core.variableTooltips,    0, sizeof(Libretro.core.variableTooltips));
-    memset(Libretro.core.variableVisible,     0, sizeof(Libretro.core.variableVisible));
-    Libretro.core.variableCount          = 0;
-    Libretro.core.variableOptionsVersion = 0;
-    Libretro.core.variablesDirty         = false;
-    Libretro.core.variablesVisibilityDirty = false;
+    // Release owned pointers before the memset wipes them.
+    UnloadLibretroMemoryMaps();
 
-    // Audio & Video
-    Libretro.core.rotation    = 0;
-    Libretro.core.width       = 0;
-    Libretro.core.height      = 0;
-    Libretro.core.fps         = 0;
-    Libretro.core.sampleRate  = 0.0;
-    Libretro.core.aspectRatio = 0.0f;
-    Libretro.core.minimumAudioLatencyMs = 0;
-    memset(&Libretro.core.audio_buffer_status_callback, 0, sizeof(Libretro.core.audio_buffer_status_callback));
+    memset(&Libretro.core, 0, sizeof(Libretro.core));
 
-    // VFS
-    memset(&Libretro.core.vfs_interface, 0, sizeof(Libretro.core.vfs_interface));
-
-    // Content Information
-    memset(Libretro.core.contentInfoOverrideExts,        0, sizeof(Libretro.core.contentInfoOverrideExts));
-    memset(Libretro.core.contentInfoOverrideNeedFullpath, 0, sizeof(Libretro.core.contentInfoOverrideNeedFullpath));
-    memset(Libretro.core.contentInfoOverridePersistent,   0, sizeof(Libretro.core.contentInfoOverridePersistent));
-    Libretro.core.contentInfoOverrideCount = 0;
-
-    // Runtime flags that should not survive a core close. shutdown is the
-    // RETRO_ENVIRONMENT_SHUTDOWN request from the previous core; loaded is
-    // set by retro_load_game and should be implied false once we've closed.
-    //
-    // NOTE: identity fields (corePath, libraryName, libraryVersion,
-    // validExtensions, needFullpath, blockExtract, supportNoGame, apiVersion,
-    // performanceLevel, pixelFormat) are intentionally NOT reset here. The
-    // peek path in InitLibretroEx populates these via retro_get_system_info
-    // and then calls CloseLibretro() before returning; the caller
-    // (ScanLibretroCoreDirectory) reads them off the global afterwards. They
-    // get re-freshened at the start of the next InitLibretroEx.
-    Libretro.core.loaded   = false;
-    Libretro.core.shutdown = false;
-
-    // Performance Counter
-    Libretro.core.perf_counter_last = NULL;
-
-    Libretro.speed = 1.0f;
-    memset(Libretro.core.rumbleStrong, 0, sizeof(Libretro.core.rumbleStrong));
-    memset(Libretro.core.rumbleWeak,   0, sizeof(Libretro.core.rumbleWeak));
-
-    // Per-session counters / accumulators.
-    Libretro.core.gameTimeNSEC      = 0;
-    Libretro.core.singleSampleCount = 0;
-    Libretro.core.audioDropWarnCount = 0;
-
-    // On-Screen Message
-    memset(Libretro.core.osdMessage, 0, sizeof(Libretro.core.osdMessage));
-    Libretro.core.osdEndTime = 0.0;
-
-    // Dynamic Rate Control
+    // Non-zero defaults.
     Libretro.core.drcAdjustment = 1.0f;
     Libretro.core.drcEnabled = true;
 
-    UnloadLibretroMemoryMaps();
+    Libretro.speed = 1.0f;
 }
 
 /**

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -162,16 +162,16 @@ static int LibretroMapRetroLogLevelToTraceLogType(int level);
 
 // Dynamic loading methods.
 #define LoadLibretroMethodHandle(V, S) do {\
-    function_t func = dylib_proc(Libretro.core.handle, #S); \
+    function_t func = dylib_proc(LIBRETRO.core.handle, #S); \
     memcpy(&V, &func, sizeof(func)); \
     if (!func) { \
         TraceLog(LOG_ERROR, "LIBRETRO: Failed to load symbol '" #S "' ", dylib_error()); \
         return false; \
     }\
 } while (0)
-#define LoadLibretroMethod(S) LoadLibretroMethodHandle(Libretro.core.S, S)
+#define LoadLibretroMethod(S) LoadLibretroMethodHandle(LIBRETRO.core.S, S)
 
-typedef struct rLibretroCore {
+typedef struct LibretroCoreData {
     // Dynamic library symbols.
     void *handle;
     void (*retro_init)(void);
@@ -319,9 +319,9 @@ typedef struct rLibretroCore {
     // Memory map from RETRO_ENVIRONMENT_SET_MEMORY_MAPS (owned copy).
     struct retro_memory_descriptor *memoryMapDescriptors;
     unsigned memoryMapDescriptorCount;
-} rLibretroCore;
+} LibretroCoreData;
 
-typedef struct rLibretro {
+typedef struct LibretroData {
     // Persistent settings that survive core loads.
     float volume;
     float speed;
@@ -335,8 +335,8 @@ typedef struct rLibretro {
     char fileBrowserStartDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
 
     // Per-core state (reset with memset(0) on core unload).
-    rLibretroCore core;
-} rLibretro;
+    LibretroCoreData core;
+} LibretroData;
 
 #if defined(__cplusplus)
 extern "C" {
@@ -345,43 +345,43 @@ extern "C" {
 /**
  * The global libretro core object.
  *
- * TODO: Figure out a way to have Libretro not be a static global?
+ * TODO: Figure out a way to have LIBRETRO not be a static global?
  */
-static rLibretro Libretro = {
+static LibretroData LIBRETRO = {
     .volume = 1.0f,
     .speed = 1.0f,
 };
 
 static void LibretroInitCoreVariable(const char *key, const char *defaultValue,
     const char *label, const char *valuesList, const char *displayList, const char *tooltip) {
-    for (unsigned i = 0; i < Libretro.core.variableCount; i++) {
-        if (TextIsEqual(Libretro.core.variableKeys[i], key)) {
+    for (unsigned i = 0; i < LIBRETRO.core.variableCount; i++) {
+        if (TextIsEqual(LIBRETRO.core.variableKeys[i], key)) {
             return; // Already registered; don't overwrite user-set value.
         }
     }
-    if (Libretro.core.variableCount >= LIBRETRO_MAX_CORE_VARIABLES) {
+    if (LIBRETRO.core.variableCount >= LIBRETRO_MAX_CORE_VARIABLES) {
         TraceLog(LOG_WARNING, "LIBRETRO: Core variable limit reached, ignoring: %s", key);
         return;
     }
-    unsigned n = Libretro.core.variableCount;
-    TextCopy(Libretro.core.variableKeys[n],        key);
-    TextCopy(Libretro.core.variableValues[n],      defaultValue  ? defaultValue  : "");
-    TextCopy(Libretro.core.variableLabels[n],      label         ? label         : "");
-    TextCopy(Libretro.core.variableValuesList[n],  valuesList    ? valuesList    : "");
-    TextCopy(Libretro.core.variableDisplayList[n], displayList   ? displayList   : "");
-    TextCopy(Libretro.core.variableTooltips[n],    tooltip       ? tooltip       : "");
-    Libretro.core.variableVisible[n] = true;
-    Libretro.core.variableCount++;
+    unsigned n = LIBRETRO.core.variableCount;
+    TextCopy(LIBRETRO.core.variableKeys[n],        key);
+    TextCopy(LIBRETRO.core.variableValues[n],      defaultValue  ? defaultValue  : "");
+    TextCopy(LIBRETRO.core.variableLabels[n],      label         ? label         : "");
+    TextCopy(LIBRETRO.core.variableValuesList[n],  valuesList    ? valuesList    : "");
+    TextCopy(LIBRETRO.core.variableDisplayList[n], displayList   ? displayList   : "");
+    TextCopy(LIBRETRO.core.variableTooltips[n],    tooltip       ? tooltip       : "");
+    LIBRETRO.core.variableVisible[n] = true;
+    LIBRETRO.core.variableCount++;
     // A new option appeared: cores that register variables after the menu has
     // been built (e.g. mgba registering GB model options during its deferred
     // setup on first retro_run) need the Core Options section to refresh.
-    Libretro.core.variablesVisibilityDirty = true;
+    LIBRETRO.core.variablesVisibilityDirty = true;
 }
 
 static const char *LibretroGetCoreVariable(const char *key) {
-    for (unsigned i = 0; i < Libretro.core.variableCount; i++) {
-        if (TextIsEqual(Libretro.core.variableKeys[i], key)) {
-            return Libretro.core.variableValues[i];
+    for (unsigned i = 0; i < LIBRETRO.core.variableCount; i++) {
+        if (TextIsEqual(LIBRETRO.core.variableKeys[i], key)) {
+            return LIBRETRO.core.variableValues[i];
         }
     }
     return NULL;
@@ -393,10 +393,10 @@ static const char *LibretroGetCoreVariable(const char *key) {
  * @param value New value for the option.
  * @return true if the key was found and the value applied; false if the key is unknown. */
 static bool SetLibretroCoreOption(const char *key, const char *value) {
-    for (unsigned i = 0; i < Libretro.core.variableCount; i++) {
-        if (TextIsEqual(Libretro.core.variableKeys[i], key)) {
-            snprintf(Libretro.core.variableValues[i], LIBRETRO_CORE_VARIABLE_VALUE_LEN, "%s", value);
-            Libretro.core.variablesDirty = true;
+    for (unsigned i = 0; i < LIBRETRO.core.variableCount; i++) {
+        if (TextIsEqual(LIBRETRO.core.variableKeys[i], key)) {
+            snprintf(LIBRETRO.core.variableValues[i], LIBRETRO_CORE_VARIABLE_VALUE_LEN, "%s", value);
+            LIBRETRO.core.variablesDirty = true;
             return true;
         }
     }
@@ -432,11 +432,11 @@ static const char* GetLibretroDirectory(int directory) {
 
     char* output = NULL;
     switch (directory) {
-        case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY: output = Libretro.saveDirectory; break;
-        case RETRO_ENVIRONMENT_GET_CORE_ASSETS_DIRECTORY: output = Libretro.coreAssetsDirectory; break; // RETRO_ENVIRONMENT_GET_CONTENT_DIRECTORY
-        case RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY: output = Libretro.systemDirectory; break;
-        case RETRO_ENVIRONMENT_GET_PLAYLIST_DIRECTORY: output = Libretro.playlistsDirectory; break;
-        case RETRO_ENVIRONMENT_GET_FILE_BROWSER_START_DIRECTORY: output = Libretro.fileBrowserStartDirectory; break;
+        case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY: output = LIBRETRO.saveDirectory; break;
+        case RETRO_ENVIRONMENT_GET_CORE_ASSETS_DIRECTORY: output = LIBRETRO.coreAssetsDirectory; break; // RETRO_ENVIRONMENT_GET_CONTENT_DIRECTORY
+        case RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY: output = LIBRETRO.systemDirectory; break;
+        case RETRO_ENVIRONMENT_GET_PLAYLIST_DIRECTORY: output = LIBRETRO.playlistsDirectory; break;
+        case RETRO_ENVIRONMENT_GET_FILE_BROWSER_START_DIRECTORY: output = LIBRETRO.fileBrowserStartDirectory; break;
         default: return NULL;
     }
 
@@ -459,8 +459,8 @@ static const char* GetLibretroDirectory(int directory) {
  * @param count Output parameter filled with the number of descriptors.
  * @return Pointer to the descriptor array, or NULL if none were set. */
 static const struct retro_input_descriptor* GetLibretroInputDescriptors(unsigned *count) {
-    if (count != NULL) *count = Libretro.core.inputDescriptorCount;
-    return Libretro.core.inputDescriptors;
+    if (count != NULL) *count = LIBRETRO.core.inputDescriptorCount;
+    return LIBRETRO.core.inputDescriptors;
 }
 
 /**
@@ -468,22 +468,22 @@ static const struct retro_input_descriptor* GetLibretroInputDescriptors(unsigned
  * @param count Output parameter filled with the number of ports.
  * @return Pointer to the controller info array, or NULL if none were set. */
 static const struct retro_controller_info* GetLibretroControllerInfo(unsigned *count) {
-    if (count != NULL) *count = Libretro.core.controllerPortCount;
-    return Libretro.core.controllerInfo;
+    if (count != NULL) *count = LIBRETRO.core.controllerPortCount;
+    return LIBRETRO.core.controllerInfo;
 }
 
 /**
  * Free the stored memory map descriptors. */
 static void UnloadLibretroMemoryMaps(void) {
-    if (Libretro.core.memoryMapDescriptors) {
-        for (unsigned i = 0; i < Libretro.core.memoryMapDescriptorCount; i++) {
-            if (Libretro.core.memoryMapDescriptors[i].addrspace) {
-                MemFree((void*)Libretro.core.memoryMapDescriptors[i].addrspace);
+    if (LIBRETRO.core.memoryMapDescriptors) {
+        for (unsigned i = 0; i < LIBRETRO.core.memoryMapDescriptorCount; i++) {
+            if (LIBRETRO.core.memoryMapDescriptors[i].addrspace) {
+                MemFree((void*)LIBRETRO.core.memoryMapDescriptors[i].addrspace);
             }
         }
-        MemFree(Libretro.core.memoryMapDescriptors);
-        Libretro.core.memoryMapDescriptors = NULL;
-        Libretro.core.memoryMapDescriptorCount = 0;
+        MemFree(LIBRETRO.core.memoryMapDescriptors);
+        LIBRETRO.core.memoryMapDescriptors = NULL;
+        LIBRETRO.core.memoryMapDescriptorCount = 0;
     }
 }
 
@@ -497,18 +497,18 @@ static bool SetLibretroMemoryMaps(const struct retro_memory_map *map) {
         return map != NULL;
     }
     size_t sz = sizeof(struct retro_memory_descriptor) * map->num_descriptors;
-    Libretro.core.memoryMapDescriptors = (struct retro_memory_descriptor*)MemAlloc((unsigned int)sz);
-    if (!Libretro.core.memoryMapDescriptors) {
+    LIBRETRO.core.memoryMapDescriptors = (struct retro_memory_descriptor*)MemAlloc((unsigned int)sz);
+    if (!LIBRETRO.core.memoryMapDescriptors) {
         return false;
     }
-    memcpy(Libretro.core.memoryMapDescriptors, map->descriptors, sz);
-    Libretro.core.memoryMapDescriptorCount = map->num_descriptors;
+    memcpy(LIBRETRO.core.memoryMapDescriptors, map->descriptors, sz);
+    LIBRETRO.core.memoryMapDescriptorCount = map->num_descriptors;
     for (unsigned i = 0; i < map->num_descriptors; i++) {
         if (map->descriptors[i].addrspace) {
             size_t len = strlen(map->descriptors[i].addrspace) + 1;
             char *copy = (char*)MemAlloc((unsigned int)len);
             if (copy) memcpy(copy, map->descriptors[i].addrspace, len);
-            Libretro.core.memoryMapDescriptors[i].addrspace = copy;
+            LIBRETRO.core.memoryMapDescriptors[i].addrspace = copy;
         }
     }
     TraceLog(LOG_INFO, "LIBRETRO: Memory map stored (%u descriptor(s))", map->num_descriptors);
@@ -520,8 +520,8 @@ static bool SetLibretroMemoryMaps(const struct retro_memory_map *map) {
  * @param count Output parameter filled with the number of descriptors.
  * @return Pointer to the descriptor array, or NULL if none are stored. */
 static const struct retro_memory_descriptor* GetLibretroMemoryMaps(unsigned *count) {
-    if (count != NULL) *count = Libretro.core.memoryMapDescriptorCount;
-    return Libretro.core.memoryMapDescriptors;
+    if (count != NULL) *count = LIBRETRO.core.memoryMapDescriptorCount;
+    return LIBRETRO.core.memoryMapDescriptors;
 }
 
 // Returns an absolute path for `path`. The result is either the input pointer
@@ -569,52 +569,52 @@ static size_t UpdateLibretroAudioSampleBatch(const int16_t *data, size_t frames)
 
 static void CloseLibretroVideo(void) {
     // Unload the existing texture if it exists already.
-    if (IsTextureValid(Libretro.core.texture)) {
-        UnloadTexture(Libretro.core.texture);
-        memset(&Libretro.core.texture, 0, sizeof(Libretro.core.texture));
+    if (IsTextureValid(LIBRETRO.core.texture)) {
+        UnloadTexture(LIBRETRO.core.texture);
+        memset(&LIBRETRO.core.texture, 0, sizeof(LIBRETRO.core.texture));
     }
 
-    if (Libretro.core.frameBuffer != NULL) {
-        MemFree(Libretro.core.frameBuffer);
+    if (LIBRETRO.core.frameBuffer != NULL) {
+        MemFree(LIBRETRO.core.frameBuffer);
     }
-    Libretro.core.frameBuffer = NULL;
-    Libretro.core.frameBufferSize = 0;
-    Libretro.core.textureRebuild = false;
+    LIBRETRO.core.frameBuffer = NULL;
+    LIBRETRO.core.frameBufferSize = 0;
+    LIBRETRO.core.textureRebuild = false;
 }
 
 static bool InitLibretroVideo(void) {
     CloseLibretroVideo();
 
     // Build the rendering image.
-    if (Libretro.core.width == 0 || Libretro.core.height == 0) {
+    if (LIBRETRO.core.width == 0 || LIBRETRO.core.height == 0) {
         return false;
     }
 
-    Image image = GenImageColor(Libretro.core.width, Libretro.core.height, BLACK);
+    Image image = GenImageColor(LIBRETRO.core.width, LIBRETRO.core.height, BLACK);
     if (!IsImageValid(image)) {
         return false;
     }
-    ImageFormat(&image, LibretroRetroPixelFormatToPixelFormat(Libretro.core.pixelFormat));
+    ImageFormat(&image, LibretroRetroPixelFormatToPixelFormat(LIBRETRO.core.pixelFormat));
 
     // Create the texture.
-    Libretro.core.texture = LoadTextureFromImage(image);
+    LIBRETRO.core.texture = LoadTextureFromImage(image);
     UnloadImage(image);
-    if (!IsTextureValid(Libretro.core.texture)) {
+    if (!IsTextureValid(LIBRETRO.core.texture)) {
         return false;
     }
 
-    SetTextureFilter(Libretro.core.texture, Libretro.textureFilter);
+    SetTextureFilter(LIBRETRO.core.texture, LIBRETRO.textureFilter);
 
     // (Re-)allocate the frame conversion buffer sized for XRGB8888→RGBA8888 (worst case).
-    size_t needed = (size_t)GetPixelDataSize(Libretro.core.width, Libretro.core.height, PIXELFORMAT_UNCOMPRESSED_R8G8B8A8);
+    size_t needed = (size_t)GetPixelDataSize(LIBRETRO.core.width, LIBRETRO.core.height, PIXELFORMAT_UNCOMPRESSED_R8G8B8A8);
     if (needed == 0) {
         CloseLibretroVideo();
         return false;
     }
-    Libretro.core.frameBuffer = MemAlloc(needed);
-    Libretro.core.frameBufferSize = needed;
+    LIBRETRO.core.frameBuffer = MemAlloc(needed);
+    LIBRETRO.core.frameBufferSize = needed;
 
-    Libretro.core.textureRebuild = false;
+    LIBRETRO.core.textureRebuild = false;
     return true;
 }
 
@@ -624,7 +624,7 @@ static bool InitLibretroVideo(void) {
  * @return retro_time_t The current in-game time in microseconds.
  */
 static retro_time_t GetLibretroTimeUSEC(void) {
-    return (retro_time_t)(Libretro.core.gameTimeNSEC / 1000);
+    return (retro_time_t)(LIBRETRO.core.gameTimeNSEC / 1000);
 }
 
 /**
@@ -644,7 +644,7 @@ static uint64_t GetLibretroCPUFeatures(void) {
  * @return retro_perf_tick_t The current value of the high resolution counter.
  */
 static retro_perf_tick_t GetLibretroPerfCounter(void) {
-    return Libretro.core.gameTimeNSEC;
+    return LIBRETRO.core.gameTimeNSEC;
 }
 
 /**
@@ -653,7 +653,7 @@ static retro_perf_tick_t GetLibretroPerfCounter(void) {
  * @see retro_perf_register_t
  */
 static void SetLibretroPerformanceCounter(struct retro_perf_counter* counter) {
-    Libretro.core.perf_counter_last = counter;
+    LIBRETRO.core.perf_counter_last = counter;
     counter->registered = true;
 }
 
@@ -684,10 +684,10 @@ static void StopLibretroPerformanceCounter(struct retro_perf_counter* counter) {
  */
 static void LogLibretroPerformanceCounter(void) {
     // TODO: Use a linked list of counters, and loop through them all.
-    if (Libretro.core.perf_counter_last == NULL) {
+    if (LIBRETRO.core.perf_counter_last == NULL) {
         return;
     }
-    TraceLog(LOG_INFO, "LIBRETRO: Timer %s: %i - %i", Libretro.core.perf_counter_last->ident, Libretro.core.perf_counter_last->start, Libretro.core.perf_counter_last->total);
+    TraceLog(LOG_INFO, "LIBRETRO: Timer %s: %i - %i", LIBRETRO.core.perf_counter_last->ident, LIBRETRO.core.perf_counter_last->start, LIBRETRO.core.perf_counter_last->total);
 }
 
 static bool SetLibretroRumbleState(unsigned port, enum retro_rumble_effect effect, uint16_t strength) {
@@ -696,11 +696,11 @@ static bool SetLibretroRumbleState(unsigned port, enum retro_rumble_effect effec
     }
     float normalized = (float)strength / 65535.0f;
     if (effect == RETRO_RUMBLE_STRONG) {
-        Libretro.core.rumbleStrong[port] = normalized;
+        LIBRETRO.core.rumbleStrong[port] = normalized;
     } else {
-        Libretro.core.rumbleWeak[port] = normalized;
+        LIBRETRO.core.rumbleWeak[port] = normalized;
     }
-    SetGamepadVibration((int)port, Libretro.core.rumbleStrong[port], Libretro.core.rumbleWeak[port], 3600.0f);
+    SetGamepadVibration((int)port, LIBRETRO.core.rumbleStrong[port], LIBRETRO.core.rumbleWeak[port], 3600.0f);
     return true;
 }
 
@@ -710,8 +710,8 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
             if (data == NULL) {
                 return false;
             }
-            Libretro.core.rotation = *(const unsigned *)data;
-            TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_ROTATION: %u (%u°)", Libretro.core.rotation, Libretro.core.rotation * 90);
+            LIBRETRO.core.rotation = *(const unsigned *)data;
+            TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_ROTATION: %u (%u°)", LIBRETRO.core.rotation, LIBRETRO.core.rotation * 90);
             return true;
         }
 
@@ -741,14 +741,14 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_MESSAGE: %s (%i frames)", message->msg, message->frames);
-            TextCopy(Libretro.core.osdMessage, message->msg);
-            Libretro.core.osdEndTime = GetTime() + message->frames / (Libretro.core.fps > 0 ? (double)Libretro.core.fps : 60.0);
+            TextCopy(LIBRETRO.core.osdMessage, message->msg);
+            LIBRETRO.core.osdEndTime = GetTime() + message->frames / (LIBRETRO.core.fps > 0 ? (double)LIBRETRO.core.fps : 60.0);
             return true;
         }
 
         case RETRO_ENVIRONMENT_SHUTDOWN: {
             TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SHUTDOWN");
-            Libretro.core.shutdown = true;
+            LIBRETRO.core.shutdown = true;
             return true;
         }
 
@@ -757,8 +757,8 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 TraceLog(LOG_WARNING, "LIBRETRO: RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL no data provided");
                 return false;
             }
-            Libretro.core.performanceLevel = *(const unsigned *)data;
-            TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL(%i)", Libretro.core.performanceLevel);
+            LIBRETRO.core.performanceLevel = *(const unsigned *)data;
+            TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL(%i)", LIBRETRO.core.performanceLevel);
             return true;
         }
 
@@ -778,9 +778,9 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 TraceLog(LOG_WARNING, "LIBRETRO: RETRO_ENVIRONMENT_SET_PIXEL_FORMAT no data set");
                 return false;
             }
-            Libretro.core.pixelFormat = *pixelFormat;
+            LIBRETRO.core.pixelFormat = *pixelFormat;
 
-            switch (Libretro.core.pixelFormat) {
+            switch (LIBRETRO.core.pixelFormat) {
             case RETRO_PIXEL_FORMAT_0RGB1555:
                 TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_PIXEL_FORMAT 0RGB1555");
                 break;
@@ -792,7 +792,7 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 break;
             default:
                 TraceLog(LOG_ERROR, "LIBRETRO: RETRO_ENVIRONMENT_SET_PIXEL_FORMAT Unknown. Falling to RGB565");
-                Libretro.core.pixelFormat = RETRO_PIXEL_FORMAT_RGB565;
+                LIBRETRO.core.pixelFormat = RETRO_PIXEL_FORMAT_RGB565;
                 return false;
             }
             return true;
@@ -808,20 +808,20 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
             for (const struct retro_input_descriptor *d = desc; d->description != NULL; d++) {
                 count++;
             }
-            if (Libretro.core.inputDescriptors != NULL) {
-                MemFree(Libretro.core.inputDescriptors);
-                Libretro.core.inputDescriptors = NULL;
-                Libretro.core.inputDescriptorCount = 0;
+            if (LIBRETRO.core.inputDescriptors != NULL) {
+                MemFree(LIBRETRO.core.inputDescriptors);
+                LIBRETRO.core.inputDescriptors = NULL;
+                LIBRETRO.core.inputDescriptorCount = 0;
             }
             if (count > 0) {
-                Libretro.core.inputDescriptors = (struct retro_input_descriptor *)MemAlloc(count * sizeof(struct retro_input_descriptor));
-                if (Libretro.core.inputDescriptors != NULL) {
+                LIBRETRO.core.inputDescriptors = (struct retro_input_descriptor *)MemAlloc(count * sizeof(struct retro_input_descriptor));
+                if (LIBRETRO.core.inputDescriptors != NULL) {
                     for (unsigned i = 0; i < count; i++) {
-                        Libretro.core.inputDescriptors[i] = desc[i];
+                        LIBRETRO.core.inputDescriptors[i] = desc[i];
                         TraceLog(LOG_INFO, "LIBRETRO: Input port %u device %u index %u id %u: %s",
                             desc[i].port, desc[i].device, desc[i].index, desc[i].id, desc[i].description);
                     }
-                    Libretro.core.inputDescriptorCount = count;
+                    LIBRETRO.core.inputDescriptorCount = count;
                 }
             }
             return true;
@@ -833,7 +833,7 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const struct retro_keyboard_callback * callback = (const struct retro_keyboard_callback *)data;
-            Libretro.core.keyboard_event = callback->callback;
+            LIBRETRO.core.keyboard_event = callback->callback;
             return true;
         }
 
@@ -870,7 +870,7 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 TraceLog(LOG_WARNING, "LIBRETRO: RETRO_ENVIRONMENT_SET_VARIABLES no data set");
                 return false;
             }
-            Libretro.core.variableOptionsVersion = 0;
+            LIBRETRO.core.variableOptionsVersion = 0;
             const struct retro_variable *var = (const struct retro_variable *)data;
             for (; var->key != NULL; var++) {
                 // Description format: "Desc text; option1|option2|...". Default is the first option.
@@ -909,8 +909,8 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             bool *updated = (bool *)data;
-            *updated = Libretro.core.variablesDirty;
-            Libretro.core.variablesDirty = false;
+            *updated = LIBRETRO.core.variablesDirty;
+            LIBRETRO.core.variablesDirty = false;
             return true;
         }
 
@@ -920,8 +920,8 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 TraceLog(LOG_WARNING, "LIBRETRO: RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME no data provided");
                 return false;
             }
-            Libretro.core.supportNoGame = *(bool*)data;
-            TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME: %s", Libretro.core.supportNoGame ? "true" : "false");
+            LIBRETRO.core.supportNoGame = *(bool*)data;
+            TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME: %s", LIBRETRO.core.supportNoGame ? "true" : "false");
             return true;
         }
 
@@ -931,7 +931,7 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const char** path = (const char**)data;
-            *path = Libretro.core.corePath[0] != '\0' ? Libretro.core.corePath : NULL;
+            *path = LIBRETRO.core.corePath[0] != '\0' ? LIBRETRO.core.corePath : NULL;
             return true;
         }
 
@@ -941,7 +941,7 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const struct retro_frame_time_callback *frame_time = (const struct retro_frame_time_callback*)data;
-            Libretro.core.runloop_frame_time = *frame_time;
+            LIBRETRO.core.runloop_frame_time = *frame_time;
             return true;
         }
 
@@ -951,7 +951,7 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             struct retro_audio_callback *audio_cb = (struct retro_audio_callback*)data;
-            Libretro.core.audio_callback = *audio_cb;
+            LIBRETRO.core.audio_callback = *audio_cb;
             return true;
         }
 
@@ -1045,17 +1045,17 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const struct retro_system_av_info av = *(const struct retro_system_av_info *)data;
-            bool sampleRateChanged = (av.timing.sample_rate != Libretro.core.sampleRate);
-            bool dimsChanged = (av.geometry.base_width != Libretro.core.width || av.geometry.base_height != Libretro.core.height);
-            Libretro.core.width = av.geometry.base_width;
-            Libretro.core.height = av.geometry.base_height;
-            Libretro.core.fps = (unsigned int)av.timing.fps;
-            Libretro.core.sampleRate = av.timing.sample_rate;
-            Libretro.core.aspectRatio = av.geometry.aspect_ratio;
+            bool sampleRateChanged = (av.timing.sample_rate != LIBRETRO.core.sampleRate);
+            bool dimsChanged = (av.geometry.base_width != LIBRETRO.core.width || av.geometry.base_height != LIBRETRO.core.height);
+            LIBRETRO.core.width = av.geometry.base_width;
+            LIBRETRO.core.height = av.geometry.base_height;
+            LIBRETRO.core.fps = (unsigned int)av.timing.fps;
+            LIBRETRO.core.sampleRate = av.timing.sample_rate;
+            LIBRETRO.core.aspectRatio = av.geometry.aspect_ratio;
             TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO %i x %i @ %i FPS",
-                Libretro.core.width,
-                Libretro.core.height,
-                Libretro.core.fps
+                LIBRETRO.core.width,
+                LIBRETRO.core.height,
+                LIBRETRO.core.fps
             );
             if (dimsChanged) {
                 InitLibretroVideo();
@@ -1063,7 +1063,7 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
             if (sampleRateChanged) {
                 InitLibretroAudio();
             }
-            SetTargetFPS((int)(Libretro.core.fps * Libretro.speed));
+            SetTargetFPS((int)(LIBRETRO.core.fps * LIBRETRO.speed));
             return true;
         }
 
@@ -1083,26 +1083,26 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const struct retro_controller_info *info = (const struct retro_controller_info *)data;
-            if (Libretro.core.controllerInfo != NULL) {
-                MemFree(Libretro.core.controllerInfo);
-                Libretro.core.controllerInfo = NULL;
-                Libretro.core.controllerPortCount = 0;
+            if (LIBRETRO.core.controllerInfo != NULL) {
+                MemFree(LIBRETRO.core.controllerInfo);
+                LIBRETRO.core.controllerInfo = NULL;
+                LIBRETRO.core.controllerPortCount = 0;
             }
             unsigned portCount = 0;
             for (unsigned port = 0; info[port].types != NULL; port++) {
                 portCount++;
             }
             if (portCount > 0) {
-                Libretro.core.controllerInfo = (struct retro_controller_info *)MemAlloc(portCount * sizeof(struct retro_controller_info));
-                if (Libretro.core.controllerInfo != NULL) {
+                LIBRETRO.core.controllerInfo = (struct retro_controller_info *)MemAlloc(portCount * sizeof(struct retro_controller_info));
+                if (LIBRETRO.core.controllerInfo != NULL) {
                     for (unsigned port = 0; port < portCount; port++) {
-                        Libretro.core.controllerInfo[port] = info[port];
+                        LIBRETRO.core.controllerInfo[port] = info[port];
                         TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_CONTROLLER_INFO port %u (%u types)", port, info[port].num_types);
                         for (unsigned i = 0; i < info[port].num_types; i++) {
                             TraceLog(LOG_INFO, "    > [%u] %s (id: %u)", i, info[port].types[i].desc, info[port].types[i].id);
                         }
                     }
-                    Libretro.core.controllerPortCount = portCount;
+                    LIBRETRO.core.controllerPortCount = portCount;
                 }
             }
             return true;
@@ -1122,15 +1122,15 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const struct retro_game_geometry *geom = (const struct retro_game_geometry *)data;
-            Libretro.core.width = geom->base_width;
-            Libretro.core.height = geom->base_height;
-            Libretro.core.aspectRatio = geom->aspect_ratio;
+            LIBRETRO.core.width = geom->base_width;
+            LIBRETRO.core.height = geom->base_height;
+            LIBRETRO.core.aspectRatio = geom->aspect_ratio;
             TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_GEOMETRY %i x %i @ %f",
-                Libretro.core.width,
-                Libretro.core.height,
-                Libretro.core.aspectRatio
+                LIBRETRO.core.width,
+                LIBRETRO.core.height,
+                LIBRETRO.core.aspectRatio
             );
-            Libretro.core.textureRebuild = true;
+            LIBRETRO.core.textureRebuild = true;
             return true;
         }
 
@@ -1195,7 +1195,7 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
             }
 
             struct retro_vfs_interface_info * vfs_interface = (struct retro_vfs_interface_info *)data;
-            vfs_interface->iface = &Libretro.core.vfs_interface;
+            vfs_interface->iface = &LIBRETRO.core.vfs_interface;
 
             // VFS 1
             if (vfs_interface->required_interface_version >= 1) {
@@ -1268,7 +1268,7 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 TraceLog(LOG_WARNING, "LIBRETRO: RETRO_ENVIRONMENT_GET_FASTFORWARDING data missing");
                 return false;
             }
-            *output = (Libretro.speed > 1.0f);
+            *output = (LIBRETRO.speed > 1.0f);
             return true;
         }
 
@@ -1303,7 +1303,7 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 TraceLog(LOG_WARNING, "LIBRETRO: RETRO_ENVIRONMENT_SET_CORE_OPTIONS data missing");
                 return false;
             }
-            Libretro.core.variableOptionsVersion = 1;
+            LIBRETRO.core.variableOptionsVersion = 1;
             for (; opts->key != NULL; opts++) {
                 const char *def = opts->default_value;
                 if (def == NULL && opts->values[0].value != NULL) {
@@ -1353,10 +1353,10 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
         case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY: {
             const struct retro_core_option_display *disp = (const struct retro_core_option_display *)data;
             if (!disp || !disp->key) return false;
-            for (unsigned i = 0; i < Libretro.core.variableCount; i++) {
-                if (TextIsEqual(Libretro.core.variableKeys[i], disp->key)) {
-                    Libretro.core.variableVisible[i] = disp->visible;
-                    Libretro.core.variablesVisibilityDirty = true;
+            for (unsigned i = 0; i < LIBRETRO.core.variableCount; i++) {
+                if (TextIsEqual(LIBRETRO.core.variableKeys[i], disp->key)) {
+                    LIBRETRO.core.variableVisible[i] = disp->visible;
+                    LIBRETRO.core.variablesVisibilityDirty = true;
                     return true;
                 }
             }
@@ -1398,8 +1398,8 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 TraceLog(LibretroMapRetroLogLevelToTraceLogType(message->level), "LIBRETRO: %s", message->msg);
             }
             if (message->target == RETRO_MESSAGE_TARGET_OSD || message->target == RETRO_MESSAGE_TARGET_ALL) {
-                TextCopy(Libretro.core.osdMessage, message->msg);
-                Libretro.core.osdEndTime = GetTime() + message->duration / 1000.0;
+                TextCopy(LIBRETRO.core.osdMessage, message->msg);
+                LIBRETRO.core.osdEndTime = GetTime() + message->duration / 1000.0;
             }
             return true;
         }
@@ -1420,13 +1420,13 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
 
         case RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK: {
             if (data == NULL) {
-                Libretro.core.audio_buffer_status_callback.callback = NULL;
+                LIBRETRO.core.audio_buffer_status_callback.callback = NULL;
                 TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK disabled");
                 return true;
             }
             const struct retro_audio_buffer_status_callback *cb =
                 (const struct retro_audio_buffer_status_callback *)data;
-            Libretro.core.audio_buffer_status_callback = *cb;
+            LIBRETRO.core.audio_buffer_status_callback = *cb;
             TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK registered");
             return true;
         }
@@ -1437,15 +1437,15 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             unsigned latencyMs = *(const unsigned *)data;
-            if (latencyMs == Libretro.core.minimumAudioLatencyMs) {
+            if (latencyMs == LIBRETRO.core.minimumAudioLatencyMs) {
                 return true;
             }
-            Libretro.core.minimumAudioLatencyMs = latencyMs;
+            LIBRETRO.core.minimumAudioLatencyMs = latencyMs;
             TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_MINIMUM_AUDIO_LATENCY: %u ms", latencyMs);
             // Reinit audio so the new minimum is reflected in the ring buffer.
             // Safe before audio init (no-op via the NULL check) and at runtime
             // (matches the SET_SYSTEM_AV_INFO sample-rate-change path above).
-            if (Libretro.core.audioRingBuffer != NULL && Libretro.core.sampleRate > 0.0) {
+            if (LIBRETRO.core.audioRingBuffer != NULL && LIBRETRO.core.sampleRate > 0.0) {
                 InitLibretroAudio();
             }
             return true;
@@ -1470,18 +1470,18 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
             // its real array.
             if (data == NULL) return true;
 
-            Libretro.core.contentInfoOverrideCount = 0;
+            LIBRETRO.core.contentInfoOverrideCount = 0;
             const struct retro_system_content_info_override *o =
                 (const struct retro_system_content_info_override *)data;
             for (; o->extensions != NULL; o++) {
-                if (Libretro.core.contentInfoOverrideCount >= LIBRETRO_MAX_CONTENT_INFO_OVERRIDES) {
+                if (LIBRETRO.core.contentInfoOverrideCount >= LIBRETRO_MAX_CONTENT_INFO_OVERRIDES) {
                     TraceLog(LOG_WARNING, "LIBRETRO: Too many content info overrides; dropping rest");
                     break;
                 }
-                unsigned i = Libretro.core.contentInfoOverrideCount++;
-                TextCopy(Libretro.core.contentInfoOverrideExts[i], o->extensions);
-                Libretro.core.contentInfoOverrideNeedFullpath[i] = o->need_fullpath;
-                Libretro.core.contentInfoOverridePersistent[i]   = o->persistent_data;
+                unsigned i = LIBRETRO.core.contentInfoOverrideCount++;
+                TextCopy(LIBRETRO.core.contentInfoOverrideExts[i], o->extensions);
+                LIBRETRO.core.contentInfoOverrideNeedFullpath[i] = o->need_fullpath;
+                LIBRETRO.core.contentInfoOverridePersistent[i]   = o->persistent_data;
                 TraceLog(LOG_INFO, "LIBRETRO: content_info_override: ext=\"%s\" need_fullpath=%s persistent=%s",
                     o->extensions,
                     o->need_fullpath ? "true" : "false",
@@ -1491,8 +1491,8 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
         }
 
         case RETRO_ENVIRONMENT_GET_GAME_INFO_EXT: {
-            if (data == NULL || !Libretro.core.gameInfoExtValid) return false;
-            *(const struct retro_game_info_ext **)data = &Libretro.core.gameInfoExt;
+            if (data == NULL || !LIBRETRO.core.gameInfoExtValid) return false;
+            *(const struct retro_game_info_ext **)data = &LIBRETRO.core.gameInfoExt;
             return true;
         }
 
@@ -1504,7 +1504,7 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
             if (opts->definitions == NULL) {
                 return false;
             }
-            Libretro.core.variableOptionsVersion = 2;
+            LIBRETRO.core.variableOptionsVersion = 2;
             const struct retro_core_option_v2_definition *def = opts->definitions;
             for (; def->key != NULL; def++) {
                 const char *defaultVal = def->default_value;
@@ -1558,7 +1558,7 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
         case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_UPDATE_DISPLAY_CALLBACK: {
             const struct retro_core_options_update_display_callback *cb =
                 (const struct retro_core_options_update_display_callback *)data;
-            Libretro.core.options_update_display_callback = (cb && cb->callback) ? cb->callback : NULL;
+            LIBRETRO.core.options_update_display_callback = (cb && cb->callback) ? cb->callback : NULL;
             return true;
         }
 
@@ -1575,15 +1575,15 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
             if (state == NULL) {
                 return false;
             }
-            if (Libretro.speed > 1.0f) {
+            if (LIBRETRO.speed > 1.0f) {
                 state->mode = RETRO_THROTTLE_FAST_FORWARD;
-                state->rate = Libretro.core.fps * Libretro.speed;
-            } else if (Libretro.speed < 1.0f) {
+                state->rate = LIBRETRO.core.fps * LIBRETRO.speed;
+            } else if (LIBRETRO.speed < 1.0f) {
                 state->mode = RETRO_THROTTLE_SLOW_MOTION;
-                state->rate = Libretro.core.fps * Libretro.speed;
+                state->rate = LIBRETRO.core.fps * LIBRETRO.speed;
             } else {
                 state->mode = RETRO_THROTTLE_NONE;
-                state->rate = (float)Libretro.core.fps;
+                state->rate = (float)LIBRETRO.core.fps;
             }
             return true;
         }
@@ -1666,21 +1666,21 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
  * Retrieve the audio/video information for the core.
  */
 static bool LibretroGetAudioVideo(void) {
-    if (Libretro.core.retro_get_system_av_info == NULL) {
+    if (LIBRETRO.core.retro_get_system_av_info == NULL) {
         return false;
     }
 
     struct retro_system_av_info av = {0};
-    Libretro.core.retro_get_system_av_info(&av);
-    Libretro.core.width = av.geometry.base_width;
-    Libretro.core.height = av.geometry.base_height;
-    Libretro.core.fps = (unsigned int)av.timing.fps;
-    Libretro.core.sampleRate = av.timing.sample_rate;
-    Libretro.core.aspectRatio = av.geometry.aspect_ratio;
+    LIBRETRO.core.retro_get_system_av_info(&av);
+    LIBRETRO.core.width = av.geometry.base_width;
+    LIBRETRO.core.height = av.geometry.base_height;
+    LIBRETRO.core.fps = (unsigned int)av.timing.fps;
+    LIBRETRO.core.sampleRate = av.timing.sample_rate;
+    LIBRETRO.core.aspectRatio = av.geometry.aspect_ratio;
     TraceLog(LOG_INFO, "LIBRETRO: Video and Audio information");
-    TraceLog(LOG_INFO, "    > Display size: %i x %i", Libretro.core.width, Libretro.core.height);
-    TraceLog(LOG_INFO, "    > Target FPS:   %i", Libretro.core.fps);
-    TraceLog(LOG_INFO, "    > Sample rate:  %.2f Hz", Libretro.core.sampleRate);
+    TraceLog(LOG_INFO, "    > Display size: %i x %i", LIBRETRO.core.width, LIBRETRO.core.height);
+    TraceLog(LOG_INFO, "    > Target FPS:   %i", LIBRETRO.core.fps);
+    TraceLog(LOG_INFO, "    > Sample rate:  %.2f Hz", LIBRETRO.core.sampleRate);
     return true;
 }
 
@@ -1688,33 +1688,33 @@ static bool LibretroGetAudioVideo(void) {
  * Run one emulation frame of the loaded core.
  */
 static void UpdateLibretro(void) {
-    if (Libretro.core.textureRebuild) {
+    if (LIBRETRO.core.textureRebuild) {
         InitLibretroVideo();
     }
 
     if (IsLibretroGameReady()) {
-        Libretro.core.gameTimeNSEC += (retro_perf_tick_t)((double)GetFrameTime() * 1000000000.0);
+        LIBRETRO.core.gameTimeNSEC += (retro_perf_tick_t)((double)GetFrameTime() * 1000000000.0);
     }
 
     // Update the game loop timer.
-    if (Libretro.core.runloop_frame_time.callback) {
+    if (LIBRETRO.core.runloop_frame_time.callback) {
         retro_time_t current = GetLibretroTimeUSEC();
-        retro_time_t delta = current - Libretro.core.runloop_frame_time_last;
+        retro_time_t delta = current - LIBRETRO.core.runloop_frame_time_last;
 
-        if (!Libretro.core.runloop_frame_time_last) {
-            delta = Libretro.core.runloop_frame_time.reference;
+        if (!LIBRETRO.core.runloop_frame_time_last) {
+            delta = LIBRETRO.core.runloop_frame_time.reference;
         }
-        Libretro.core.runloop_frame_time_last = current;
-        Libretro.core.runloop_frame_time.callback(delta);
+        LIBRETRO.core.runloop_frame_time_last = current;
+        LIBRETRO.core.runloop_frame_time.callback(delta);
     }
 
     // Ask the core to emit the audio.
-    if (Libretro.core.audio_callback.callback) {
-        Libretro.core.audio_callback.callback();
+    if (LIBRETRO.core.audio_callback.callback) {
+        LIBRETRO.core.audio_callback.callback();
     }
 
     // Check keyboard event callback.
-    if (Libretro.core.keyboard_event != NULL) {
+    if (LIBRETRO.core.keyboard_event != NULL) {
         // Prepare the key modifiers.
         uint16_t key_modifiers = 0;
         if (IsKeyDown(KEY_LEFT_SHIFT) || IsKeyDown(KEY_RIGHT_SHIFT)) {
@@ -1755,10 +1755,10 @@ static void UpdateLibretro(void) {
             int raylibKey = LibretroRetroKeyToKeyboardKey(key);
             if (raylibKey > 0) {
                 if (IsKeyPressed(raylibKey)) {
-                    Libretro.core.keyboard_event(true, key, (uint32_t)keyCharMap[raylibKey], key_modifiers);
+                    LIBRETRO.core.keyboard_event(true, key, (uint32_t)keyCharMap[raylibKey], key_modifiers);
                 }
                 else if (IsKeyReleased(raylibKey)) {
-                    Libretro.core.keyboard_event(false, key, 0, key_modifiers);
+                    LIBRETRO.core.keyboard_event(false, key, 0, key_modifiers);
                 }
             }
         }
@@ -1767,51 +1767,51 @@ static void UpdateLibretro(void) {
     if (IsLibretroGameReady()) {
         // Report audio buffer occupancy to the core just before retro_run, so
         // it can decide whether to frameskip to avoid under-runs.
-        if (Libretro.core.audio_buffer_status_callback.callback && Libretro.core.audioRingBufferSize > 0) {
-            unsigned occupancy = (unsigned)((Libretro.core.audioRingAvailable * 100) / Libretro.core.audioRingBufferSize);
+        if (LIBRETRO.core.audio_buffer_status_callback.callback && LIBRETRO.core.audioRingBufferSize > 0) {
+            unsigned occupancy = (unsigned)((LIBRETRO.core.audioRingAvailable * 100) / LIBRETRO.core.audioRingBufferSize);
             if (occupancy > 100) occupancy = 100;
             bool underrun_likely = occupancy < 25;
-            Libretro.core.audio_buffer_status_callback.callback(true, occupancy, underrun_likely);
+            LIBRETRO.core.audio_buffer_status_callback.callback(true, occupancy, underrun_likely);
         }
 
-        Libretro.core.retro_run();
+        LIBRETRO.core.retro_run();
 
         // Flush any single-sample accumulator left over from retro_run so
         // samples arrive in the ring buffer within the same frame.
-        if (Libretro.core.singleSampleCount > 0) {
-            UpdateLibretroAudioSampleBatch(Libretro.core.singleSampleBuffer, Libretro.core.singleSampleCount);
-            Libretro.core.singleSampleCount = 0;
+        if (LIBRETRO.core.singleSampleCount > 0) {
+            UpdateLibretroAudioSampleBatch(LIBRETRO.core.singleSampleBuffer, LIBRETRO.core.singleSampleCount);
+            LIBRETRO.core.singleSampleCount = 0;
         }
 
         // Dynamic Rate Control: nudge audio pitch to steer ring-buffer occupancy
         // toward 50% so the audio stays in sync.
-        if (Libretro.core.drcEnabled && Libretro.core.audioRingBufferSize > 0 && IsAudioStreamValid(Libretro.core.audioStream)) {
+        if (LIBRETRO.core.drcEnabled && LIBRETRO.core.audioRingBufferSize > 0 && IsAudioStreamValid(LIBRETRO.core.audioStream)) {
             // Positive drift when buffer is full (consume faster).
             // Negative drift when buffer is empty (consume slower).
-            float drift = ((float)Libretro.core.audioRingAvailable / (float)Libretro.core.audioRingBufferSize) - 0.5f;
-            Libretro.core.drcAdjustment += drift * 0.001f;
-            if (Libretro.core.drcAdjustment < 0.995f) Libretro.core.drcAdjustment = 0.995f;
-            if (Libretro.core.drcAdjustment > 1.005f) Libretro.core.drcAdjustment = 1.005f;
-            SetAudioStreamPitch(Libretro.core.audioStream, Libretro.core.drcAdjustment);
+            float drift = ((float)LIBRETRO.core.audioRingAvailable / (float)LIBRETRO.core.audioRingBufferSize) - 0.5f;
+            LIBRETRO.core.drcAdjustment += drift * 0.001f;
+            if (LIBRETRO.core.drcAdjustment < 0.995f) LIBRETRO.core.drcAdjustment = 0.995f;
+            if (LIBRETRO.core.drcAdjustment > 1.005f) LIBRETRO.core.drcAdjustment = 1.005f;
+            SetAudioStreamPitch(LIBRETRO.core.audioStream, LIBRETRO.core.drcAdjustment);
         }
 
         // Some cores (notably mgba GB/GBC) defer the actual core reset until
         // the first retro_run, so retro_get_system_av_info called pre-run
         // returns sample_rate=0. Once we have a frame, re-query AV info and
         // reinit audio if a valid sample rate has appeared.
-        if (Libretro.core.sampleRate <= 0.0 && Libretro.core.retro_get_system_av_info) {
+        if (LIBRETRO.core.sampleRate <= 0.0 && LIBRETRO.core.retro_get_system_av_info) {
             struct retro_system_av_info av = {0};
-            Libretro.core.retro_get_system_av_info(&av);
+            LIBRETRO.core.retro_get_system_av_info(&av);
             if (av.timing.sample_rate > 0.0) {
-                Libretro.core.sampleRate = av.timing.sample_rate;
-                TraceLog(LOG_INFO, "LIBRETRO: Sample rate now %.2f Hz (post-retro_run); reinitializing audio", Libretro.core.sampleRate);
+                LIBRETRO.core.sampleRate = av.timing.sample_rate;
+                TraceLog(LOG_INFO, "LIBRETRO: Sample rate now %.2f Hz (post-retro_run); reinitializing audio", LIBRETRO.core.sampleRate);
                 InitLibretroAudio();
             }
         }
 
-        if (Libretro.core.options_update_display_callback) {
-            if (Libretro.core.options_update_display_callback()) {
-                Libretro.core.variablesVisibilityDirty = true;
+        if (LIBRETRO.core.options_update_display_callback) {
+            if (LIBRETRO.core.options_update_display_callback()) {
+                LIBRETRO.core.variablesVisibilityDirty = true;
             }
         }
     }
@@ -1821,7 +1821,7 @@ static void UpdateLibretro(void) {
  * Check whether a core has been successfully initialized.
  * @return true if a core is loaded and ready. */
 static bool IsLibretroReady(void) {
-    return Libretro.core.handle != NULL;
+    return LIBRETRO.core.handle != NULL;
 }
 
 /**
@@ -1829,7 +1829,7 @@ static bool IsLibretroReady(void) {
  * @return true if the core wants to close.
  */
 static bool LibretroShouldClose(void) {
-    return Libretro.core.shutdown;
+    return LIBRETRO.core.shutdown;
 }
 
 static void LibretroMapPixelFormatARGB8888ToRGBA8888(void *output_, const void *input_,
@@ -1864,54 +1864,54 @@ static void LibretroVideoRefresh(const void *data, unsigned width, unsigned heig
     }
 
     // Resize the video if needed.
-    if (width != Libretro.core.width || height != Libretro.core.height) {
-        Libretro.core.width = width;
-        Libretro.core.height = height;
+    if (width != LIBRETRO.core.width || height != LIBRETRO.core.height) {
+        LIBRETRO.core.width = width;
+        LIBRETRO.core.height = height;
         if (!InitLibretroVideo()) {
             return;
         }
     }
 
-    if (!IsTextureValid(Libretro.core.texture)) {
+    if (!IsTextureValid(LIBRETRO.core.texture)) {
         return;
     }
 
-    switch (Libretro.core.pixelFormat) {
+    switch (LIBRETRO.core.pixelFormat) {
         case RETRO_PIXEL_FORMAT_UNKNOWN:
         case RETRO_PIXEL_FORMAT_RGB565: {
             // For small pitches, we can use the data 1:1, otherwise we need to adjust it.
             if (pitch == width * 2) {
                 // Core: FCEUM
-                UpdateTexture(Libretro.core.texture, data);
+                UpdateTexture(LIBRETRO.core.texture, data);
             }
             else {
                 // Core: SNES9x
                 const uint8_t *src = (const uint8_t *)data;
-                uint8_t *dst = (uint8_t *)Libretro.core.frameBuffer;
+                uint8_t *dst = (uint8_t *)LIBRETRO.core.frameBuffer;
                 size_t row_bytes = width * 2;
                 for (unsigned h = 0; h < height; h++) {
                     memcpy(dst, src, row_bytes);
                     src += pitch;
                     dst += row_bytes;
                 }
-                UpdateTexture(Libretro.core.texture, Libretro.core.frameBuffer);
+                UpdateTexture(LIBRETRO.core.texture, LIBRETRO.core.frameBuffer);
             }
         }
         break;
         case RETRO_PIXEL_FORMAT_0RGB1555: {
-            LibretroPixelFormatARGB1555ToRGB565(Libretro.core.frameBuffer, data, width, height,
+            LibretroPixelFormatARGB1555ToRGB565(LIBRETRO.core.frameBuffer, data, width, height,
                 (int)(width * 2),
                 pitch);
-            UpdateTexture(Libretro.core.texture, Libretro.core.frameBuffer);
+            UpdateTexture(LIBRETRO.core.texture, LIBRETRO.core.frameBuffer);
         }
         break;
         case RETRO_PIXEL_FORMAT_XRGB8888: {
             // Core: Blastem
             // Core: BSNES
-            LibretroMapPixelFormatARGB8888ToRGBA8888(Libretro.core.frameBuffer, data,
+            LibretroMapPixelFormatARGB8888ToRGBA8888(LIBRETRO.core.frameBuffer, data,
                 width, height,
                 (int)(width * 4), pitch);
-            UpdateTexture(Libretro.core.texture, Libretro.core.frameBuffer);
+            UpdateTexture(LIBRETRO.core.texture, LIBRETRO.core.frameBuffer);
         }
         break;
     }
@@ -1919,8 +1919,8 @@ static void LibretroVideoRefresh(const void *data, unsigned width, unsigned heig
 
 static void LibretroInputPoll(void) {
     // Mouse
-    Libretro.core.inputLastMousePosition = Libretro.core.inputMousePosition;
-    Libretro.core.inputMousePosition = GetMousePosition();
+    LIBRETRO.core.inputLastMousePosition = LIBRETRO.core.inputMousePosition;
+    LIBRETRO.core.inputMousePosition = GetMousePosition();
 }
 
 static int16_t LibretroInputState(unsigned port, unsigned device, unsigned index, unsigned id) {
@@ -1940,14 +1940,14 @@ static int16_t LibretroInputState(unsigned port, unsigned device, unsigned index
                 for (int btn = 0; btn < 16; btn++) {
                     bool pressed = false;
                     if (port == 0) {
-                        if (btn < 16 && Libretro.core.virtualJoypadState[btn]) {
+                        if (btn < 16 && LIBRETRO.core.virtualJoypadState[btn]) {
                             pressed = true;
                         } else if (gpAvail) {
                             int gamepadButton = LibretroRetroJoypadButtonToGamepadButton(btn);
                             pressed = (gamepadButton != GAMEPAD_BUTTON_UNKNOWN && IsGamepadButtonDown(0, gamepadButton));
                         }
                         if (!pressed) {
-                            int kbKey = (btn < 16) ? Libretro.keyboardPlayer1[btn] : KEY_NULL;
+                            int kbKey = (btn < 16) ? LIBRETRO.keyboardPlayer1[btn] : KEY_NULL;
                             if (kbKey != KEY_NULL) {
                                 pressed = IsKeyDown(kbKey);
                             } else {
@@ -1968,7 +1968,7 @@ static int16_t LibretroInputState(unsigned port, unsigned device, unsigned index
 
             // Port 0: gamepad if available, otherwise keyboard.
             if (port == 0) {
-                if (id < 16 && Libretro.core.virtualJoypadState[id]) {
+                if (id < 16 && LIBRETRO.core.virtualJoypadState[id]) {
                     return 1;
                 }
                 if (IsGamepadAvailable(0)) {
@@ -1977,7 +1977,7 @@ static int16_t LibretroInputState(unsigned port, unsigned device, unsigned index
                         return 1;
                     }
                 }
-                int kbKey = (id < 16) ? Libretro.keyboardPlayer1[id] : KEY_NULL;
+                int kbKey = (id < 16) ? LIBRETRO.keyboardPlayer1[id] : KEY_NULL;
                 if (kbKey != KEY_NULL) {
                     return (int)IsKeyDown(kbKey);
                 }
@@ -2006,9 +2006,9 @@ static int16_t LibretroInputState(unsigned port, unsigned device, unsigned index
                 case RETRO_DEVICE_ID_MOUSE_MIDDLE:
                     return IsMouseButtonDown(MOUSE_MIDDLE_BUTTON);
                 case RETRO_DEVICE_ID_MOUSE_X:
-                    return Libretro.core.inputMousePosition.x - Libretro.core.inputLastMousePosition.x;
+                    return LIBRETRO.core.inputMousePosition.x - LIBRETRO.core.inputLastMousePosition.x;
                 case RETRO_DEVICE_ID_MOUSE_Y:
-                    return Libretro.core.inputMousePosition.y - Libretro.core.inputLastMousePosition.y;
+                    return LIBRETRO.core.inputMousePosition.y - LIBRETRO.core.inputLastMousePosition.y;
                 case RETRO_DEVICE_ID_MOUSE_WHEELUP:
                     return GetMouseWheelMove() > 0;
                 case RETRO_DEVICE_ID_MOUSE_WHEELDOWN:
@@ -2058,9 +2058,9 @@ static int16_t LibretroInputState(unsigned port, unsigned device, unsigned index
                 case RETRO_DEVICE_ID_LIGHTGUN_DPAD_RIGHT:
                     return IsKeyDown(KEY_RIGHT);
                 case RETRO_DEVICE_ID_LIGHTGUN_X:
-                    return Libretro.core.inputMousePosition.x - Libretro.core.inputLastMousePosition.x;
+                    return LIBRETRO.core.inputMousePosition.x - LIBRETRO.core.inputLastMousePosition.x;
                 case RETRO_DEVICE_ID_LIGHTGUN_Y:
-                    return Libretro.core.inputMousePosition.y - Libretro.core.inputLastMousePosition.y;
+                    return LIBRETRO.core.inputMousePosition.y - LIBRETRO.core.inputLastMousePosition.y;
             }
             return 0;
         }
@@ -2114,61 +2114,61 @@ static int16_t LibretroInputState(unsigned port, unsigned device, unsigned index
 static void LibretroAudioStreamCallback(void *audioData, unsigned int frameCount) {
     float *output = (float *)audioData;
 
-    if (!Libretro.core.audioRingBuffer || Libretro.core.audioRingAvailable == 0) {
+    if (!LIBRETRO.core.audioRingBuffer || LIBRETRO.core.audioRingAvailable == 0) {
         memset(output, 0, frameCount * 2 * sizeof(float));
         return;
     }
 
     size_t frames_to_read = frameCount;
-    if (frames_to_read > Libretro.core.audioRingAvailable) {
-        size_t silence_frames = frames_to_read - Libretro.core.audioRingAvailable;
-        memset(output + Libretro.core.audioRingAvailable * 2, 0, silence_frames * 2 * sizeof(float));
-        frames_to_read = Libretro.core.audioRingAvailable;
+    if (frames_to_read > LIBRETRO.core.audioRingAvailable) {
+        size_t silence_frames = frames_to_read - LIBRETRO.core.audioRingAvailable;
+        memset(output + LIBRETRO.core.audioRingAvailable * 2, 0, silence_frames * 2 * sizeof(float));
+        frames_to_read = LIBRETRO.core.audioRingAvailable;
     }
 
-    size_t read_pos = (Libretro.core.audioRingWritePos + Libretro.core.audioRingBufferSize - Libretro.core.audioRingAvailable) % Libretro.core.audioRingBufferSize;
-    size_t first_chunk = Libretro.core.audioRingBufferSize - read_pos;
+    size_t read_pos = (LIBRETRO.core.audioRingWritePos + LIBRETRO.core.audioRingBufferSize - LIBRETRO.core.audioRingAvailable) % LIBRETRO.core.audioRingBufferSize;
+    size_t first_chunk = LIBRETRO.core.audioRingBufferSize - read_pos;
     if (first_chunk > frames_to_read) first_chunk = frames_to_read;
     size_t second_chunk = frames_to_read - first_chunk;
-    memcpy(output, Libretro.core.audioRingBuffer + read_pos * 2, first_chunk * 2 * sizeof(float));
+    memcpy(output, LIBRETRO.core.audioRingBuffer + read_pos * 2, first_chunk * 2 * sizeof(float));
     if (second_chunk > 0) {
-        memcpy(output + first_chunk * 2, Libretro.core.audioRingBuffer, second_chunk * 2 * sizeof(float));
+        memcpy(output + first_chunk * 2, LIBRETRO.core.audioRingBuffer, second_chunk * 2 * sizeof(float));
     }
 
-    Libretro.core.audioRingAvailable -= frames_to_read;
+    LIBRETRO.core.audioRingAvailable -= frames_to_read;
 }
 
 /**
  * Write a batch of int16_t stereo frames into the ring buffer.
  */
 static size_t UpdateLibretroAudioSampleBatch(const int16_t *data, size_t frames) {
-    if (!data || frames == 0 || !Libretro.core.audioRingBuffer) return 0;
+    if (!data || frames == 0 || !LIBRETRO.core.audioRingBuffer) return 0;
 
-    size_t available_space = Libretro.core.audioRingBufferSize - Libretro.core.audioRingAvailable;
+    size_t available_space = LIBRETRO.core.audioRingBufferSize - LIBRETRO.core.audioRingAvailable;
     size_t frames_to_write = (frames < available_space) ? frames : available_space;
 
     if (frames_to_write == 0) {
-        if (Libretro.core.audioDropWarnCount++ < 3) {
+        if (LIBRETRO.core.audioDropWarnCount++ < 3) {
             TraceLog(LOG_WARNING, "LIBRETRO: Audio ring buffer full, dropping %zu frames", frames);
         }
         return 0;
     }
 
     static const float scale = 1.0f / 32768.0f;
-    size_t wfirst = Libretro.core.audioRingBufferSize - Libretro.core.audioRingWritePos;
+    size_t wfirst = LIBRETRO.core.audioRingBufferSize - LIBRETRO.core.audioRingWritePos;
     if (wfirst > frames_to_write) wfirst = frames_to_write;
     size_t wsecond = frames_to_write - wfirst;
     for (size_t i = 0; i < wfirst; i++) {
-        Libretro.core.audioRingBuffer[(Libretro.core.audioRingWritePos + i) * 2]     = (float)data[i * 2]     * scale;
-        Libretro.core.audioRingBuffer[(Libretro.core.audioRingWritePos + i) * 2 + 1] = (float)data[i * 2 + 1] * scale;
+        LIBRETRO.core.audioRingBuffer[(LIBRETRO.core.audioRingWritePos + i) * 2]     = (float)data[i * 2]     * scale;
+        LIBRETRO.core.audioRingBuffer[(LIBRETRO.core.audioRingWritePos + i) * 2 + 1] = (float)data[i * 2 + 1] * scale;
     }
     for (size_t i = 0; i < wsecond; i++) {
-        Libretro.core.audioRingBuffer[i * 2]     = (float)data[(wfirst + i) * 2]     * scale;
-        Libretro.core.audioRingBuffer[i * 2 + 1] = (float)data[(wfirst + i) * 2 + 1] * scale;
+        LIBRETRO.core.audioRingBuffer[i * 2]     = (float)data[(wfirst + i) * 2]     * scale;
+        LIBRETRO.core.audioRingBuffer[i * 2 + 1] = (float)data[(wfirst + i) * 2 + 1] * scale;
     }
 
-    Libretro.core.audioRingWritePos = (Libretro.core.audioRingWritePos + frames_to_write) % Libretro.core.audioRingBufferSize;
-    Libretro.core.audioRingAvailable += frames_to_write;
+    LIBRETRO.core.audioRingWritePos = (LIBRETRO.core.audioRingWritePos + frames_to_write) % LIBRETRO.core.audioRingBufferSize;
+    LIBRETRO.core.audioRingAvailable += frames_to_write;
 
     return frames_to_write;
 }
@@ -2177,29 +2177,29 @@ static size_t UpdateLibretroAudioSampleBatch(const int16_t *data, size_t frames)
  * Accumulate single-sample callbacks into a buffer before flushing to the ring buffer.
  */
 static void UpdateLibretroAudioSample(int16_t left, int16_t right) {
-    if (Libretro.core.singleSampleCount >= LIBRETRO_AUDIO_SINGLE_SAMPLE_BUFFER_SIZE) {
-        UpdateLibretroAudioSampleBatch(Libretro.core.singleSampleBuffer, Libretro.core.singleSampleCount);
-        Libretro.core.singleSampleCount = 0;
+    if (LIBRETRO.core.singleSampleCount >= LIBRETRO_AUDIO_SINGLE_SAMPLE_BUFFER_SIZE) {
+        UpdateLibretroAudioSampleBatch(LIBRETRO.core.singleSampleBuffer, LIBRETRO.core.singleSampleCount);
+        LIBRETRO.core.singleSampleCount = 0;
     }
 
-    Libretro.core.singleSampleBuffer[Libretro.core.singleSampleCount * 2]     = left;
-    Libretro.core.singleSampleBuffer[Libretro.core.singleSampleCount * 2 + 1] = right;
-    Libretro.core.singleSampleCount++;
+    LIBRETRO.core.singleSampleBuffer[LIBRETRO.core.singleSampleCount * 2]     = left;
+    LIBRETRO.core.singleSampleBuffer[LIBRETRO.core.singleSampleCount * 2 + 1] = right;
+    LIBRETRO.core.singleSampleCount++;
 }
 
 static void CloseLibretroAudio(void) {
     // Unload the audiostream first.
-    if (IsAudioStreamValid(Libretro.core.audioStream)) {
-        StopAudioStream(Libretro.core.audioStream);
-        UnloadAudioStream(Libretro.core.audioStream);
-        memset(&Libretro.core.audioStream, 0, sizeof(Libretro.core.audioStream));
+    if (IsAudioStreamValid(LIBRETRO.core.audioStream)) {
+        StopAudioStream(LIBRETRO.core.audioStream);
+        UnloadAudioStream(LIBRETRO.core.audioStream);
+        memset(&LIBRETRO.core.audioStream, 0, sizeof(LIBRETRO.core.audioStream));
     }
-    if (Libretro.core.audioRingBuffer != NULL) {
-        MemFree(Libretro.core.audioRingBuffer);
-        Libretro.core.audioRingBuffer = NULL;
+    if (LIBRETRO.core.audioRingBuffer != NULL) {
+        MemFree(LIBRETRO.core.audioRingBuffer);
+        LIBRETRO.core.audioRingBuffer = NULL;
     }
-    Libretro.core.audioRingAvailable = 0;
-    Libretro.core.audioRingWritePos = 0;
+    LIBRETRO.core.audioRingAvailable = 0;
+    LIBRETRO.core.audioRingWritePos = 0;
 }
 
 static void InitLibretroAudio(void) {
@@ -2209,7 +2209,7 @@ static void InitLibretroAudio(void) {
     // (mgba GB/GBC) defer their internal reset until the first retro_run,
     // so retro_get_system_av_info returns 0 here. UpdateLibretro will
     // re-call InitLibretroAudio after the first run once the rate appears.
-    if (Libretro.core.sampleRate <= 0.0) {
+    if (LIBRETRO.core.sampleRate <= 0.0) {
         TraceLog(LOG_INFO, "LIBRETRO: Deferring audio init (sample rate not yet known)");
         return;
     }
@@ -2218,33 +2218,33 @@ static void InitLibretroAudio(void) {
     // LIBRETRO_AUDIO_RING_BUFFER_SIZE frames; grown to satisfy the core's
     // RETRO_ENVIRONMENT_SET_MINIMUM_AUDIO_LATENCY request if any.
     size_t frames = LIBRETRO_AUDIO_RING_BUFFER_SIZE;
-    if (Libretro.core.minimumAudioLatencyMs > 0) {
-        size_t requested = (size_t)((Libretro.core.minimumAudioLatencyMs / 1000.0) * Libretro.core.sampleRate);
+    if (LIBRETRO.core.minimumAudioLatencyMs > 0) {
+        size_t requested = (size_t)((LIBRETRO.core.minimumAudioLatencyMs / 1000.0) * LIBRETRO.core.sampleRate);
         if (requested > frames) frames = requested;
     }
-    Libretro.core.audioRingBufferSize = frames;
-    Libretro.core.audioRingBuffer = (float *)MemAlloc(Libretro.core.audioRingBufferSize * 2 * sizeof(float));
-    Libretro.core.audioRingWritePos = 0;
-    Libretro.core.audioRingAvailable = 0;
+    LIBRETRO.core.audioRingBufferSize = frames;
+    LIBRETRO.core.audioRingBuffer = (float *)MemAlloc(LIBRETRO.core.audioRingBufferSize * 2 * sizeof(float));
+    LIBRETRO.core.audioRingWritePos = 0;
+    LIBRETRO.core.audioRingAvailable = 0;
 
     // Create the audio stream: 32-bit float, stereo, pulled via callback.
     int sampleSize = 32;
     int channels = 2;
-    Libretro.core.audioStream = LoadAudioStream((unsigned int)Libretro.core.sampleRate, sampleSize, channels);
-    SetAudioStreamCallback(Libretro.core.audioStream, LibretroAudioStreamCallback);
-    SetAudioStreamVolume(Libretro.core.audioStream, Libretro.volume);
-    Libretro.core.drcAdjustment = 1.0f;
-    Libretro.core.drcEnabled = true;
-    Libretro.core.audioDropWarnCount = 0;
-    PlayAudioStream(Libretro.core.audioStream);
+    LIBRETRO.core.audioStream = LoadAudioStream((unsigned int)LIBRETRO.core.sampleRate, sampleSize, channels);
+    SetAudioStreamCallback(LIBRETRO.core.audioStream, LibretroAudioStreamCallback);
+    SetAudioStreamVolume(LIBRETRO.core.audioStream, LIBRETRO.volume);
+    LIBRETRO.core.drcAdjustment = 1.0f;
+    LIBRETRO.core.drcEnabled = true;
+    LIBRETRO.core.audioDropWarnCount = 0;
+    PlayAudioStream(LIBRETRO.core.audioStream);
 
     // Let the core know that the audio device has been initialized.
-    if (Libretro.core.audio_callback.set_state) {
-        Libretro.core.audio_callback.set_state(true);
+    if (LIBRETRO.core.audio_callback.set_state) {
+        LIBRETRO.core.audio_callback.set_state(true);
     }
 
     TraceLog(LOG_INFO, "LIBRETRO: Audio stream initialized (%i Hz, %i-bit float, ring buffer %i frames)",
-        (int)Libretro.core.sampleRate, sampleSize, (int)Libretro.core.audioRingBufferSize);
+        (int)LIBRETRO.core.sampleRate, sampleSize, (int)LIBRETRO.core.audioRingBufferSize);
 }
 
 static bool InitLibretroAudioVideo(void) {
@@ -2252,49 +2252,49 @@ static bool InitLibretroAudioVideo(void) {
     InitLibretroVideo();
     InitLibretroAudio();
 
-    SetTargetFPS((int)(Libretro.core.fps * Libretro.speed));
+    SetTargetFPS((int)(LIBRETRO.core.fps * LIBRETRO.speed));
 
     return true;
 }
 
-// Populate Libretro.core.gameInfoExt from Libretro.core.contentPath for
+// Populate LIBRETRO.core.gameInfoExt from LIBRETRO.core.contentPath for
 // RETRO_ENVIRONMENT_GET_GAME_INFO_EXT. Caller must set contentPath first.
 // `data`/`size` are only valid while retro_load_game() is executing.
 static void SetLibretroGameInfoExt(const void *data, size_t size) {
-    memset(&Libretro.core.gameInfoExt, 0, sizeof(Libretro.core.gameInfoExt));
-    Libretro.core.contentDir[0]  = '\0';
-    Libretro.core.contentName[0] = '\0';
-    Libretro.core.contentExt[0]  = '\0';
-    Libretro.core.gameInfoExtValid = false;
+    memset(&LIBRETRO.core.gameInfoExt, 0, sizeof(LIBRETRO.core.gameInfoExt));
+    LIBRETRO.core.contentDir[0]  = '\0';
+    LIBRETRO.core.contentName[0] = '\0';
+    LIBRETRO.core.contentExt[0]  = '\0';
+    LIBRETRO.core.gameInfoExtValid = false;
 
-    if (Libretro.core.contentPath[0] == '\0') return;
+    if (LIBRETRO.core.contentPath[0] == '\0') return;
 
-    TextCopy(Libretro.core.contentDir,  GetDirectoryPath(Libretro.core.contentPath));
-    TextCopy(Libretro.core.contentName, GetFileNameWithoutExt(Libretro.core.contentPath));
+    TextCopy(LIBRETRO.core.contentDir,  GetDirectoryPath(LIBRETRO.core.contentPath));
+    TextCopy(LIBRETRO.core.contentName, GetFileNameWithoutExt(LIBRETRO.core.contentPath));
 
     // Extension without leading dot, lower-cased.
-    const char *ext = GetFileExtension(Libretro.core.contentPath);
+    const char *ext = GetFileExtension(LIBRETRO.core.contentPath);
     if (ext != NULL && ext[0] == '.') ext++;
     if (ext != NULL) {
         size_t i = 0;
-        for (; ext[i] != '\0' && i + 1 < sizeof(Libretro.core.contentExt); i++) {
+        for (; ext[i] != '\0' && i + 1 < sizeof(LIBRETRO.core.contentExt); i++) {
             char c = ext[i];
             if (c >= 'A' && c <= 'Z') c = (char)(c - 'A' + 'a');
-            Libretro.core.contentExt[i] = c;
+            LIBRETRO.core.contentExt[i] = c;
         }
-        Libretro.core.contentExt[i] = '\0';
+        LIBRETRO.core.contentExt[i] = '\0';
     }
 
-    Libretro.core.gameInfoExt.full_path       = Libretro.core.contentPath;
-    Libretro.core.gameInfoExt.dir             = Libretro.core.contentDir;
-    Libretro.core.gameInfoExt.name            = Libretro.core.contentName;
-    Libretro.core.gameInfoExt.ext             = Libretro.core.contentExt;
-    Libretro.core.gameInfoExt.meta            = "";
-    Libretro.core.gameInfoExt.data            = data;
-    Libretro.core.gameInfoExt.size            = size;
-    Libretro.core.gameInfoExt.file_in_archive = false;
-    Libretro.core.gameInfoExt.persistent_data = false;
-    Libretro.core.gameInfoExtValid            = true;
+    LIBRETRO.core.gameInfoExt.full_path       = LIBRETRO.core.contentPath;
+    LIBRETRO.core.gameInfoExt.dir             = LIBRETRO.core.contentDir;
+    LIBRETRO.core.gameInfoExt.name            = LIBRETRO.core.contentName;
+    LIBRETRO.core.gameInfoExt.ext             = LIBRETRO.core.contentExt;
+    LIBRETRO.core.gameInfoExt.meta            = "";
+    LIBRETRO.core.gameInfoExt.data            = data;
+    LIBRETRO.core.gameInfoExt.size            = size;
+    LIBRETRO.core.gameInfoExt.file_in_archive = false;
+    LIBRETRO.core.gameInfoExt.persistent_data = false;
+    LIBRETRO.core.gameInfoExtValid            = true;
 }
 
 static bool LoadLibretroGameFromMemory(const unsigned char *fileData, int dataSize) {
@@ -2308,7 +2308,7 @@ static bool LoadLibretroGameFromMemory(const unsigned char *fileData, int dataSi
     }
 
     // Check if it needs the full path
-    if (Libretro.core.needFullpath) {
+    if (LIBRETRO.core.needFullpath) {
         TraceLog(LOG_ERROR, "LIBRETRO: The core requires the full path, can't load from memory");
         // TODO: Allow saving to a temporary location and then use LoadLibretroGame()?
         return false;
@@ -2321,14 +2321,14 @@ static bool LoadLibretroGameFromMemory(const unsigned char *fileData, int dataSi
     info.size = (size_t)dataSize;
     info.meta = "";
     SetLibretroGameInfoExt(fileData, (size_t)dataSize);
-    if (!Libretro.core.retro_load_game(&info)) {
+    if (!LIBRETRO.core.retro_load_game(&info)) {
         TraceLog(LOG_ERROR, "LIBRETRO: Failed to load game data with retro_load_game()");
-        Libretro.core.loaded = false;
+        LIBRETRO.core.loaded = false;
         return false;
     }
 
-    Libretro.core.loaded = InitLibretroAudioVideo();
-    if (!Libretro.core.loaded) {
+    LIBRETRO.core.loaded = InitLibretroAudioVideo();
+    if (!LIBRETRO.core.loaded) {
         return false;
     }
     TraceLog(LOG_INFO, "LIBRETRO: Loaded content from memory");
@@ -2370,32 +2370,32 @@ static void GetLibretroFileExtensionPattern(const char *exts, char *pattern, siz
  */
 static bool GetLibretroNeedFullpath(const char *path, bool *persistent) {
     if (persistent) *persistent = false;
-    if (path == NULL) return Libretro.core.needFullpath;
+    if (path == NULL) return LIBRETRO.core.needFullpath;
 
-    for (unsigned i = 0; i < Libretro.core.contentInfoOverrideCount; i++) {
+    for (unsigned i = 0; i < LIBRETRO.core.contentInfoOverrideCount; i++) {
         char pattern[LIBRETRO_CONTENT_INFO_OVERRIDE_EXTS_LEN + 16];
-        GetLibretroFileExtensionPattern(Libretro.core.contentInfoOverrideExts[i], pattern, sizeof(pattern));
+        GetLibretroFileExtensionPattern(LIBRETRO.core.contentInfoOverrideExts[i], pattern, sizeof(pattern));
         if (IsFileExtension(path, pattern)) {
-            if (persistent) *persistent = Libretro.core.contentInfoOverridePersistent[i];
-            return Libretro.core.contentInfoOverrideNeedFullpath[i];
+            if (persistent) *persistent = LIBRETRO.core.contentInfoOverridePersistent[i];
+            return LIBRETRO.core.contentInfoOverrideNeedFullpath[i];
         }
     }
-    return Libretro.core.needFullpath;
+    return LIBRETRO.core.needFullpath;
 }
 
 /**
  * Load game data into the core, with full control over the path stored on
- * Libretro.core.contentPath and over persistent_data ownership.
+ * LIBRETRO.core.contentPath and over persistent_data ownership.
  *
  * When @p persistent is true (typically from a CONTENT_INFO_OVERRIDE
  * declaring persistent_data), ownership of @p fileData transfers to
- * Libretro.core.persistentGameData and the buffer is released by
+ * LIBRETRO.core.persistentGameData and the buffer is released by
  * UnloadLibretroGame(). When false, the caller retains ownership and may
  * free @p fileData immediately after this returns.
  *
  * @param fileData    ROM data. Must not be NULL.
  * @param dataSize    Size of @p fileData in bytes.
- * @param contentPath Optional path stored on Libretro.core.contentPath and
+ * @param contentPath Optional path stored on LIBRETRO.core.contentPath and
  *                    surfaced via RETRO_ENVIRONMENT_GET_GAME_INFO_EXT. May
  *                    be NULL.
  * @param persistent  See RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE; when
@@ -2412,9 +2412,9 @@ static bool LoadLibretroGameFromMemoryEx(unsigned char* fileData, int dataSize, 
     }
 
     if (contentPath != NULL && contentPath[0] != '\0') {
-        TextCopy(Libretro.core.contentPath, contentPath);
+        TextCopy(LIBRETRO.core.contentPath, contentPath);
     } else {
-        Libretro.core.contentPath[0] = '\0';
+        LIBRETRO.core.contentPath[0] = '\0';
     }
 
     struct retro_game_info info;
@@ -2423,22 +2423,22 @@ static bool LoadLibretroGameFromMemoryEx(unsigned char* fileData, int dataSize, 
     info.size = (size_t)dataSize;
     info.meta = "";
     SetLibretroGameInfoExt(fileData, (size_t)dataSize);
-    if (!Libretro.core.retro_load_game(&info)) {
+    if (!LIBRETRO.core.retro_load_game(&info)) {
         TraceLog(LOG_ERROR, "LIBRETRO: Failed to load game data with retro_load_game()");
-        Libretro.core.loaded = false;
+        LIBRETRO.core.loaded = false;
         return false;
     }
 
     if (persistent) {
-        if (Libretro.core.persistentGameData != NULL && Libretro.core.persistentGameData != fileData) {
-            UnloadFileData(Libretro.core.persistentGameData);
+        if (LIBRETRO.core.persistentGameData != NULL && LIBRETRO.core.persistentGameData != fileData) {
+            UnloadFileData(LIBRETRO.core.persistentGameData);
         }
-        Libretro.core.persistentGameData = fileData;
-        Libretro.core.persistentGameDataSize = dataSize;
+        LIBRETRO.core.persistentGameData = fileData;
+        LIBRETRO.core.persistentGameDataSize = dataSize;
     }
 
-    Libretro.core.loaded = InitLibretroAudioVideo();
-    if (!Libretro.core.loaded) return false;
+    LIBRETRO.core.loaded = InitLibretroAudioVideo();
+    if (!LIBRETRO.core.loaded) return false;
     TraceLog(LOG_INFO, "LIBRETRO: Loaded content from memory");
     return true;
 }
@@ -2448,7 +2448,7 @@ static bool LoadLibretroGameFromMemoryEx(unsigned char* fileData, int dataSize, 
  * @return Extension list string (e.g. "nes|fds"), or empty string if not reported.
  */
 static const char* GetLibretroValidExtensions(void) {
-    return Libretro.core.validExtensions;
+    return LIBRETRO.core.validExtensions;
 }
 
 /**
@@ -2456,7 +2456,7 @@ static const char* GetLibretroValidExtensions(void) {
  * @return true if the core wants archives passed as-is.
  */
 static bool IsLibretroBlockExtract(void) {
-    return Libretro.core.blockExtract;
+    return LIBRETRO.core.blockExtract;
 }
 
 /**
@@ -2482,11 +2482,11 @@ static bool LoadLibretroGame(const char* gameFile) {
         info.size = 0;
         info.path = NULL;
         info.meta = "";
-        Libretro.core.contentPath[0] = '\0';
+        LIBRETRO.core.contentPath[0] = '\0';
         SetLibretroGameInfoExt(NULL, 0);
-        if (Libretro.core.retro_load_game(&info)) {
+        if (LIBRETRO.core.retro_load_game(&info)) {
             TraceLog(LOG_INFO, "LIBRETRO: Loaded without content");
-            Libretro.core.loaded = true;
+            LIBRETRO.core.loaded = true;
             return InitLibretroAudioVideo();
         }
         TraceLog(LOG_ERROR, "LIBRETRO: Failed to load core without content");
@@ -2495,7 +2495,7 @@ static bool LoadLibretroGame(const char* gameFile) {
 
     if (!FileExists(gameFile)) {
         TraceLog(LOG_ERROR, "LIBRETRO: Given content does not exist: %s", gameFile);
-        Libretro.core.loaded = false;
+        LIBRETRO.core.loaded = false;
         return false;
     }
 
@@ -2507,17 +2507,17 @@ static bool LoadLibretroGame(const char* gameFile) {
         info.size = 0;
         info.path = gameFile;
         info.meta = "";
-        TextCopy(Libretro.core.contentPath, gameFile);
+        TextCopy(LIBRETRO.core.contentPath, gameFile);
         SetLibretroGameInfoExt(NULL, 0);
-        if (Libretro.core.retro_load_game(&info)) {
+        if (LIBRETRO.core.retro_load_game(&info)) {
             TraceLog(LOG_INFO, "LIBRETRO: Loaded content with full path: %s", gameFile);
-            Libretro.core.loaded = true;
+            LIBRETRO.core.loaded = true;
             return InitLibretroAudioVideo();
         }
         TraceLog(LOG_ERROR, "LIBRETRO: Failed to load full path: %s", gameFile);
-        Libretro.core.loaded = false;
-        Libretro.core.contentPath[0] = '\0';
-        Libretro.core.gameInfoExtValid = false;
+        LIBRETRO.core.loaded = false;
+        LIBRETRO.core.contentPath[0] = '\0';
+        LIBRETRO.core.gameInfoExtValid = false;
         return false;
     }
 
@@ -2525,7 +2525,7 @@ static bool LoadLibretroGame(const char* gameFile) {
     unsigned char* gameData = LoadFileData(gameFile, &size);
     if (gameData == NULL || size == 0) {
         TraceLog(LOG_ERROR, "LIBRETRO: Failed to load game data with LoadFileData()");
-        Libretro.core.loaded = false;
+        LIBRETRO.core.loaded = false;
         UnloadFileData(gameData);
         return false;
     }
@@ -2541,7 +2541,7 @@ static bool LoadLibretroGame(const char* gameFile) {
  * Get the display name of the loaded core.
  * @return Library name string, or an empty string if no core is loaded. */
 static const char* GetLibretroName(void) {
-    return Libretro.core.libraryName;
+    return LIBRETRO.core.libraryName;
 }
 
 /**
@@ -2549,10 +2549,10 @@ static const char* GetLibretroName(void) {
  * @return Content or core name string.
  */
 static const char* GetLibretroContentName(void) {
-    if (Libretro.core.contentPath[0] != '\0') {
-        return GetFileNameWithoutExt(Libretro.core.contentPath);
+    if (LIBRETRO.core.contentPath[0] != '\0') {
+        return GetFileNameWithoutExt(LIBRETRO.core.contentPath);
     }
-    return Libretro.core.libraryName;
+    return LIBRETRO.core.libraryName;
 }
 
 /**
@@ -2560,7 +2560,7 @@ static const char* GetLibretroContentName(void) {
  * @return Version string reported by the core.
  */
 static const char* GetLibretroVersion(void) {
-    return Libretro.core.libraryVersion;
+    return LIBRETRO.core.libraryVersion;
 }
 
 /**
@@ -2568,7 +2568,7 @@ static const char* GetLibretroVersion(void) {
  * @return true if content must be provided; false if the core can run standalone.
  */
 static bool IsLibretroGameRequired(void) {
-    return !Libretro.core.supportNoGame;
+    return !LIBRETRO.core.supportNoGame;
 }
 
 /**
@@ -2591,17 +2591,17 @@ static bool InitLibretroEx(const char* core, bool peek) {
     }
 
     // Open the dynamic library.
-    Libretro.core.handle = dylib_load(core);
-    if (!Libretro.core.handle) {
+    LIBRETRO.core.handle = dylib_load(core);
+    if (!LIBRETRO.core.handle) {
         TraceLog(LOG_ERROR, "LIBRETRO: Failed to load provided library");
         return false;
     }
 
     // Find the libretro API version.
     LoadLibretroMethod(retro_api_version);
-    Libretro.core.apiVersion = Libretro.core.retro_api_version();
-    TraceLog(LOG_INFO, "LIBRETRO: API version: %i", Libretro.core.apiVersion);
-    if (Libretro.core.apiVersion != 1) {
+    LIBRETRO.core.apiVersion = LIBRETRO.core.retro_api_version();
+    TraceLog(LOG_INFO, "LIBRETRO: API version: %i", LIBRETRO.core.apiVersion);
+    if (LIBRETRO.core.apiVersion != 1) {
         CloseLibretro();
         TraceLog(LOG_ERROR, "LIBRETRO: Incompatible API version");
         return false;
@@ -2610,22 +2610,22 @@ static bool InitLibretroEx(const char* core, bool peek) {
     // Retrieve the libretro core system information.
     LoadLibretroMethod(retro_get_system_info);
     struct retro_system_info systemInfo;
-    Libretro.core.retro_get_system_info(&systemInfo);
-    TextCopy(Libretro.core.libraryName, systemInfo.library_name);
-    TextCopy(Libretro.core.libraryVersion, systemInfo.library_version);
-    TextCopy(Libretro.core.validExtensions, systemInfo.valid_extensions);
-    Libretro.core.needFullpath = systemInfo.need_fullpath;
-    Libretro.core.blockExtract = systemInfo.block_extract;
+    LIBRETRO.core.retro_get_system_info(&systemInfo);
+    TextCopy(LIBRETRO.core.libraryName, systemInfo.library_name);
+    TextCopy(LIBRETRO.core.libraryVersion, systemInfo.library_version);
+    TextCopy(LIBRETRO.core.validExtensions, systemInfo.valid_extensions);
+    LIBRETRO.core.needFullpath = systemInfo.need_fullpath;
+    LIBRETRO.core.blockExtract = systemInfo.block_extract;
     TraceLog(LOG_INFO, "LIBRETRO: Core loaded successfully");
-    TraceLog(LOG_INFO, "    > Name:         %s", Libretro.core.libraryName);
-    TraceLog(LOG_INFO, "    > Version:      %s", Libretro.core.libraryVersion);
-    if (TextLength(Libretro.core.validExtensions) > 0) {
-        TraceLog(LOG_INFO, "    > Extensions:   %s", Libretro.core.validExtensions);
+    TraceLog(LOG_INFO, "    > Name:         %s", LIBRETRO.core.libraryName);
+    TraceLog(LOG_INFO, "    > Version:      %s", LIBRETRO.core.libraryVersion);
+    if (TextLength(LIBRETRO.core.validExtensions) > 0) {
+        TraceLog(LOG_INFO, "    > Extensions:   %s", LIBRETRO.core.validExtensions);
     }
 
     if (peek) {
         // Leave the dylib open so the caller can read identity fields off
-        // Libretro.core. The caller is responsible for CloseLibretro().
+        // LIBRETRO.core. The caller is responsible for CloseLibretro().
         return true;
     }
 
@@ -2654,18 +2654,18 @@ static bool InitLibretroEx(const char* core, bool peek) {
     LoadLibretroMethod(retro_get_memory_data);
     LoadLibretroMethod(retro_get_memory_size);
 
-    TextCopy(Libretro.core.corePath, core);
+    TextCopy(LIBRETRO.core.corePath, core);
 
     // Set up the callbacks.
-    Libretro.core.retro_set_video_refresh(LibretroVideoRefresh);
-    Libretro.core.retro_set_input_poll(LibretroInputPoll);
-    Libretro.core.retro_set_input_state(LibretroInputState);
-    Libretro.core.retro_set_audio_sample(UpdateLibretroAudioSample);
-    Libretro.core.retro_set_audio_sample_batch(UpdateLibretroAudioSampleBatch);
-    Libretro.core.retro_set_environment(CallLibretroEnvironment);
+    LIBRETRO.core.retro_set_video_refresh(LibretroVideoRefresh);
+    LIBRETRO.core.retro_set_input_poll(LibretroInputPoll);
+    LIBRETRO.core.retro_set_input_state(LibretroInputState);
+    LIBRETRO.core.retro_set_audio_sample(UpdateLibretroAudioSample);
+    LIBRETRO.core.retro_set_audio_sample_batch(UpdateLibretroAudioSampleBatch);
+    LIBRETRO.core.retro_set_environment(CallLibretroEnvironment);
 
     // Initialize the core.
-    Libretro.core.retro_init();
+    LIBRETRO.core.retro_init();
     return true;
 }
 
@@ -2686,10 +2686,10 @@ static bool InitLibretro(const char* core) {
  * @param tint Color tint applied to the framebuffer texture.
  */
 static void DrawLibretroTexture(int posX, int posY, Color tint) {
-    if (Libretro.core.loaded == false) {
+    if (LIBRETRO.core.loaded == false) {
         return;
     }
-    DrawTexture(Libretro.core.texture, posX, posY, tint);
+    DrawTexture(LIBRETRO.core.texture, posX, posY, tint);
 }
 
 /**
@@ -2698,10 +2698,10 @@ static void DrawLibretroTexture(int posX, int posY, Color tint) {
  * @param tint Color tint applied to the framebuffer texture.
  */
 static void DrawLibretroV(Vector2 position, Color tint) {
-    if (Libretro.core.loaded == false) {
+    if (LIBRETRO.core.loaded == false) {
         return;
     }
-    DrawTextureV(Libretro.core.texture, position, tint);
+    DrawTextureV(LIBRETRO.core.texture, position, tint);
 }
 
 /**
@@ -2712,10 +2712,10 @@ static void DrawLibretroV(Vector2 position, Color tint) {
  * @param tint Color tint applied to the framebuffer texture.
  */
 static void DrawLibretroEx(Vector2 position, float rotation, float scale, Color tint) {
-    if (Libretro.core.loaded == false) {
+    if (LIBRETRO.core.loaded == false) {
         return;
     }
-    DrawTextureEx(Libretro.core.texture, position, rotation, scale, tint);
+    DrawTextureEx(LIBRETRO.core.texture, position, rotation, scale, tint);
 }
 
 /**
@@ -2724,12 +2724,12 @@ static void DrawLibretroEx(Vector2 position, float rotation, float scale, Color 
  * @param tint Color tint applied to the framebuffer texture.
  */
 static void DrawLibretroPro(Rectangle destRec, Color tint) {
-    if (Libretro.core.loaded == false) {
+    if (LIBRETRO.core.loaded == false) {
         return;
     }
-    Rectangle source = {0, 0, Libretro.core.width, Libretro.core.height};
+    Rectangle source = {0, 0, LIBRETRO.core.width, LIBRETRO.core.height};
     Vector2 origin = {0, 0};
-    DrawTexturePro(Libretro.core.texture, source, destRec, origin, 0, tint);
+    DrawTexturePro(LIBRETRO.core.texture, source, destRec, origin, 0, tint);
 }
 
 /**
@@ -2737,17 +2737,17 @@ static void DrawLibretroPro(Rectangle destRec, Color tint) {
  * @return true if a message was drawn; false if there was nothing to display.
  */
 static bool DrawLibretroMessage(void) {
-    if (GetTime() > Libretro.core.osdEndTime) {
+    if (GetTime() > LIBRETRO.core.osdEndTime) {
         return false;
     }
 
     int fontSize = 20;
     int padding = 8;
-    int textWidth = MeasureText(Libretro.core.osdMessage, fontSize);
+    int textWidth = MeasureText(LIBRETRO.core.osdMessage, fontSize);
     int x = (GetScreenWidth() - textWidth) / 2;
     int y = GetScreenHeight() - fontSize - padding * 2;
     DrawRectangle(x - padding, y - padding, textWidth + padding * 2, fontSize + padding * 2, (Color){0, 0, 0, 180});
-    DrawText(Libretro.core.osdMessage, x, y, fontSize, WHITE);
+    DrawText(LIBRETRO.core.osdMessage, x, y, fontSize, WHITE);
     return true;
 }
 
@@ -2756,17 +2756,17 @@ static bool DrawLibretroMessage(void) {
  * @param tint Color tint applied to the framebuffer texture.
  */
 static void DrawLibretroTint(Color tint) {
-    if (Libretro.core.loaded == false) {
+    if (LIBRETRO.core.loaded == false) {
         return;
     }
 
-    float rotationDeg = (float)Libretro.core.rotation * 90.0f;
-    bool swapDims = (Libretro.core.rotation == 1 || Libretro.core.rotation == 3);
+    float rotationDeg = (float)LIBRETRO.core.rotation * 90.0f;
+    bool swapDims = (LIBRETRO.core.rotation == 1 || LIBRETRO.core.rotation == 3);
 
     // Find the aspect ratio.
-    float aspect = Libretro.core.aspectRatio;
+    float aspect = LIBRETRO.core.aspectRatio;
     if (aspect <= 0) {
-        aspect = (float)Libretro.core.width / (float)Libretro.core.height;
+        aspect = (float)LIBRETRO.core.width / (float)LIBRETRO.core.height;
     }
 
     // When rotated 90/270, the visual bounding box has the inverted aspect ratio.
@@ -2788,10 +2788,10 @@ static void DrawLibretroTint(Color tint) {
     // Draw centered with rotation around the dest rect's center.
     float cx = GetScreenWidth() / 2.0f;
     float cy = GetScreenHeight() / 2.0f;
-    Rectangle source = {0, 0, Libretro.core.width, Libretro.core.height};
+    Rectangle source = {0, 0, LIBRETRO.core.width, LIBRETRO.core.height};
     Rectangle dest = {cx, cy, (float)destW, (float)destH};
     Vector2 origin = {destW / 2.0f, destH / 2.0f};
-    DrawTexturePro(Libretro.core.texture, source, dest, origin, rotationDeg, tint);
+    DrawTexturePro(LIBRETRO.core.texture, source, dest, origin, rotationDeg, tint);
 }
 
 /**
@@ -2806,8 +2806,8 @@ static void DrawLibretro(void) {
  * @param msg      Message text to display.
  * @param duration How long to show the message, in seconds. */
 static void SetLibretroMessage(const char* msg, float duration) {
-    TextCopy(Libretro.core.osdMessage, msg);
-    Libretro.core.osdEndTime = GetTime() + (double)duration;
+    TextCopy(LIBRETRO.core.osdMessage, msg);
+    LIBRETRO.core.osdEndTime = GetTime() + (double)duration;
 }
 
 /**
@@ -2817,9 +2817,9 @@ static void SetLibretroMessage(const char* msg, float duration) {
 static void SetLibretroVolume(float volume) {
     if (volume < 0) volume = 0.0f;
     else if (volume > 1.0f) volume = 1.0f;
-    Libretro.volume = volume;
-    if (IsAudioStreamValid(Libretro.core.audioStream)) {
-        SetAudioStreamVolume(Libretro.core.audioStream, volume);
+    LIBRETRO.volume = volume;
+    if (IsAudioStreamValid(LIBRETRO.core.audioStream)) {
+        SetAudioStreamVolume(LIBRETRO.core.audioStream, volume);
     }
 }
 
@@ -2827,7 +2827,7 @@ static void SetLibretroVolume(float volume) {
  * Get the current audio output volume.
  * @return Volume level in the range [0.0, 1.0]. */
 static float GetLibretroVolume(void) {
-    return Libretro.volume;
+    return LIBRETRO.volume;
 }
 
 /**
@@ -2835,11 +2835,11 @@ static float GetLibretroVolume(void) {
  * @param speed Multiplier relative to normal speed (1.0 = normal, >1.0 = fast-forward, <1.0 = slow-motion). */
 static void SetLibretroSpeed(float speed) {
     if (speed <= 0.0f) speed = 0.1f;
-    Libretro.speed = speed;
+    LIBRETRO.speed = speed;
     if (speed > 1.0f) {
         SetTargetFPS(0);
     } else {
-        SetTargetFPS((int)(Libretro.core.fps * speed));
+        SetTargetFPS((int)(LIBRETRO.core.fps * speed));
     }
 }
 
@@ -2847,7 +2847,7 @@ static void SetLibretroSpeed(float speed) {
  * Get the current emulation playback speed multiplier.
  * @return Current speed multiplier. */
 static float GetLibretroSpeed(void) {
-    return Libretro.speed;
+    return LIBRETRO.speed;
 }
 
 /**
@@ -2864,10 +2864,10 @@ static float GetLibretroSpeed(void) {
  * @param enabled true to enable DRC, false to disable and restore unity pitch.
  */
 static void SetLibretroDynamicRateControl(bool enabled) {
-    Libretro.core.drcEnabled = enabled;
-    if (!enabled && IsAudioStreamValid(Libretro.core.audioStream)) {
-        Libretro.core.drcAdjustment = 1.0f;
-        SetAudioStreamPitch(Libretro.core.audioStream, 1.0f);
+    LIBRETRO.core.drcEnabled = enabled;
+    if (!enabled && IsAudioStreamValid(LIBRETRO.core.audioStream)) {
+        LIBRETRO.core.drcAdjustment = 1.0f;
+        SetAudioStreamPitch(LIBRETRO.core.audioStream, 1.0f);
     }
 }
 
@@ -2877,7 +2877,7 @@ static void SetLibretroDynamicRateControl(bool enabled) {
  * @return true if DRC is enabled, false otherwise.
  */
 static bool IsLibretroDynamicRateControlEnabled(void) {
-    return Libretro.core.drcEnabled;
+    return LIBRETRO.core.drcEnabled;
 }
 
 /**
@@ -2885,7 +2885,7 @@ static bool IsLibretroDynamicRateControlEnabled(void) {
  * @return Rotation index.
  */
 static unsigned GetLibretroRotation(void) {
-    return Libretro.core.rotation;
+    return LIBRETRO.core.rotation;
 }
 
 /**
@@ -2893,7 +2893,7 @@ static unsigned GetLibretroRotation(void) {
  * @return Width in pixels
  */
 static unsigned GetLibretroWidth(void) {
-    return Libretro.core.width;
+    return LIBRETRO.core.width;
 }
 
 /**
@@ -2901,15 +2901,15 @@ static unsigned GetLibretroWidth(void) {
  * @return Height in pixels.
  */
 static unsigned GetLibretroHeight(void) {
-    return Libretro.core.height;
+    return LIBRETRO.core.height;
 }
 
 static double GetLibretroFPS(void) {
-    return Libretro.core.fps > 0 ? (double)Libretro.core.fps : 60.0;
+    return LIBRETRO.core.fps > 0 ? (double)LIBRETRO.core.fps : 60.0;
 }
 
 static float GetLibretroAspectRatio(void) {
-    return Libretro.core.aspectRatio;
+    return LIBRETRO.core.aspectRatio;
 }
 
 /**
@@ -2917,7 +2917,7 @@ static float GetLibretroAspectRatio(void) {
  * @return Texture2D containing the last rendered frame.
  */
 static Texture2D GetLibretroTexture(void) {
-    return Libretro.core.texture;
+    return LIBRETRO.core.texture;
 }
 
 /**
@@ -2925,7 +2925,7 @@ static Texture2D GetLibretroTexture(void) {
  * @return true if a game/content is currently loaded.
  */
 static bool IsLibretroGameReady(void) {
-    return Libretro.core.loaded && Libretro.core.retro_run != NULL;
+    return LIBRETRO.core.loaded && LIBRETRO.core.retro_run != NULL;
 }
 
 /**
@@ -2934,8 +2934,8 @@ static bool IsLibretroGameReady(void) {
  * @return true if the core reset callback was called.
  */
 static bool ResetLibretro(void) {
-    if (IsLibretroReady() && Libretro.core.retro_reset) {
-        Libretro.core.retro_reset();
+    if (IsLibretroReady() && LIBRETRO.core.retro_reset) {
+        LIBRETRO.core.retro_reset();
         return true;
     }
     return false;
@@ -2948,12 +2948,12 @@ static bool ResetLibretro(void) {
  */
 static void* GetLibretroSRAMData(size_t* size) {
     if (!IsLibretroGameReady()) return NULL;
-    if (Libretro.core.retro_get_memory_data == NULL || Libretro.core.retro_get_memory_size == NULL) return NULL;
+    if (LIBRETRO.core.retro_get_memory_data == NULL || LIBRETRO.core.retro_get_memory_size == NULL) return NULL;
 
-    size_t sramSize = Libretro.core.retro_get_memory_size(RETRO_MEMORY_SAVE_RAM);
+    size_t sramSize = LIBRETRO.core.retro_get_memory_size(RETRO_MEMORY_SAVE_RAM);
     if (sramSize == 0) return NULL;
 
-    void* data = Libretro.core.retro_get_memory_data(RETRO_MEMORY_SAVE_RAM);
+    void* data = LIBRETRO.core.retro_get_memory_data(RETRO_MEMORY_SAVE_RAM);
     if (data == NULL) return NULL;
 
     if (size != NULL) *size = sramSize;
@@ -2982,21 +2982,21 @@ static bool SetLibretroSRAMData(const void* data, size_t size) {
  * Unload the currently loaded content without closing the core.
  */
 static void UnloadLibretroGame(void) {
-    if (Libretro.core.retro_unload_game != NULL) {
-        Libretro.core.retro_unload_game();
-        Libretro.core.retro_unload_game = NULL;
+    if (LIBRETRO.core.retro_unload_game != NULL) {
+        LIBRETRO.core.retro_unload_game();
+        LIBRETRO.core.retro_unload_game = NULL;
     }
-    Libretro.core.retro_run = NULL;
-    Libretro.core.loaded = false;
-    Libretro.core.contentPath[0] = '\0';
-    Libretro.core.gameInfoExtValid = false;
-    memset(&Libretro.core.gameInfoExt, 0, sizeof(Libretro.core.gameInfoExt));
+    LIBRETRO.core.retro_run = NULL;
+    LIBRETRO.core.loaded = false;
+    LIBRETRO.core.contentPath[0] = '\0';
+    LIBRETRO.core.gameInfoExtValid = false;
+    memset(&LIBRETRO.core.gameInfoExt, 0, sizeof(LIBRETRO.core.gameInfoExt));
 
     // Release the persistent ROM buffer kept alive for persistent_data=true.
-    if (Libretro.core.persistentGameData != NULL) {
-        UnloadFileData(Libretro.core.persistentGameData);
-        Libretro.core.persistentGameData = NULL;
-        Libretro.core.persistentGameDataSize = 0;
+    if (LIBRETRO.core.persistentGameData != NULL) {
+        UnloadFileData(LIBRETRO.core.persistentGameData);
+        LIBRETRO.core.persistentGameData = NULL;
+        LIBRETRO.core.persistentGameDataSize = 0;
     }
 
     // Free memory map descriptors — these are game-specific and must not
@@ -3012,11 +3012,11 @@ static void ResetLibretroCoreState(void) {
     // Release owned pointers before the memset wipes them.
     UnloadLibretroMemoryMaps();
 
-    memset(&Libretro.core, 0, sizeof(Libretro.core));
+    memset(&LIBRETRO.core, 0, sizeof(LIBRETRO.core));
 
     // Non-zero defaults.
-    Libretro.core.drcAdjustment = 1.0f;
-    Libretro.core.drcEnabled = true;
+    LIBRETRO.core.drcAdjustment = 1.0f;
+    LIBRETRO.core.drcEnabled = true;
 }
 
 /**
@@ -3030,32 +3030,32 @@ static void CloseLibretro(void) {
 
     // Let the core know that the audio device has been deinitialized. The
     // function pointer lives in the dylib we're about to close.
-    if (Libretro.core.audio_callback.set_state != NULL) {
-        Libretro.core.audio_callback.set_state(false);
+    if (LIBRETRO.core.audio_callback.set_state != NULL) {
+        LIBRETRO.core.audio_callback.set_state(false);
     }
 
     // Call retro_deinit() to deinitialize the core.
-    if (Libretro.core.retro_deinit != NULL) {
-        Libretro.core.retro_deinit();
+    if (LIBRETRO.core.retro_deinit != NULL) {
+        LIBRETRO.core.retro_deinit();
     }
 
     CloseLibretroAudio();
     CloseLibretroVideo();
 
-    if (Libretro.core.inputDescriptors != NULL) {
-        MemFree(Libretro.core.inputDescriptors);
+    if (LIBRETRO.core.inputDescriptors != NULL) {
+        MemFree(LIBRETRO.core.inputDescriptors);
     }
 
-    if (Libretro.core.controllerInfo != NULL) {
-        MemFree(Libretro.core.controllerInfo);
+    if (LIBRETRO.core.controllerInfo != NULL) {
+        MemFree(LIBRETRO.core.controllerInfo);
     }
 
     // Close the dynamically loaded handle.
-    if (Libretro.core.handle != NULL) {
-        dylib_close(Libretro.core.handle);
+    if (LIBRETRO.core.handle != NULL) {
+        dylib_close(LIBRETRO.core.handle);
     }
 
-    // ResetLibretroCoreState() memsets Libretro.core, which zeroes every
+    // ResetLibretroCoreState() memsets LIBRETRO.core, which zeroes every
     // field above — function pointers into the now-closed dylib, descriptor
     // pointers and counts, audio/keyboard callbacks, etc.
     ResetLibretroCoreState();
@@ -3507,11 +3507,11 @@ static void* GetLibretroSerializedData(unsigned int* size) {
         return NULL;
     }
 
-    if (Libretro.core.retro_serialize_size == NULL || Libretro.core.retro_serialize == NULL) {
+    if (LIBRETRO.core.retro_serialize_size == NULL || LIBRETRO.core.retro_serialize == NULL) {
         return NULL;
     }
 
-    size_t finalSize = Libretro.core.retro_serialize_size();
+    size_t finalSize = LIBRETRO.core.retro_serialize_size();
     if (finalSize == 0) {
         return NULL;
     }
@@ -3524,7 +3524,7 @@ static void* GetLibretroSerializedData(unsigned int* size) {
         return NULL;
     }
 
-    if (Libretro.core.retro_serialize(saveData, finalSize)) {
+    if (LIBRETRO.core.retro_serialize(saveData, finalSize)) {
         return saveData;
     }
     TraceLog(LOG_ERROR, "LIBRETRO: Failed to get retro_serialize");
@@ -3542,11 +3542,11 @@ static bool SetLibretroSerializedData(void* data, unsigned int size) {
         return false;
     }
 
-    if (Libretro.core.retro_unserialize == NULL) {
+    if (LIBRETRO.core.retro_unserialize == NULL) {
         return false;
     }
 
-    return Libretro.core.retro_unserialize(data, (size_t)size);
+    return LIBRETRO.core.retro_unserialize(data, (size_t)size);
 }
 
 #endif

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -171,9 +171,11 @@ static int LibretroMapRetroLogLevelToTraceLogType(int level);
 } while (0)
 #define LoadLibretroMethod(S) LoadLibretroMethodHandle(LIBRETRO.core.S, S)
 
+/**
+ * Dynamic library symbols for a libretro core.
+ */
 typedef struct LibretroCoreData {
-    // Dynamic library symbols.
-    void *handle;
+    void *handle; /** The dynamic linked library handle. */
     void (*retro_init)(void);
     void (*retro_deinit)(void);
     unsigned (*retro_api_version)(void);
@@ -201,7 +203,7 @@ typedef struct LibretroCoreData {
     size_t (*retro_get_memory_size)(unsigned);
 
     // System Information.
-    bool shutdown;
+    bool shutdown; /** Indicates whether or not the core requested to shutdown. */
     unsigned width, height, fps;
     double sampleRate;
     float aspectRatio;
@@ -3023,10 +3025,11 @@ static void ResetLibretroCoreState(void) {
  * Deinitialize and unload the libretro core.
  */
 static void CloseLibretro(void) {
-    // Make sure the game is unloaded prior to unloading the core.
-    if (IsLibretroGameReady()) {
-        UnloadLibretroGame();
-    }
+    // Free game-scoped resources before tearing down the core. Called
+    // unconditionally because a partial load (retro_load_game succeeded but
+    // InitLibretroAudioVideo failed) leaves persistentGameData allocated
+    // with loaded=false, and IsLibretroGameReady() would skip the cleanup.
+    UnloadLibretroGame();
 
     // Let the core know that the audio device has been deinitialized. The
     // function pointer lives in the dylib we're about to close.

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -347,7 +347,10 @@ extern "C" {
  *
  * TODO: Figure out a way to have Libretro not be a static global?
  */
-static rLibretro Libretro = {0};
+static rLibretro Libretro = {
+    .volume = 1.0f,
+    .speed = 1.0f,
+};
 
 static void LibretroInitCoreVariable(const char *key, const char *defaultValue,
     const char *label, const char *valuesList, const char *displayList, const char *tooltip) {
@@ -2653,9 +2656,6 @@ static bool InitLibretroEx(const char* core, bool peek) {
 
     // Initialize the core.
     TextCopy(Libretro.core.corePath, core);
-    Libretro.core.shutdown = false;
-    Libretro.volume = 1.0f;
-    Libretro.speed = 1.0f;
 
     // Set up the callbacks.
     Libretro.core.retro_set_video_refresh(LibretroVideoRefresh);
@@ -3018,8 +3018,6 @@ static void ResetLibretroCoreState(void) {
     // Non-zero defaults.
     Libretro.core.drcAdjustment = 1.0f;
     Libretro.core.drcEnabled = true;
-
-    Libretro.speed = 1.0f;
 }
 
 /**
@@ -3031,24 +3029,15 @@ static void CloseLibretro(void) {
         UnloadLibretroGame();
     }
 
-    // Let the core know that the audio device has been deinitialized.
+    // Let the core know that the audio device has been deinitialized. The
+    // function pointer lives in the dylib we're about to close.
     if (Libretro.core.audio_callback.set_state != NULL) {
         Libretro.core.audio_callback.set_state(false);
-        memset(&Libretro.core.audio_callback, 0, sizeof(Libretro.core.audio_callback));
     }
-
-    // Drop any callbacks the core registered into its own .text — dylib_close()
-    // below invalidates those addresses, and a follow-up InitLibretro() with a
-    // different core that doesn't re-register them would call freed memory.
-    Libretro.core.keyboard_event = NULL;
-    Libretro.core.options_update_display_callback = NULL;
-    memset(&Libretro.core.runloop_frame_time, 0, sizeof(Libretro.core.runloop_frame_time));
-    Libretro.core.runloop_frame_time_last = 0;
 
     // Call retro_deinit() to deinitialize the core.
     if (Libretro.core.retro_deinit != NULL) {
         Libretro.core.retro_deinit();
-        Libretro.core.retro_deinit = NULL;
     }
 
     CloseLibretroAudio();
@@ -3056,22 +3045,20 @@ static void CloseLibretro(void) {
 
     if (Libretro.core.inputDescriptors != NULL) {
         MemFree(Libretro.core.inputDescriptors);
-        Libretro.core.inputDescriptors = NULL;
-        Libretro.core.inputDescriptorCount = 0;
     }
 
     if (Libretro.core.controllerInfo != NULL) {
         MemFree(Libretro.core.controllerInfo);
-        Libretro.core.controllerInfo = NULL;
-        Libretro.core.controllerPortCount = 0;
     }
 
     // Close the dynamically loaded handle.
     if (Libretro.core.handle != NULL) {
         dylib_close(Libretro.core.handle);
-        Libretro.core.handle = NULL;
     }
 
+    // ResetLibretroCoreState() memsets Libretro.core, which zeroes every
+    // field above — function pointers into the now-closed dylib, descriptor
+    // pointers and counts, audio/keyboard callbacks, etc.
     ResetLibretroCoreState();
 }
 

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -2990,9 +2990,32 @@ static void UnloadLibretroGame(void) {
     }
     LIBRETRO.core.retro_run = NULL;
     LIBRETRO.core.loaded = false;
+    LIBRETRO.core.shutdown = false;
     LIBRETRO.core.contentPath[0] = '\0';
+    LIBRETRO.core.contentDir[0]  = '\0';
+    LIBRETRO.core.contentName[0] = '\0';
+    LIBRETRO.core.contentExt[0]  = '\0';
     LIBRETRO.core.gameInfoExtValid = false;
     memset(&LIBRETRO.core.gameInfoExt, 0, sizeof(LIBRETRO.core.gameInfoExt));
+
+    // Per-game runtime state that must not leak into the next game.
+    LIBRETRO.core.rotation         = 0;
+    LIBRETRO.core.gameTimeNSEC     = 0;
+    LIBRETRO.core.osdMessage[0]    = '\0';
+    LIBRETRO.core.osdEndTime       = 0.0;
+    LIBRETRO.core.singleSampleCount = 0;
+    LIBRETRO.core.audioDropWarnCount = 0;
+
+    // Stop any in-flight controller rumble before clearing the stored state —
+    // SetLibretroRumbleState pushed long-duration values to the hardware that
+    // would otherwise keep buzzing after the game is gone.
+    for (unsigned p = 0; p < RAYLIB_LIBRETRO_RUMBLE_PORTS; p++) {
+        if (LIBRETRO.core.rumbleStrong[p] > 0.0f || LIBRETRO.core.rumbleWeak[p] > 0.0f) {
+            SetGamepadVibration((int)p, 0.0f, 0.0f, 0.0f);
+        }
+    }
+    memset(LIBRETRO.core.rumbleStrong, 0, sizeof(LIBRETRO.core.rumbleStrong));
+    memset(LIBRETRO.core.rumbleWeak,   0, sizeof(LIBRETRO.core.rumbleWeak));
 
     // Release the persistent ROM buffer kept alive for persistent_data=true.
     if (LIBRETRO.core.persistentGameData != NULL) {

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -162,16 +162,16 @@ static int LibretroMapRetroLogLevelToTraceLogType(int level);
 
 // Dynamic loading methods.
 #define LoadLibretroMethodHandle(V, S) do {\
-    function_t func = dylib_proc(LibretroCore.handle, #S); \
+    function_t func = dylib_proc(Libretro.core.handle, #S); \
     memcpy(&V, &func, sizeof(func)); \
     if (!func) { \
         TraceLog(LOG_ERROR, "LIBRETRO: Failed to load symbol '" #S "' ", dylib_error()); \
         return false; \
     }\
 } while (0)
-#define LoadLibretroMethod(S) LoadLibretroMethodHandle(LibretroCore.S, S)
+#define LoadLibretroMethod(S) LoadLibretroMethodHandle(Libretro.core.S, S)
 
-typedef struct rLibretro {
+typedef struct rLibretroCore {
     // Dynamic library symbols.
     void *handle;
     void (*retro_init)(void);
@@ -216,7 +216,6 @@ typedef struct rLibretro {
     enum retro_pixel_format pixelFormat;
     unsigned performanceLevel;
     bool loaded;
-    float volume;
 
     // The last performance counter registered. TODO: Make it a linked list.
     struct retro_perf_counter* perf_counter_last;
@@ -231,7 +230,6 @@ typedef struct rLibretro {
     // Raylib objects used to play the libretro core.
     Texture texture;
     bool textureRebuild;
-    int textureFilter; // TextureFilter
 
     // Pre-allocated frame conversion buffer (avoids per-frame MemAlloc).
     void *frameBuffer;
@@ -275,9 +273,6 @@ typedef struct rLibretro {
     bool variablesDirty; // Whether or not the variables have been changed since last RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE call.
     bool variablesVisibilityDirty; // Whether option visibility changed and the menu should rebuild.
 
-    // Playback speed: 1.0 = normal, >1.0 = fast-forward, <1.0 = slow-motion.
-    float speed;
-
     // Screen rotation: 0=0°, 1=90°, 2=180°, 3=270°
     unsigned rotation;
 
@@ -304,15 +299,6 @@ typedef struct rLibretro {
     struct retro_game_info_ext gameInfoExt;
     bool gameInfoExtValid;
 
-    // Directory configuration. Empty string means use GetApplicationDirectory().
-    // TODO: Change this to be MemAlloc-ed?
-    char coreDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
-    char saveDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
-    char coreAssetsDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
-    char systemDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
-    char playlistsDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
-    char fileBrowserStartDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
-
     float rumbleStrong[RAYLIB_LIBRETRO_RUMBLE_PORTS];
     float rumbleWeak[RAYLIB_LIBRETRO_RUMBLE_PORTS];
 
@@ -333,10 +319,23 @@ typedef struct rLibretro {
     // Memory map from RETRO_ENVIRONMENT_SET_MEMORY_MAPS (owned copy).
     struct retro_memory_descriptor *memoryMapDescriptors;
     unsigned memoryMapDescriptorCount;
+} rLibretroCore;
 
-    // Keyboard bindings for player 1 (port 0). Stored as raylib KeyboardKey values.
-    // Index matches RETRO_DEVICE_ID_JOYPAD_* constants. KEY_NULL means no binding.
+typedef struct rLibretro {
+    // Persistent settings that survive core loads.
+    float volume;
+    float speed;
+    int textureFilter; // TextureFilter
     int keyboardPlayer1[16];
+    char coreDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    char saveDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    char coreAssetsDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    char systemDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    char playlistsDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+    char fileBrowserStartDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
+
+    // Per-core state (reset with memset(0) on core unload).
+    rLibretroCore core;
 } rLibretro;
 
 #if defined(__cplusplus)
@@ -346,40 +345,40 @@ extern "C" {
 /**
  * The global libretro core object.
  *
- * TODO: Figure out a way to have LibretroCore not be a static global?
+ * TODO: Figure out a way to have Libretro not be a static global?
  */
-static rLibretro LibretroCore = {0};
+static rLibretro Libretro = {0};
 
 static void LibretroInitCoreVariable(const char *key, const char *defaultValue,
     const char *label, const char *valuesList, const char *displayList, const char *tooltip) {
-    for (unsigned i = 0; i < LibretroCore.variableCount; i++) {
-        if (TextIsEqual(LibretroCore.variableKeys[i], key)) {
+    for (unsigned i = 0; i < Libretro.core.variableCount; i++) {
+        if (TextIsEqual(Libretro.core.variableKeys[i], key)) {
             return; // Already registered; don't overwrite user-set value.
         }
     }
-    if (LibretroCore.variableCount >= LIBRETRO_MAX_CORE_VARIABLES) {
+    if (Libretro.core.variableCount >= LIBRETRO_MAX_CORE_VARIABLES) {
         TraceLog(LOG_WARNING, "LIBRETRO: Core variable limit reached, ignoring: %s", key);
         return;
     }
-    unsigned n = LibretroCore.variableCount;
-    TextCopy(LibretroCore.variableKeys[n],        key);
-    TextCopy(LibretroCore.variableValues[n],      defaultValue  ? defaultValue  : "");
-    TextCopy(LibretroCore.variableLabels[n],      label         ? label         : "");
-    TextCopy(LibretroCore.variableValuesList[n],  valuesList    ? valuesList    : "");
-    TextCopy(LibretroCore.variableDisplayList[n], displayList   ? displayList   : "");
-    TextCopy(LibretroCore.variableTooltips[n],    tooltip       ? tooltip       : "");
-    LibretroCore.variableVisible[n] = true;
-    LibretroCore.variableCount++;
+    unsigned n = Libretro.core.variableCount;
+    TextCopy(Libretro.core.variableKeys[n],        key);
+    TextCopy(Libretro.core.variableValues[n],      defaultValue  ? defaultValue  : "");
+    TextCopy(Libretro.core.variableLabels[n],      label         ? label         : "");
+    TextCopy(Libretro.core.variableValuesList[n],  valuesList    ? valuesList    : "");
+    TextCopy(Libretro.core.variableDisplayList[n], displayList   ? displayList   : "");
+    TextCopy(Libretro.core.variableTooltips[n],    tooltip       ? tooltip       : "");
+    Libretro.core.variableVisible[n] = true;
+    Libretro.core.variableCount++;
     // A new option appeared: cores that register variables after the menu has
     // been built (e.g. mgba registering GB model options during its deferred
     // setup on first retro_run) need the Core Options section to refresh.
-    LibretroCore.variablesVisibilityDirty = true;
+    Libretro.core.variablesVisibilityDirty = true;
 }
 
 static const char *LibretroGetCoreVariable(const char *key) {
-    for (unsigned i = 0; i < LibretroCore.variableCount; i++) {
-        if (TextIsEqual(LibretroCore.variableKeys[i], key)) {
-            return LibretroCore.variableValues[i];
+    for (unsigned i = 0; i < Libretro.core.variableCount; i++) {
+        if (TextIsEqual(Libretro.core.variableKeys[i], key)) {
+            return Libretro.core.variableValues[i];
         }
     }
     return NULL;
@@ -391,10 +390,10 @@ static const char *LibretroGetCoreVariable(const char *key) {
  * @param value New value for the option.
  * @return true if the key was found and the value applied; false if the key is unknown. */
 static bool SetLibretroCoreOption(const char *key, const char *value) {
-    for (unsigned i = 0; i < LibretroCore.variableCount; i++) {
-        if (TextIsEqual(LibretroCore.variableKeys[i], key)) {
-            snprintf(LibretroCore.variableValues[i], LIBRETRO_CORE_VARIABLE_VALUE_LEN, "%s", value);
-            LibretroCore.variablesDirty = true;
+    for (unsigned i = 0; i < Libretro.core.variableCount; i++) {
+        if (TextIsEqual(Libretro.core.variableKeys[i], key)) {
+            snprintf(Libretro.core.variableValues[i], LIBRETRO_CORE_VARIABLE_VALUE_LEN, "%s", value);
+            Libretro.core.variablesDirty = true;
             return true;
         }
     }
@@ -430,11 +429,11 @@ static const char* GetLibretroDirectory(int directory) {
 
     char* output = NULL;
     switch (directory) {
-        case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY: output = LibretroCore.saveDirectory; break;
-        case RETRO_ENVIRONMENT_GET_CORE_ASSETS_DIRECTORY: output = LibretroCore.coreAssetsDirectory; break; // RETRO_ENVIRONMENT_GET_CONTENT_DIRECTORY
-        case RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY: output = LibretroCore.systemDirectory; break;
-        case RETRO_ENVIRONMENT_GET_PLAYLIST_DIRECTORY: output = LibretroCore.playlistsDirectory; break;
-        case RETRO_ENVIRONMENT_GET_FILE_BROWSER_START_DIRECTORY: output = LibretroCore.fileBrowserStartDirectory; break;
+        case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY: output = Libretro.saveDirectory; break;
+        case RETRO_ENVIRONMENT_GET_CORE_ASSETS_DIRECTORY: output = Libretro.coreAssetsDirectory; break; // RETRO_ENVIRONMENT_GET_CONTENT_DIRECTORY
+        case RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY: output = Libretro.systemDirectory; break;
+        case RETRO_ENVIRONMENT_GET_PLAYLIST_DIRECTORY: output = Libretro.playlistsDirectory; break;
+        case RETRO_ENVIRONMENT_GET_FILE_BROWSER_START_DIRECTORY: output = Libretro.fileBrowserStartDirectory; break;
         default: return NULL;
     }
 
@@ -457,8 +456,8 @@ static const char* GetLibretroDirectory(int directory) {
  * @param count Output parameter filled with the number of descriptors.
  * @return Pointer to the descriptor array, or NULL if none were set. */
 static const struct retro_input_descriptor* GetLibretroInputDescriptors(unsigned *count) {
-    if (count != NULL) *count = LibretroCore.inputDescriptorCount;
-    return LibretroCore.inputDescriptors;
+    if (count != NULL) *count = Libretro.core.inputDescriptorCount;
+    return Libretro.core.inputDescriptors;
 }
 
 /**
@@ -466,22 +465,22 @@ static const struct retro_input_descriptor* GetLibretroInputDescriptors(unsigned
  * @param count Output parameter filled with the number of ports.
  * @return Pointer to the controller info array, or NULL if none were set. */
 static const struct retro_controller_info* GetLibretroControllerInfo(unsigned *count) {
-    if (count != NULL) *count = LibretroCore.controllerPortCount;
-    return LibretroCore.controllerInfo;
+    if (count != NULL) *count = Libretro.core.controllerPortCount;
+    return Libretro.core.controllerInfo;
 }
 
 /**
  * Free the stored memory map descriptors. */
 static void UnloadLibretroMemoryMaps(void) {
-    if (LibretroCore.memoryMapDescriptors) {
-        for (unsigned i = 0; i < LibretroCore.memoryMapDescriptorCount; i++) {
-            if (LibretroCore.memoryMapDescriptors[i].addrspace) {
-                MemFree((void*)LibretroCore.memoryMapDescriptors[i].addrspace);
+    if (Libretro.core.memoryMapDescriptors) {
+        for (unsigned i = 0; i < Libretro.core.memoryMapDescriptorCount; i++) {
+            if (Libretro.core.memoryMapDescriptors[i].addrspace) {
+                MemFree((void*)Libretro.core.memoryMapDescriptors[i].addrspace);
             }
         }
-        MemFree(LibretroCore.memoryMapDescriptors);
-        LibretroCore.memoryMapDescriptors = NULL;
-        LibretroCore.memoryMapDescriptorCount = 0;
+        MemFree(Libretro.core.memoryMapDescriptors);
+        Libretro.core.memoryMapDescriptors = NULL;
+        Libretro.core.memoryMapDescriptorCount = 0;
     }
 }
 
@@ -495,18 +494,18 @@ static bool SetLibretroMemoryMaps(const struct retro_memory_map *map) {
         return map != NULL;
     }
     size_t sz = sizeof(struct retro_memory_descriptor) * map->num_descriptors;
-    LibretroCore.memoryMapDescriptors = (struct retro_memory_descriptor*)MemAlloc((unsigned int)sz);
-    if (!LibretroCore.memoryMapDescriptors) {
+    Libretro.core.memoryMapDescriptors = (struct retro_memory_descriptor*)MemAlloc((unsigned int)sz);
+    if (!Libretro.core.memoryMapDescriptors) {
         return false;
     }
-    memcpy(LibretroCore.memoryMapDescriptors, map->descriptors, sz);
-    LibretroCore.memoryMapDescriptorCount = map->num_descriptors;
+    memcpy(Libretro.core.memoryMapDescriptors, map->descriptors, sz);
+    Libretro.core.memoryMapDescriptorCount = map->num_descriptors;
     for (unsigned i = 0; i < map->num_descriptors; i++) {
         if (map->descriptors[i].addrspace) {
             size_t len = strlen(map->descriptors[i].addrspace) + 1;
             char *copy = (char*)MemAlloc((unsigned int)len);
             if (copy) memcpy(copy, map->descriptors[i].addrspace, len);
-            LibretroCore.memoryMapDescriptors[i].addrspace = copy;
+            Libretro.core.memoryMapDescriptors[i].addrspace = copy;
         }
     }
     TraceLog(LOG_INFO, "LIBRETRO: Memory map stored (%u descriptor(s))", map->num_descriptors);
@@ -518,8 +517,8 @@ static bool SetLibretroMemoryMaps(const struct retro_memory_map *map) {
  * @param count Output parameter filled with the number of descriptors.
  * @return Pointer to the descriptor array, or NULL if none are stored. */
 static const struct retro_memory_descriptor* GetLibretroMemoryMaps(unsigned *count) {
-    if (count != NULL) *count = LibretroCore.memoryMapDescriptorCount;
-    return LibretroCore.memoryMapDescriptors;
+    if (count != NULL) *count = Libretro.core.memoryMapDescriptorCount;
+    return Libretro.core.memoryMapDescriptors;
 }
 
 // Returns an absolute path for `path`. The result is either the input pointer
@@ -567,52 +566,52 @@ static size_t UpdateLibretroAudioSampleBatch(const int16_t *data, size_t frames)
 
 static void CloseLibretroVideo(void) {
     // Unload the existing texture if it exists already.
-    if (IsTextureValid(LibretroCore.texture)) {
-        UnloadTexture(LibretroCore.texture);
-        memset(&LibretroCore.texture, 0, sizeof(LibretroCore.texture));
+    if (IsTextureValid(Libretro.core.texture)) {
+        UnloadTexture(Libretro.core.texture);
+        memset(&Libretro.core.texture, 0, sizeof(Libretro.core.texture));
     }
 
-    if (LibretroCore.frameBuffer != NULL) {
-        MemFree(LibretroCore.frameBuffer);
+    if (Libretro.core.frameBuffer != NULL) {
+        MemFree(Libretro.core.frameBuffer);
     }
-    LibretroCore.frameBuffer = NULL;
-    LibretroCore.frameBufferSize = 0;
-    LibretroCore.textureRebuild = false;
+    Libretro.core.frameBuffer = NULL;
+    Libretro.core.frameBufferSize = 0;
+    Libretro.core.textureRebuild = false;
 }
 
 static bool InitLibretroVideo(void) {
     CloseLibretroVideo();
 
     // Build the rendering image.
-    if (LibretroCore.width == 0 || LibretroCore.height == 0) {
+    if (Libretro.core.width == 0 || Libretro.core.height == 0) {
         return false;
     }
 
-    Image image = GenImageColor(LibretroCore.width, LibretroCore.height, BLACK);
+    Image image = GenImageColor(Libretro.core.width, Libretro.core.height, BLACK);
     if (!IsImageValid(image)) {
         return false;
     }
-    ImageFormat(&image, LibretroRetroPixelFormatToPixelFormat(LibretroCore.pixelFormat));
+    ImageFormat(&image, LibretroRetroPixelFormatToPixelFormat(Libretro.core.pixelFormat));
 
     // Create the texture.
-    LibretroCore.texture = LoadTextureFromImage(image);
+    Libretro.core.texture = LoadTextureFromImage(image);
     UnloadImage(image);
-    if (!IsTextureValid(LibretroCore.texture)) {
+    if (!IsTextureValid(Libretro.core.texture)) {
         return false;
     }
 
-    SetTextureFilter(LibretroCore.texture, LibretroCore.textureFilter);
+    SetTextureFilter(Libretro.core.texture, Libretro.textureFilter);
 
     // (Re-)allocate the frame conversion buffer sized for XRGB8888→RGBA8888 (worst case).
-    size_t needed = (size_t)GetPixelDataSize(LibretroCore.width, LibretroCore.height, PIXELFORMAT_UNCOMPRESSED_R8G8B8A8);
+    size_t needed = (size_t)GetPixelDataSize(Libretro.core.width, Libretro.core.height, PIXELFORMAT_UNCOMPRESSED_R8G8B8A8);
     if (needed == 0) {
         CloseLibretroVideo();
         return false;
     }
-    LibretroCore.frameBuffer = MemAlloc(needed);
-    LibretroCore.frameBufferSize = needed;
+    Libretro.core.frameBuffer = MemAlloc(needed);
+    Libretro.core.frameBufferSize = needed;
 
-    LibretroCore.textureRebuild = false;
+    Libretro.core.textureRebuild = false;
     return true;
 }
 
@@ -622,7 +621,7 @@ static bool InitLibretroVideo(void) {
  * @return retro_time_t The current in-game time in microseconds.
  */
 static retro_time_t GetLibretroTimeUSEC(void) {
-    return (retro_time_t)(LibretroCore.gameTimeNSEC / 1000);
+    return (retro_time_t)(Libretro.core.gameTimeNSEC / 1000);
 }
 
 /**
@@ -642,7 +641,7 @@ static uint64_t GetLibretroCPUFeatures(void) {
  * @return retro_perf_tick_t The current value of the high resolution counter.
  */
 static retro_perf_tick_t GetLibretroPerfCounter(void) {
-    return LibretroCore.gameTimeNSEC;
+    return Libretro.core.gameTimeNSEC;
 }
 
 /**
@@ -651,7 +650,7 @@ static retro_perf_tick_t GetLibretroPerfCounter(void) {
  * @see retro_perf_register_t
  */
 static void SetLibretroPerformanceCounter(struct retro_perf_counter* counter) {
-    LibretroCore.perf_counter_last = counter;
+    Libretro.core.perf_counter_last = counter;
     counter->registered = true;
 }
 
@@ -682,10 +681,10 @@ static void StopLibretroPerformanceCounter(struct retro_perf_counter* counter) {
  */
 static void LogLibretroPerformanceCounter(void) {
     // TODO: Use a linked list of counters, and loop through them all.
-    if (LibretroCore.perf_counter_last == NULL) {
+    if (Libretro.core.perf_counter_last == NULL) {
         return;
     }
-    TraceLog(LOG_INFO, "LIBRETRO: Timer %s: %i - %i", LibretroCore.perf_counter_last->ident, LibretroCore.perf_counter_last->start, LibretroCore.perf_counter_last->total);
+    TraceLog(LOG_INFO, "LIBRETRO: Timer %s: %i - %i", Libretro.core.perf_counter_last->ident, Libretro.core.perf_counter_last->start, Libretro.core.perf_counter_last->total);
 }
 
 static bool SetLibretroRumbleState(unsigned port, enum retro_rumble_effect effect, uint16_t strength) {
@@ -694,11 +693,11 @@ static bool SetLibretroRumbleState(unsigned port, enum retro_rumble_effect effec
     }
     float normalized = (float)strength / 65535.0f;
     if (effect == RETRO_RUMBLE_STRONG) {
-        LibretroCore.rumbleStrong[port] = normalized;
+        Libretro.core.rumbleStrong[port] = normalized;
     } else {
-        LibretroCore.rumbleWeak[port] = normalized;
+        Libretro.core.rumbleWeak[port] = normalized;
     }
-    SetGamepadVibration((int)port, LibretroCore.rumbleStrong[port], LibretroCore.rumbleWeak[port], 3600.0f);
+    SetGamepadVibration((int)port, Libretro.core.rumbleStrong[port], Libretro.core.rumbleWeak[port], 3600.0f);
     return true;
 }
 
@@ -708,8 +707,8 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
             if (data == NULL) {
                 return false;
             }
-            LibretroCore.rotation = *(const unsigned *)data;
-            TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_ROTATION: %u (%u°)", LibretroCore.rotation, LibretroCore.rotation * 90);
+            Libretro.core.rotation = *(const unsigned *)data;
+            TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_ROTATION: %u (%u°)", Libretro.core.rotation, Libretro.core.rotation * 90);
             return true;
         }
 
@@ -739,14 +738,14 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_MESSAGE: %s (%i frames)", message->msg, message->frames);
-            TextCopy(LibretroCore.osdMessage, message->msg);
-            LibretroCore.osdEndTime = GetTime() + message->frames / (LibretroCore.fps > 0 ? (double)LibretroCore.fps : 60.0);
+            TextCopy(Libretro.core.osdMessage, message->msg);
+            Libretro.core.osdEndTime = GetTime() + message->frames / (Libretro.core.fps > 0 ? (double)Libretro.core.fps : 60.0);
             return true;
         }
 
         case RETRO_ENVIRONMENT_SHUTDOWN: {
             TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SHUTDOWN");
-            LibretroCore.shutdown = true;
+            Libretro.core.shutdown = true;
             return true;
         }
 
@@ -755,8 +754,8 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 TraceLog(LOG_WARNING, "LIBRETRO: RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL no data provided");
                 return false;
             }
-            LibretroCore.performanceLevel = *(const unsigned *)data;
-            TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL(%i)", LibretroCore.performanceLevel);
+            Libretro.core.performanceLevel = *(const unsigned *)data;
+            TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL(%i)", Libretro.core.performanceLevel);
             return true;
         }
 
@@ -776,9 +775,9 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 TraceLog(LOG_WARNING, "LIBRETRO: RETRO_ENVIRONMENT_SET_PIXEL_FORMAT no data set");
                 return false;
             }
-            LibretroCore.pixelFormat = *pixelFormat;
+            Libretro.core.pixelFormat = *pixelFormat;
 
-            switch (LibretroCore.pixelFormat) {
+            switch (Libretro.core.pixelFormat) {
             case RETRO_PIXEL_FORMAT_0RGB1555:
                 TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_PIXEL_FORMAT 0RGB1555");
                 break;
@@ -790,7 +789,7 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 break;
             default:
                 TraceLog(LOG_ERROR, "LIBRETRO: RETRO_ENVIRONMENT_SET_PIXEL_FORMAT Unknown. Falling to RGB565");
-                LibretroCore.pixelFormat = RETRO_PIXEL_FORMAT_RGB565;
+                Libretro.core.pixelFormat = RETRO_PIXEL_FORMAT_RGB565;
                 return false;
             }
             return true;
@@ -806,20 +805,20 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
             for (const struct retro_input_descriptor *d = desc; d->description != NULL; d++) {
                 count++;
             }
-            if (LibretroCore.inputDescriptors != NULL) {
-                MemFree(LibretroCore.inputDescriptors);
-                LibretroCore.inputDescriptors = NULL;
-                LibretroCore.inputDescriptorCount = 0;
+            if (Libretro.core.inputDescriptors != NULL) {
+                MemFree(Libretro.core.inputDescriptors);
+                Libretro.core.inputDescriptors = NULL;
+                Libretro.core.inputDescriptorCount = 0;
             }
             if (count > 0) {
-                LibretroCore.inputDescriptors = (struct retro_input_descriptor *)MemAlloc(count * sizeof(struct retro_input_descriptor));
-                if (LibretroCore.inputDescriptors != NULL) {
+                Libretro.core.inputDescriptors = (struct retro_input_descriptor *)MemAlloc(count * sizeof(struct retro_input_descriptor));
+                if (Libretro.core.inputDescriptors != NULL) {
                     for (unsigned i = 0; i < count; i++) {
-                        LibretroCore.inputDescriptors[i] = desc[i];
+                        Libretro.core.inputDescriptors[i] = desc[i];
                         TraceLog(LOG_INFO, "LIBRETRO: Input port %u device %u index %u id %u: %s",
                             desc[i].port, desc[i].device, desc[i].index, desc[i].id, desc[i].description);
                     }
-                    LibretroCore.inputDescriptorCount = count;
+                    Libretro.core.inputDescriptorCount = count;
                 }
             }
             return true;
@@ -831,7 +830,7 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const struct retro_keyboard_callback * callback = (const struct retro_keyboard_callback *)data;
-            LibretroCore.keyboard_event = callback->callback;
+            Libretro.core.keyboard_event = callback->callback;
             return true;
         }
 
@@ -868,7 +867,7 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 TraceLog(LOG_WARNING, "LIBRETRO: RETRO_ENVIRONMENT_SET_VARIABLES no data set");
                 return false;
             }
-            LibretroCore.variableOptionsVersion = 0;
+            Libretro.core.variableOptionsVersion = 0;
             const struct retro_variable *var = (const struct retro_variable *)data;
             for (; var->key != NULL; var++) {
                 // Description format: "Desc text; option1|option2|...". Default is the first option.
@@ -907,8 +906,8 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             bool *updated = (bool *)data;
-            *updated = LibretroCore.variablesDirty;
-            LibretroCore.variablesDirty = false;
+            *updated = Libretro.core.variablesDirty;
+            Libretro.core.variablesDirty = false;
             return true;
         }
 
@@ -918,8 +917,8 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 TraceLog(LOG_WARNING, "LIBRETRO: RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME no data provided");
                 return false;
             }
-            LibretroCore.supportNoGame = *(bool*)data;
-            TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME: %s", LibretroCore.supportNoGame ? "true" : "false");
+            Libretro.core.supportNoGame = *(bool*)data;
+            TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME: %s", Libretro.core.supportNoGame ? "true" : "false");
             return true;
         }
 
@@ -929,7 +928,7 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const char** path = (const char**)data;
-            *path = LibretroCore.corePath[0] != '\0' ? LibretroCore.corePath : NULL;
+            *path = Libretro.core.corePath[0] != '\0' ? Libretro.core.corePath : NULL;
             return true;
         }
 
@@ -939,7 +938,7 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const struct retro_frame_time_callback *frame_time = (const struct retro_frame_time_callback*)data;
-            LibretroCore.runloop_frame_time = *frame_time;
+            Libretro.core.runloop_frame_time = *frame_time;
             return true;
         }
 
@@ -949,7 +948,7 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             struct retro_audio_callback *audio_cb = (struct retro_audio_callback*)data;
-            LibretroCore.audio_callback = *audio_cb;
+            Libretro.core.audio_callback = *audio_cb;
             return true;
         }
 
@@ -1043,17 +1042,17 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const struct retro_system_av_info av = *(const struct retro_system_av_info *)data;
-            bool sampleRateChanged = (av.timing.sample_rate != LibretroCore.sampleRate);
-            bool dimsChanged = (av.geometry.base_width != LibretroCore.width || av.geometry.base_height != LibretroCore.height);
-            LibretroCore.width = av.geometry.base_width;
-            LibretroCore.height = av.geometry.base_height;
-            LibretroCore.fps = (unsigned int)av.timing.fps;
-            LibretroCore.sampleRate = av.timing.sample_rate;
-            LibretroCore.aspectRatio = av.geometry.aspect_ratio;
+            bool sampleRateChanged = (av.timing.sample_rate != Libretro.core.sampleRate);
+            bool dimsChanged = (av.geometry.base_width != Libretro.core.width || av.geometry.base_height != Libretro.core.height);
+            Libretro.core.width = av.geometry.base_width;
+            Libretro.core.height = av.geometry.base_height;
+            Libretro.core.fps = (unsigned int)av.timing.fps;
+            Libretro.core.sampleRate = av.timing.sample_rate;
+            Libretro.core.aspectRatio = av.geometry.aspect_ratio;
             TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO %i x %i @ %i FPS",
-                LibretroCore.width,
-                LibretroCore.height,
-                LibretroCore.fps
+                Libretro.core.width,
+                Libretro.core.height,
+                Libretro.core.fps
             );
             if (dimsChanged) {
                 InitLibretroVideo();
@@ -1061,7 +1060,7 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
             if (sampleRateChanged) {
                 InitLibretroAudio();
             }
-            SetTargetFPS((int)(LibretroCore.fps * LibretroCore.speed));
+            SetTargetFPS((int)(Libretro.core.fps * Libretro.speed));
             return true;
         }
 
@@ -1081,26 +1080,26 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const struct retro_controller_info *info = (const struct retro_controller_info *)data;
-            if (LibretroCore.controllerInfo != NULL) {
-                MemFree(LibretroCore.controllerInfo);
-                LibretroCore.controllerInfo = NULL;
-                LibretroCore.controllerPortCount = 0;
+            if (Libretro.core.controllerInfo != NULL) {
+                MemFree(Libretro.core.controllerInfo);
+                Libretro.core.controllerInfo = NULL;
+                Libretro.core.controllerPortCount = 0;
             }
             unsigned portCount = 0;
             for (unsigned port = 0; info[port].types != NULL; port++) {
                 portCount++;
             }
             if (portCount > 0) {
-                LibretroCore.controllerInfo = (struct retro_controller_info *)MemAlloc(portCount * sizeof(struct retro_controller_info));
-                if (LibretroCore.controllerInfo != NULL) {
+                Libretro.core.controllerInfo = (struct retro_controller_info *)MemAlloc(portCount * sizeof(struct retro_controller_info));
+                if (Libretro.core.controllerInfo != NULL) {
                     for (unsigned port = 0; port < portCount; port++) {
-                        LibretroCore.controllerInfo[port] = info[port];
+                        Libretro.core.controllerInfo[port] = info[port];
                         TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_CONTROLLER_INFO port %u (%u types)", port, info[port].num_types);
                         for (unsigned i = 0; i < info[port].num_types; i++) {
                             TraceLog(LOG_INFO, "    > [%u] %s (id: %u)", i, info[port].types[i].desc, info[port].types[i].id);
                         }
                     }
-                    LibretroCore.controllerPortCount = portCount;
+                    Libretro.core.controllerPortCount = portCount;
                 }
             }
             return true;
@@ -1120,15 +1119,15 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             const struct retro_game_geometry *geom = (const struct retro_game_geometry *)data;
-            LibretroCore.width = geom->base_width;
-            LibretroCore.height = geom->base_height;
-            LibretroCore.aspectRatio = geom->aspect_ratio;
+            Libretro.core.width = geom->base_width;
+            Libretro.core.height = geom->base_height;
+            Libretro.core.aspectRatio = geom->aspect_ratio;
             TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_GEOMETRY %i x %i @ %f",
-                LibretroCore.width,
-                LibretroCore.height,
-                LibretroCore.aspectRatio
+                Libretro.core.width,
+                Libretro.core.height,
+                Libretro.core.aspectRatio
             );
-            LibretroCore.textureRebuild = true;
+            Libretro.core.textureRebuild = true;
             return true;
         }
 
@@ -1193,7 +1192,7 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
             }
 
             struct retro_vfs_interface_info * vfs_interface = (struct retro_vfs_interface_info *)data;
-            vfs_interface->iface = &LibretroCore.vfs_interface;
+            vfs_interface->iface = &Libretro.core.vfs_interface;
 
             // VFS 1
             if (vfs_interface->required_interface_version >= 1) {
@@ -1266,7 +1265,7 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 TraceLog(LOG_WARNING, "LIBRETRO: RETRO_ENVIRONMENT_GET_FASTFORWARDING data missing");
                 return false;
             }
-            *output = (LibretroCore.speed > 1.0f);
+            *output = (Libretro.speed > 1.0f);
             return true;
         }
 
@@ -1301,7 +1300,7 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 TraceLog(LOG_WARNING, "LIBRETRO: RETRO_ENVIRONMENT_SET_CORE_OPTIONS data missing");
                 return false;
             }
-            LibretroCore.variableOptionsVersion = 1;
+            Libretro.core.variableOptionsVersion = 1;
             for (; opts->key != NULL; opts++) {
                 const char *def = opts->default_value;
                 if (def == NULL && opts->values[0].value != NULL) {
@@ -1351,10 +1350,10 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
         case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY: {
             const struct retro_core_option_display *disp = (const struct retro_core_option_display *)data;
             if (!disp || !disp->key) return false;
-            for (unsigned i = 0; i < LibretroCore.variableCount; i++) {
-                if (TextIsEqual(LibretroCore.variableKeys[i], disp->key)) {
-                    LibretroCore.variableVisible[i] = disp->visible;
-                    LibretroCore.variablesVisibilityDirty = true;
+            for (unsigned i = 0; i < Libretro.core.variableCount; i++) {
+                if (TextIsEqual(Libretro.core.variableKeys[i], disp->key)) {
+                    Libretro.core.variableVisible[i] = disp->visible;
+                    Libretro.core.variablesVisibilityDirty = true;
                     return true;
                 }
             }
@@ -1396,8 +1395,8 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 TraceLog(LibretroMapRetroLogLevelToTraceLogType(message->level), "LIBRETRO: %s", message->msg);
             }
             if (message->target == RETRO_MESSAGE_TARGET_OSD || message->target == RETRO_MESSAGE_TARGET_ALL) {
-                TextCopy(LibretroCore.osdMessage, message->msg);
-                LibretroCore.osdEndTime = GetTime() + message->duration / 1000.0;
+                TextCopy(Libretro.core.osdMessage, message->msg);
+                Libretro.core.osdEndTime = GetTime() + message->duration / 1000.0;
             }
             return true;
         }
@@ -1418,13 +1417,13 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
 
         case RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK: {
             if (data == NULL) {
-                LibretroCore.audio_buffer_status_callback.callback = NULL;
+                Libretro.core.audio_buffer_status_callback.callback = NULL;
                 TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK disabled");
                 return true;
             }
             const struct retro_audio_buffer_status_callback *cb =
                 (const struct retro_audio_buffer_status_callback *)data;
-            LibretroCore.audio_buffer_status_callback = *cb;
+            Libretro.core.audio_buffer_status_callback = *cb;
             TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK registered");
             return true;
         }
@@ -1435,15 +1434,15 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
                 return false;
             }
             unsigned latencyMs = *(const unsigned *)data;
-            if (latencyMs == LibretroCore.minimumAudioLatencyMs) {
+            if (latencyMs == Libretro.core.minimumAudioLatencyMs) {
                 return true;
             }
-            LibretroCore.minimumAudioLatencyMs = latencyMs;
+            Libretro.core.minimumAudioLatencyMs = latencyMs;
             TraceLog(LOG_INFO, "LIBRETRO: RETRO_ENVIRONMENT_SET_MINIMUM_AUDIO_LATENCY: %u ms", latencyMs);
             // Reinit audio so the new minimum is reflected in the ring buffer.
             // Safe before audio init (no-op via the NULL check) and at runtime
             // (matches the SET_SYSTEM_AV_INFO sample-rate-change path above).
-            if (LibretroCore.audioRingBuffer != NULL && LibretroCore.sampleRate > 0.0) {
+            if (Libretro.core.audioRingBuffer != NULL && Libretro.core.sampleRate > 0.0) {
                 InitLibretroAudio();
             }
             return true;
@@ -1468,18 +1467,18 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
             // its real array.
             if (data == NULL) return true;
 
-            LibretroCore.contentInfoOverrideCount = 0;
+            Libretro.core.contentInfoOverrideCount = 0;
             const struct retro_system_content_info_override *o =
                 (const struct retro_system_content_info_override *)data;
             for (; o->extensions != NULL; o++) {
-                if (LibretroCore.contentInfoOverrideCount >= LIBRETRO_MAX_CONTENT_INFO_OVERRIDES) {
+                if (Libretro.core.contentInfoOverrideCount >= LIBRETRO_MAX_CONTENT_INFO_OVERRIDES) {
                     TraceLog(LOG_WARNING, "LIBRETRO: Too many content info overrides; dropping rest");
                     break;
                 }
-                unsigned i = LibretroCore.contentInfoOverrideCount++;
-                TextCopy(LibretroCore.contentInfoOverrideExts[i], o->extensions);
-                LibretroCore.contentInfoOverrideNeedFullpath[i] = o->need_fullpath;
-                LibretroCore.contentInfoOverridePersistent[i]   = o->persistent_data;
+                unsigned i = Libretro.core.contentInfoOverrideCount++;
+                TextCopy(Libretro.core.contentInfoOverrideExts[i], o->extensions);
+                Libretro.core.contentInfoOverrideNeedFullpath[i] = o->need_fullpath;
+                Libretro.core.contentInfoOverridePersistent[i]   = o->persistent_data;
                 TraceLog(LOG_INFO, "LIBRETRO: content_info_override: ext=\"%s\" need_fullpath=%s persistent=%s",
                     o->extensions,
                     o->need_fullpath ? "true" : "false",
@@ -1489,8 +1488,8 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
         }
 
         case RETRO_ENVIRONMENT_GET_GAME_INFO_EXT: {
-            if (data == NULL || !LibretroCore.gameInfoExtValid) return false;
-            *(const struct retro_game_info_ext **)data = &LibretroCore.gameInfoExt;
+            if (data == NULL || !Libretro.core.gameInfoExtValid) return false;
+            *(const struct retro_game_info_ext **)data = &Libretro.core.gameInfoExt;
             return true;
         }
 
@@ -1502,7 +1501,7 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
             if (opts->definitions == NULL) {
                 return false;
             }
-            LibretroCore.variableOptionsVersion = 2;
+            Libretro.core.variableOptionsVersion = 2;
             const struct retro_core_option_v2_definition *def = opts->definitions;
             for (; def->key != NULL; def++) {
                 const char *defaultVal = def->default_value;
@@ -1556,7 +1555,7 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
         case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_UPDATE_DISPLAY_CALLBACK: {
             const struct retro_core_options_update_display_callback *cb =
                 (const struct retro_core_options_update_display_callback *)data;
-            LibretroCore.options_update_display_callback = (cb && cb->callback) ? cb->callback : NULL;
+            Libretro.core.options_update_display_callback = (cb && cb->callback) ? cb->callback : NULL;
             return true;
         }
 
@@ -1573,15 +1572,15 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
             if (state == NULL) {
                 return false;
             }
-            if (LibretroCore.speed > 1.0f) {
+            if (Libretro.speed > 1.0f) {
                 state->mode = RETRO_THROTTLE_FAST_FORWARD;
-                state->rate = LibretroCore.fps * LibretroCore.speed;
-            } else if (LibretroCore.speed < 1.0f) {
+                state->rate = Libretro.core.fps * Libretro.speed;
+            } else if (Libretro.speed < 1.0f) {
                 state->mode = RETRO_THROTTLE_SLOW_MOTION;
-                state->rate = LibretroCore.fps * LibretroCore.speed;
+                state->rate = Libretro.core.fps * Libretro.speed;
             } else {
                 state->mode = RETRO_THROTTLE_NONE;
-                state->rate = (float)LibretroCore.fps;
+                state->rate = (float)Libretro.core.fps;
             }
             return true;
         }
@@ -1664,21 +1663,21 @@ static bool CallLibretroEnvironment(unsigned cmd, void * data) {
  * Retrieve the audio/video information for the core.
  */
 static bool LibretroGetAudioVideo(void) {
-    if (LibretroCore.retro_get_system_av_info == NULL) {
+    if (Libretro.core.retro_get_system_av_info == NULL) {
         return false;
     }
 
     struct retro_system_av_info av = {0};
-    LibretroCore.retro_get_system_av_info(&av);
-    LibretroCore.width = av.geometry.base_width;
-    LibretroCore.height = av.geometry.base_height;
-    LibretroCore.fps = (unsigned int)av.timing.fps;
-    LibretroCore.sampleRate = av.timing.sample_rate;
-    LibretroCore.aspectRatio = av.geometry.aspect_ratio;
+    Libretro.core.retro_get_system_av_info(&av);
+    Libretro.core.width = av.geometry.base_width;
+    Libretro.core.height = av.geometry.base_height;
+    Libretro.core.fps = (unsigned int)av.timing.fps;
+    Libretro.core.sampleRate = av.timing.sample_rate;
+    Libretro.core.aspectRatio = av.geometry.aspect_ratio;
     TraceLog(LOG_INFO, "LIBRETRO: Video and Audio information");
-    TraceLog(LOG_INFO, "    > Display size: %i x %i", LibretroCore.width, LibretroCore.height);
-    TraceLog(LOG_INFO, "    > Target FPS:   %i", LibretroCore.fps);
-    TraceLog(LOG_INFO, "    > Sample rate:  %.2f Hz", LibretroCore.sampleRate);
+    TraceLog(LOG_INFO, "    > Display size: %i x %i", Libretro.core.width, Libretro.core.height);
+    TraceLog(LOG_INFO, "    > Target FPS:   %i", Libretro.core.fps);
+    TraceLog(LOG_INFO, "    > Sample rate:  %.2f Hz", Libretro.core.sampleRate);
     return true;
 }
 
@@ -1686,33 +1685,33 @@ static bool LibretroGetAudioVideo(void) {
  * Run one emulation frame of the loaded core.
  */
 static void UpdateLibretro(void) {
-    if (LibretroCore.textureRebuild) {
+    if (Libretro.core.textureRebuild) {
         InitLibretroVideo();
     }
 
     if (IsLibretroGameReady()) {
-        LibretroCore.gameTimeNSEC += (retro_perf_tick_t)((double)GetFrameTime() * 1000000000.0);
+        Libretro.core.gameTimeNSEC += (retro_perf_tick_t)((double)GetFrameTime() * 1000000000.0);
     }
 
     // Update the game loop timer.
-    if (LibretroCore.runloop_frame_time.callback) {
+    if (Libretro.core.runloop_frame_time.callback) {
         retro_time_t current = GetLibretroTimeUSEC();
-        retro_time_t delta = current - LibretroCore.runloop_frame_time_last;
+        retro_time_t delta = current - Libretro.core.runloop_frame_time_last;
 
-        if (!LibretroCore.runloop_frame_time_last) {
-            delta = LibretroCore.runloop_frame_time.reference;
+        if (!Libretro.core.runloop_frame_time_last) {
+            delta = Libretro.core.runloop_frame_time.reference;
         }
-        LibretroCore.runloop_frame_time_last = current;
-        LibretroCore.runloop_frame_time.callback(delta);
+        Libretro.core.runloop_frame_time_last = current;
+        Libretro.core.runloop_frame_time.callback(delta);
     }
 
     // Ask the core to emit the audio.
-    if (LibretroCore.audio_callback.callback) {
-        LibretroCore.audio_callback.callback();
+    if (Libretro.core.audio_callback.callback) {
+        Libretro.core.audio_callback.callback();
     }
 
     // Check keyboard event callback.
-    if (LibretroCore.keyboard_event != NULL) {
+    if (Libretro.core.keyboard_event != NULL) {
         // Prepare the key modifiers.
         uint16_t key_modifiers = 0;
         if (IsKeyDown(KEY_LEFT_SHIFT) || IsKeyDown(KEY_RIGHT_SHIFT)) {
@@ -1753,10 +1752,10 @@ static void UpdateLibretro(void) {
             int raylibKey = LibretroRetroKeyToKeyboardKey(key);
             if (raylibKey > 0) {
                 if (IsKeyPressed(raylibKey)) {
-                    LibretroCore.keyboard_event(true, key, (uint32_t)keyCharMap[raylibKey], key_modifiers);
+                    Libretro.core.keyboard_event(true, key, (uint32_t)keyCharMap[raylibKey], key_modifiers);
                 }
                 else if (IsKeyReleased(raylibKey)) {
-                    LibretroCore.keyboard_event(false, key, 0, key_modifiers);
+                    Libretro.core.keyboard_event(false, key, 0, key_modifiers);
                 }
             }
         }
@@ -1765,51 +1764,51 @@ static void UpdateLibretro(void) {
     if (IsLibretroGameReady()) {
         // Report audio buffer occupancy to the core just before retro_run, so
         // it can decide whether to frameskip to avoid under-runs.
-        if (LibretroCore.audio_buffer_status_callback.callback && LibretroCore.audioRingBufferSize > 0) {
-            unsigned occupancy = (unsigned)((LibretroCore.audioRingAvailable * 100) / LibretroCore.audioRingBufferSize);
+        if (Libretro.core.audio_buffer_status_callback.callback && Libretro.core.audioRingBufferSize > 0) {
+            unsigned occupancy = (unsigned)((Libretro.core.audioRingAvailable * 100) / Libretro.core.audioRingBufferSize);
             if (occupancy > 100) occupancy = 100;
             bool underrun_likely = occupancy < 25;
-            LibretroCore.audio_buffer_status_callback.callback(true, occupancy, underrun_likely);
+            Libretro.core.audio_buffer_status_callback.callback(true, occupancy, underrun_likely);
         }
 
-        LibretroCore.retro_run();
+        Libretro.core.retro_run();
 
         // Flush any single-sample accumulator left over from retro_run so
         // samples arrive in the ring buffer within the same frame.
-        if (LibretroCore.singleSampleCount > 0) {
-            UpdateLibretroAudioSampleBatch(LibretroCore.singleSampleBuffer, LibretroCore.singleSampleCount);
-            LibretroCore.singleSampleCount = 0;
+        if (Libretro.core.singleSampleCount > 0) {
+            UpdateLibretroAudioSampleBatch(Libretro.core.singleSampleBuffer, Libretro.core.singleSampleCount);
+            Libretro.core.singleSampleCount = 0;
         }
 
         // Dynamic Rate Control: nudge audio pitch to steer ring-buffer occupancy
         // toward 50% so the audio stays in sync.
-        if (LibretroCore.drcEnabled && LibretroCore.audioRingBufferSize > 0 && IsAudioStreamValid(LibretroCore.audioStream)) {
+        if (Libretro.core.drcEnabled && Libretro.core.audioRingBufferSize > 0 && IsAudioStreamValid(Libretro.core.audioStream)) {
             // Positive drift when buffer is full (consume faster).
             // Negative drift when buffer is empty (consume slower).
-            float drift = ((float)LibretroCore.audioRingAvailable / (float)LibretroCore.audioRingBufferSize) - 0.5f;
-            LibretroCore.drcAdjustment += drift * 0.001f;
-            if (LibretroCore.drcAdjustment < 0.995f) LibretroCore.drcAdjustment = 0.995f;
-            if (LibretroCore.drcAdjustment > 1.005f) LibretroCore.drcAdjustment = 1.005f;
-            SetAudioStreamPitch(LibretroCore.audioStream, LibretroCore.drcAdjustment);
+            float drift = ((float)Libretro.core.audioRingAvailable / (float)Libretro.core.audioRingBufferSize) - 0.5f;
+            Libretro.core.drcAdjustment += drift * 0.001f;
+            if (Libretro.core.drcAdjustment < 0.995f) Libretro.core.drcAdjustment = 0.995f;
+            if (Libretro.core.drcAdjustment > 1.005f) Libretro.core.drcAdjustment = 1.005f;
+            SetAudioStreamPitch(Libretro.core.audioStream, Libretro.core.drcAdjustment);
         }
 
         // Some cores (notably mgba GB/GBC) defer the actual core reset until
         // the first retro_run, so retro_get_system_av_info called pre-run
         // returns sample_rate=0. Once we have a frame, re-query AV info and
         // reinit audio if a valid sample rate has appeared.
-        if (LibretroCore.sampleRate <= 0.0 && LibretroCore.retro_get_system_av_info) {
+        if (Libretro.core.sampleRate <= 0.0 && Libretro.core.retro_get_system_av_info) {
             struct retro_system_av_info av = {0};
-            LibretroCore.retro_get_system_av_info(&av);
+            Libretro.core.retro_get_system_av_info(&av);
             if (av.timing.sample_rate > 0.0) {
-                LibretroCore.sampleRate = av.timing.sample_rate;
-                TraceLog(LOG_INFO, "LIBRETRO: Sample rate now %.2f Hz (post-retro_run); reinitializing audio", LibretroCore.sampleRate);
+                Libretro.core.sampleRate = av.timing.sample_rate;
+                TraceLog(LOG_INFO, "LIBRETRO: Sample rate now %.2f Hz (post-retro_run); reinitializing audio", Libretro.core.sampleRate);
                 InitLibretroAudio();
             }
         }
 
-        if (LibretroCore.options_update_display_callback) {
-            if (LibretroCore.options_update_display_callback()) {
-                LibretroCore.variablesVisibilityDirty = true;
+        if (Libretro.core.options_update_display_callback) {
+            if (Libretro.core.options_update_display_callback()) {
+                Libretro.core.variablesVisibilityDirty = true;
             }
         }
     }
@@ -1819,7 +1818,7 @@ static void UpdateLibretro(void) {
  * Check whether a core has been successfully initialized.
  * @return true if a core is loaded and ready. */
 static bool IsLibretroReady(void) {
-    return LibretroCore.handle != NULL;
+    return Libretro.core.handle != NULL;
 }
 
 /**
@@ -1827,7 +1826,7 @@ static bool IsLibretroReady(void) {
  * @return true if the core wants to close.
  */
 static bool LibretroShouldClose(void) {
-    return LibretroCore.shutdown;
+    return Libretro.core.shutdown;
 }
 
 static void LibretroMapPixelFormatARGB8888ToRGBA8888(void *output_, const void *input_,
@@ -1862,54 +1861,54 @@ static void LibretroVideoRefresh(const void *data, unsigned width, unsigned heig
     }
 
     // Resize the video if needed.
-    if (width != LibretroCore.width || height != LibretroCore.height) {
-        LibretroCore.width = width;
-        LibretroCore.height = height;
+    if (width != Libretro.core.width || height != Libretro.core.height) {
+        Libretro.core.width = width;
+        Libretro.core.height = height;
         if (!InitLibretroVideo()) {
             return;
         }
     }
 
-    if (!IsTextureValid(LibretroCore.texture)) {
+    if (!IsTextureValid(Libretro.core.texture)) {
         return;
     }
 
-    switch (LibretroCore.pixelFormat) {
+    switch (Libretro.core.pixelFormat) {
         case RETRO_PIXEL_FORMAT_UNKNOWN:
         case RETRO_PIXEL_FORMAT_RGB565: {
             // For small pitches, we can use the data 1:1, otherwise we need to adjust it.
             if (pitch == width * 2) {
                 // Core: FCEUM
-                UpdateTexture(LibretroCore.texture, data);
+                UpdateTexture(Libretro.core.texture, data);
             }
             else {
                 // Core: SNES9x
                 const uint8_t *src = (const uint8_t *)data;
-                uint8_t *dst = (uint8_t *)LibretroCore.frameBuffer;
+                uint8_t *dst = (uint8_t *)Libretro.core.frameBuffer;
                 size_t row_bytes = width * 2;
                 for (unsigned h = 0; h < height; h++) {
                     memcpy(dst, src, row_bytes);
                     src += pitch;
                     dst += row_bytes;
                 }
-                UpdateTexture(LibretroCore.texture, LibretroCore.frameBuffer);
+                UpdateTexture(Libretro.core.texture, Libretro.core.frameBuffer);
             }
         }
         break;
         case RETRO_PIXEL_FORMAT_0RGB1555: {
-            LibretroPixelFormatARGB1555ToRGB565(LibretroCore.frameBuffer, data, width, height,
+            LibretroPixelFormatARGB1555ToRGB565(Libretro.core.frameBuffer, data, width, height,
                 (int)(width * 2),
                 pitch);
-            UpdateTexture(LibretroCore.texture, LibretroCore.frameBuffer);
+            UpdateTexture(Libretro.core.texture, Libretro.core.frameBuffer);
         }
         break;
         case RETRO_PIXEL_FORMAT_XRGB8888: {
             // Core: Blastem
             // Core: BSNES
-            LibretroMapPixelFormatARGB8888ToRGBA8888(LibretroCore.frameBuffer, data,
+            LibretroMapPixelFormatARGB8888ToRGBA8888(Libretro.core.frameBuffer, data,
                 width, height,
                 (int)(width * 4), pitch);
-            UpdateTexture(LibretroCore.texture, LibretroCore.frameBuffer);
+            UpdateTexture(Libretro.core.texture, Libretro.core.frameBuffer);
         }
         break;
     }
@@ -1917,8 +1916,8 @@ static void LibretroVideoRefresh(const void *data, unsigned width, unsigned heig
 
 static void LibretroInputPoll(void) {
     // Mouse
-    LibretroCore.inputLastMousePosition = LibretroCore.inputMousePosition;
-    LibretroCore.inputMousePosition = GetMousePosition();
+    Libretro.core.inputLastMousePosition = Libretro.core.inputMousePosition;
+    Libretro.core.inputMousePosition = GetMousePosition();
 }
 
 static int16_t LibretroInputState(unsigned port, unsigned device, unsigned index, unsigned id) {
@@ -1938,14 +1937,14 @@ static int16_t LibretroInputState(unsigned port, unsigned device, unsigned index
                 for (int btn = 0; btn < 16; btn++) {
                     bool pressed = false;
                     if (port == 0) {
-                        if (btn < 16 && LibretroCore.virtualJoypadState[btn]) {
+                        if (btn < 16 && Libretro.core.virtualJoypadState[btn]) {
                             pressed = true;
                         } else if (gpAvail) {
                             int gamepadButton = LibretroRetroJoypadButtonToGamepadButton(btn);
                             pressed = (gamepadButton != GAMEPAD_BUTTON_UNKNOWN && IsGamepadButtonDown(0, gamepadButton));
                         }
                         if (!pressed) {
-                            int kbKey = (btn < 16) ? LibretroCore.keyboardPlayer1[btn] : KEY_NULL;
+                            int kbKey = (btn < 16) ? Libretro.keyboardPlayer1[btn] : KEY_NULL;
                             if (kbKey != KEY_NULL) {
                                 pressed = IsKeyDown(kbKey);
                             } else {
@@ -1966,7 +1965,7 @@ static int16_t LibretroInputState(unsigned port, unsigned device, unsigned index
 
             // Port 0: gamepad if available, otherwise keyboard.
             if (port == 0) {
-                if (id < 16 && LibretroCore.virtualJoypadState[id]) {
+                if (id < 16 && Libretro.core.virtualJoypadState[id]) {
                     return 1;
                 }
                 if (IsGamepadAvailable(0)) {
@@ -1975,7 +1974,7 @@ static int16_t LibretroInputState(unsigned port, unsigned device, unsigned index
                         return 1;
                     }
                 }
-                int kbKey = (id < 16) ? LibretroCore.keyboardPlayer1[id] : KEY_NULL;
+                int kbKey = (id < 16) ? Libretro.keyboardPlayer1[id] : KEY_NULL;
                 if (kbKey != KEY_NULL) {
                     return (int)IsKeyDown(kbKey);
                 }
@@ -2004,9 +2003,9 @@ static int16_t LibretroInputState(unsigned port, unsigned device, unsigned index
                 case RETRO_DEVICE_ID_MOUSE_MIDDLE:
                     return IsMouseButtonDown(MOUSE_MIDDLE_BUTTON);
                 case RETRO_DEVICE_ID_MOUSE_X:
-                    return LibretroCore.inputMousePosition.x - LibretroCore.inputLastMousePosition.x;
+                    return Libretro.core.inputMousePosition.x - Libretro.core.inputLastMousePosition.x;
                 case RETRO_DEVICE_ID_MOUSE_Y:
-                    return LibretroCore.inputMousePosition.y - LibretroCore.inputLastMousePosition.y;
+                    return Libretro.core.inputMousePosition.y - Libretro.core.inputLastMousePosition.y;
                 case RETRO_DEVICE_ID_MOUSE_WHEELUP:
                     return GetMouseWheelMove() > 0;
                 case RETRO_DEVICE_ID_MOUSE_WHEELDOWN:
@@ -2056,9 +2055,9 @@ static int16_t LibretroInputState(unsigned port, unsigned device, unsigned index
                 case RETRO_DEVICE_ID_LIGHTGUN_DPAD_RIGHT:
                     return IsKeyDown(KEY_RIGHT);
                 case RETRO_DEVICE_ID_LIGHTGUN_X:
-                    return LibretroCore.inputMousePosition.x - LibretroCore.inputLastMousePosition.x;
+                    return Libretro.core.inputMousePosition.x - Libretro.core.inputLastMousePosition.x;
                 case RETRO_DEVICE_ID_LIGHTGUN_Y:
-                    return LibretroCore.inputMousePosition.y - LibretroCore.inputLastMousePosition.y;
+                    return Libretro.core.inputMousePosition.y - Libretro.core.inputLastMousePosition.y;
             }
             return 0;
         }
@@ -2112,61 +2111,61 @@ static int16_t LibretroInputState(unsigned port, unsigned device, unsigned index
 static void LibretroAudioStreamCallback(void *audioData, unsigned int frameCount) {
     float *output = (float *)audioData;
 
-    if (!LibretroCore.audioRingBuffer || LibretroCore.audioRingAvailable == 0) {
+    if (!Libretro.core.audioRingBuffer || Libretro.core.audioRingAvailable == 0) {
         memset(output, 0, frameCount * 2 * sizeof(float));
         return;
     }
 
     size_t frames_to_read = frameCount;
-    if (frames_to_read > LibretroCore.audioRingAvailable) {
-        size_t silence_frames = frames_to_read - LibretroCore.audioRingAvailable;
-        memset(output + LibretroCore.audioRingAvailable * 2, 0, silence_frames * 2 * sizeof(float));
-        frames_to_read = LibretroCore.audioRingAvailable;
+    if (frames_to_read > Libretro.core.audioRingAvailable) {
+        size_t silence_frames = frames_to_read - Libretro.core.audioRingAvailable;
+        memset(output + Libretro.core.audioRingAvailable * 2, 0, silence_frames * 2 * sizeof(float));
+        frames_to_read = Libretro.core.audioRingAvailable;
     }
 
-    size_t read_pos = (LibretroCore.audioRingWritePos + LibretroCore.audioRingBufferSize - LibretroCore.audioRingAvailable) % LibretroCore.audioRingBufferSize;
-    size_t first_chunk = LibretroCore.audioRingBufferSize - read_pos;
+    size_t read_pos = (Libretro.core.audioRingWritePos + Libretro.core.audioRingBufferSize - Libretro.core.audioRingAvailable) % Libretro.core.audioRingBufferSize;
+    size_t first_chunk = Libretro.core.audioRingBufferSize - read_pos;
     if (first_chunk > frames_to_read) first_chunk = frames_to_read;
     size_t second_chunk = frames_to_read - first_chunk;
-    memcpy(output, LibretroCore.audioRingBuffer + read_pos * 2, first_chunk * 2 * sizeof(float));
+    memcpy(output, Libretro.core.audioRingBuffer + read_pos * 2, first_chunk * 2 * sizeof(float));
     if (second_chunk > 0) {
-        memcpy(output + first_chunk * 2, LibretroCore.audioRingBuffer, second_chunk * 2 * sizeof(float));
+        memcpy(output + first_chunk * 2, Libretro.core.audioRingBuffer, second_chunk * 2 * sizeof(float));
     }
 
-    LibretroCore.audioRingAvailable -= frames_to_read;
+    Libretro.core.audioRingAvailable -= frames_to_read;
 }
 
 /**
  * Write a batch of int16_t stereo frames into the ring buffer.
  */
 static size_t UpdateLibretroAudioSampleBatch(const int16_t *data, size_t frames) {
-    if (!data || frames == 0 || !LibretroCore.audioRingBuffer) return 0;
+    if (!data || frames == 0 || !Libretro.core.audioRingBuffer) return 0;
 
-    size_t available_space = LibretroCore.audioRingBufferSize - LibretroCore.audioRingAvailable;
+    size_t available_space = Libretro.core.audioRingBufferSize - Libretro.core.audioRingAvailable;
     size_t frames_to_write = (frames < available_space) ? frames : available_space;
 
     if (frames_to_write == 0) {
-        if (LibretroCore.audioDropWarnCount++ < 3) {
+        if (Libretro.core.audioDropWarnCount++ < 3) {
             TraceLog(LOG_WARNING, "LIBRETRO: Audio ring buffer full, dropping %zu frames", frames);
         }
         return 0;
     }
 
     static const float scale = 1.0f / 32768.0f;
-    size_t wfirst = LibretroCore.audioRingBufferSize - LibretroCore.audioRingWritePos;
+    size_t wfirst = Libretro.core.audioRingBufferSize - Libretro.core.audioRingWritePos;
     if (wfirst > frames_to_write) wfirst = frames_to_write;
     size_t wsecond = frames_to_write - wfirst;
     for (size_t i = 0; i < wfirst; i++) {
-        LibretroCore.audioRingBuffer[(LibretroCore.audioRingWritePos + i) * 2]     = (float)data[i * 2]     * scale;
-        LibretroCore.audioRingBuffer[(LibretroCore.audioRingWritePos + i) * 2 + 1] = (float)data[i * 2 + 1] * scale;
+        Libretro.core.audioRingBuffer[(Libretro.core.audioRingWritePos + i) * 2]     = (float)data[i * 2]     * scale;
+        Libretro.core.audioRingBuffer[(Libretro.core.audioRingWritePos + i) * 2 + 1] = (float)data[i * 2 + 1] * scale;
     }
     for (size_t i = 0; i < wsecond; i++) {
-        LibretroCore.audioRingBuffer[i * 2]     = (float)data[(wfirst + i) * 2]     * scale;
-        LibretroCore.audioRingBuffer[i * 2 + 1] = (float)data[(wfirst + i) * 2 + 1] * scale;
+        Libretro.core.audioRingBuffer[i * 2]     = (float)data[(wfirst + i) * 2]     * scale;
+        Libretro.core.audioRingBuffer[i * 2 + 1] = (float)data[(wfirst + i) * 2 + 1] * scale;
     }
 
-    LibretroCore.audioRingWritePos = (LibretroCore.audioRingWritePos + frames_to_write) % LibretroCore.audioRingBufferSize;
-    LibretroCore.audioRingAvailable += frames_to_write;
+    Libretro.core.audioRingWritePos = (Libretro.core.audioRingWritePos + frames_to_write) % Libretro.core.audioRingBufferSize;
+    Libretro.core.audioRingAvailable += frames_to_write;
 
     return frames_to_write;
 }
@@ -2175,29 +2174,29 @@ static size_t UpdateLibretroAudioSampleBatch(const int16_t *data, size_t frames)
  * Accumulate single-sample callbacks into a buffer before flushing to the ring buffer.
  */
 static void UpdateLibretroAudioSample(int16_t left, int16_t right) {
-    if (LibretroCore.singleSampleCount >= LIBRETRO_AUDIO_SINGLE_SAMPLE_BUFFER_SIZE) {
-        UpdateLibretroAudioSampleBatch(LibretroCore.singleSampleBuffer, LibretroCore.singleSampleCount);
-        LibretroCore.singleSampleCount = 0;
+    if (Libretro.core.singleSampleCount >= LIBRETRO_AUDIO_SINGLE_SAMPLE_BUFFER_SIZE) {
+        UpdateLibretroAudioSampleBatch(Libretro.core.singleSampleBuffer, Libretro.core.singleSampleCount);
+        Libretro.core.singleSampleCount = 0;
     }
 
-    LibretroCore.singleSampleBuffer[LibretroCore.singleSampleCount * 2]     = left;
-    LibretroCore.singleSampleBuffer[LibretroCore.singleSampleCount * 2 + 1] = right;
-    LibretroCore.singleSampleCount++;
+    Libretro.core.singleSampleBuffer[Libretro.core.singleSampleCount * 2]     = left;
+    Libretro.core.singleSampleBuffer[Libretro.core.singleSampleCount * 2 + 1] = right;
+    Libretro.core.singleSampleCount++;
 }
 
 static void CloseLibretroAudio(void) {
     // Unload the audiostream first.
-    if (IsAudioStreamValid(LibretroCore.audioStream)) {
-        StopAudioStream(LibretroCore.audioStream);
-        UnloadAudioStream(LibretroCore.audioStream);
-        memset(&LibretroCore.audioStream, 0, sizeof(LibretroCore.audioStream));
+    if (IsAudioStreamValid(Libretro.core.audioStream)) {
+        StopAudioStream(Libretro.core.audioStream);
+        UnloadAudioStream(Libretro.core.audioStream);
+        memset(&Libretro.core.audioStream, 0, sizeof(Libretro.core.audioStream));
     }
-    if (LibretroCore.audioRingBuffer != NULL) {
-        MemFree(LibretroCore.audioRingBuffer);
-        LibretroCore.audioRingBuffer = NULL;
+    if (Libretro.core.audioRingBuffer != NULL) {
+        MemFree(Libretro.core.audioRingBuffer);
+        Libretro.core.audioRingBuffer = NULL;
     }
-    LibretroCore.audioRingAvailable = 0;
-    LibretroCore.audioRingWritePos = 0;
+    Libretro.core.audioRingAvailable = 0;
+    Libretro.core.audioRingWritePos = 0;
 }
 
 static void InitLibretroAudio(void) {
@@ -2207,7 +2206,7 @@ static void InitLibretroAudio(void) {
     // (mgba GB/GBC) defer their internal reset until the first retro_run,
     // so retro_get_system_av_info returns 0 here. UpdateLibretro will
     // re-call InitLibretroAudio after the first run once the rate appears.
-    if (LibretroCore.sampleRate <= 0.0) {
+    if (Libretro.core.sampleRate <= 0.0) {
         TraceLog(LOG_INFO, "LIBRETRO: Deferring audio init (sample rate not yet known)");
         return;
     }
@@ -2216,33 +2215,33 @@ static void InitLibretroAudio(void) {
     // LIBRETRO_AUDIO_RING_BUFFER_SIZE frames; grown to satisfy the core's
     // RETRO_ENVIRONMENT_SET_MINIMUM_AUDIO_LATENCY request if any.
     size_t frames = LIBRETRO_AUDIO_RING_BUFFER_SIZE;
-    if (LibretroCore.minimumAudioLatencyMs > 0) {
-        size_t requested = (size_t)((LibretroCore.minimumAudioLatencyMs / 1000.0) * LibretroCore.sampleRate);
+    if (Libretro.core.minimumAudioLatencyMs > 0) {
+        size_t requested = (size_t)((Libretro.core.minimumAudioLatencyMs / 1000.0) * Libretro.core.sampleRate);
         if (requested > frames) frames = requested;
     }
-    LibretroCore.audioRingBufferSize = frames;
-    LibretroCore.audioRingBuffer = (float *)MemAlloc(LibretroCore.audioRingBufferSize * 2 * sizeof(float));
-    LibretroCore.audioRingWritePos = 0;
-    LibretroCore.audioRingAvailable = 0;
+    Libretro.core.audioRingBufferSize = frames;
+    Libretro.core.audioRingBuffer = (float *)MemAlloc(Libretro.core.audioRingBufferSize * 2 * sizeof(float));
+    Libretro.core.audioRingWritePos = 0;
+    Libretro.core.audioRingAvailable = 0;
 
     // Create the audio stream: 32-bit float, stereo, pulled via callback.
     int sampleSize = 32;
     int channels = 2;
-    LibretroCore.audioStream = LoadAudioStream((unsigned int)LibretroCore.sampleRate, sampleSize, channels);
-    SetAudioStreamCallback(LibretroCore.audioStream, LibretroAudioStreamCallback);
-    SetAudioStreamVolume(LibretroCore.audioStream, LibretroCore.volume);
-    LibretroCore.drcAdjustment = 1.0f;
-    LibretroCore.drcEnabled = true;
-    LibretroCore.audioDropWarnCount = 0;
-    PlayAudioStream(LibretroCore.audioStream);
+    Libretro.core.audioStream = LoadAudioStream((unsigned int)Libretro.core.sampleRate, sampleSize, channels);
+    SetAudioStreamCallback(Libretro.core.audioStream, LibretroAudioStreamCallback);
+    SetAudioStreamVolume(Libretro.core.audioStream, Libretro.volume);
+    Libretro.core.drcAdjustment = 1.0f;
+    Libretro.core.drcEnabled = true;
+    Libretro.core.audioDropWarnCount = 0;
+    PlayAudioStream(Libretro.core.audioStream);
 
     // Let the core know that the audio device has been initialized.
-    if (LibretroCore.audio_callback.set_state) {
-        LibretroCore.audio_callback.set_state(true);
+    if (Libretro.core.audio_callback.set_state) {
+        Libretro.core.audio_callback.set_state(true);
     }
 
     TraceLog(LOG_INFO, "LIBRETRO: Audio stream initialized (%i Hz, %i-bit float, ring buffer %i frames)",
-        (int)LibretroCore.sampleRate, sampleSize, (int)LibretroCore.audioRingBufferSize);
+        (int)Libretro.core.sampleRate, sampleSize, (int)Libretro.core.audioRingBufferSize);
 }
 
 static bool InitLibretroAudioVideo(void) {
@@ -2250,49 +2249,49 @@ static bool InitLibretroAudioVideo(void) {
     InitLibretroVideo();
     InitLibretroAudio();
 
-    SetTargetFPS((int)(LibretroCore.fps * LibretroCore.speed));
+    SetTargetFPS((int)(Libretro.core.fps * Libretro.speed));
 
     return true;
 }
 
-// Populate LibretroCore.gameInfoExt from LibretroCore.contentPath for
+// Populate Libretro.core.gameInfoExt from Libretro.core.contentPath for
 // RETRO_ENVIRONMENT_GET_GAME_INFO_EXT. Caller must set contentPath first.
 // `data`/`size` are only valid while retro_load_game() is executing.
 static void SetLibretroGameInfoExt(const void *data, size_t size) {
-    memset(&LibretroCore.gameInfoExt, 0, sizeof(LibretroCore.gameInfoExt));
-    LibretroCore.contentDir[0]  = '\0';
-    LibretroCore.contentName[0] = '\0';
-    LibretroCore.contentExt[0]  = '\0';
-    LibretroCore.gameInfoExtValid = false;
+    memset(&Libretro.core.gameInfoExt, 0, sizeof(Libretro.core.gameInfoExt));
+    Libretro.core.contentDir[0]  = '\0';
+    Libretro.core.contentName[0] = '\0';
+    Libretro.core.contentExt[0]  = '\0';
+    Libretro.core.gameInfoExtValid = false;
 
-    if (LibretroCore.contentPath[0] == '\0') return;
+    if (Libretro.core.contentPath[0] == '\0') return;
 
-    TextCopy(LibretroCore.contentDir,  GetDirectoryPath(LibretroCore.contentPath));
-    TextCopy(LibretroCore.contentName, GetFileNameWithoutExt(LibretroCore.contentPath));
+    TextCopy(Libretro.core.contentDir,  GetDirectoryPath(Libretro.core.contentPath));
+    TextCopy(Libretro.core.contentName, GetFileNameWithoutExt(Libretro.core.contentPath));
 
     // Extension without leading dot, lower-cased.
-    const char *ext = GetFileExtension(LibretroCore.contentPath);
+    const char *ext = GetFileExtension(Libretro.core.contentPath);
     if (ext != NULL && ext[0] == '.') ext++;
     if (ext != NULL) {
         size_t i = 0;
-        for (; ext[i] != '\0' && i + 1 < sizeof(LibretroCore.contentExt); i++) {
+        for (; ext[i] != '\0' && i + 1 < sizeof(Libretro.core.contentExt); i++) {
             char c = ext[i];
             if (c >= 'A' && c <= 'Z') c = (char)(c - 'A' + 'a');
-            LibretroCore.contentExt[i] = c;
+            Libretro.core.contentExt[i] = c;
         }
-        LibretroCore.contentExt[i] = '\0';
+        Libretro.core.contentExt[i] = '\0';
     }
 
-    LibretroCore.gameInfoExt.full_path       = LibretroCore.contentPath;
-    LibretroCore.gameInfoExt.dir             = LibretroCore.contentDir;
-    LibretroCore.gameInfoExt.name            = LibretroCore.contentName;
-    LibretroCore.gameInfoExt.ext             = LibretroCore.contentExt;
-    LibretroCore.gameInfoExt.meta            = "";
-    LibretroCore.gameInfoExt.data            = data;
-    LibretroCore.gameInfoExt.size            = size;
-    LibretroCore.gameInfoExt.file_in_archive = false;
-    LibretroCore.gameInfoExt.persistent_data = false;
-    LibretroCore.gameInfoExtValid            = true;
+    Libretro.core.gameInfoExt.full_path       = Libretro.core.contentPath;
+    Libretro.core.gameInfoExt.dir             = Libretro.core.contentDir;
+    Libretro.core.gameInfoExt.name            = Libretro.core.contentName;
+    Libretro.core.gameInfoExt.ext             = Libretro.core.contentExt;
+    Libretro.core.gameInfoExt.meta            = "";
+    Libretro.core.gameInfoExt.data            = data;
+    Libretro.core.gameInfoExt.size            = size;
+    Libretro.core.gameInfoExt.file_in_archive = false;
+    Libretro.core.gameInfoExt.persistent_data = false;
+    Libretro.core.gameInfoExtValid            = true;
 }
 
 static bool LoadLibretroGameFromMemory(const unsigned char *fileData, int dataSize) {
@@ -2306,7 +2305,7 @@ static bool LoadLibretroGameFromMemory(const unsigned char *fileData, int dataSi
     }
 
     // Check if it needs the full path
-    if (LibretroCore.needFullpath) {
+    if (Libretro.core.needFullpath) {
         TraceLog(LOG_ERROR, "LIBRETRO: The core requires the full path, can't load from memory");
         // TODO: Allow saving to a temporary location and then use LoadLibretroGame()?
         return false;
@@ -2319,14 +2318,14 @@ static bool LoadLibretroGameFromMemory(const unsigned char *fileData, int dataSi
     info.size = (size_t)dataSize;
     info.meta = "";
     SetLibretroGameInfoExt(fileData, (size_t)dataSize);
-    if (!LibretroCore.retro_load_game(&info)) {
+    if (!Libretro.core.retro_load_game(&info)) {
         TraceLog(LOG_ERROR, "LIBRETRO: Failed to load game data with retro_load_game()");
-        LibretroCore.loaded = false;
+        Libretro.core.loaded = false;
         return false;
     }
 
-    LibretroCore.loaded = InitLibretroAudioVideo();
-    if (!LibretroCore.loaded) {
+    Libretro.core.loaded = InitLibretroAudioVideo();
+    if (!Libretro.core.loaded) {
         return false;
     }
     TraceLog(LOG_INFO, "LIBRETRO: Loaded content from memory");
@@ -2368,32 +2367,32 @@ static void GetLibretroFileExtensionPattern(const char *exts, char *pattern, siz
  */
 static bool GetLibretroNeedFullpath(const char *path, bool *persistent) {
     if (persistent) *persistent = false;
-    if (path == NULL) return LibretroCore.needFullpath;
+    if (path == NULL) return Libretro.core.needFullpath;
 
-    for (unsigned i = 0; i < LibretroCore.contentInfoOverrideCount; i++) {
+    for (unsigned i = 0; i < Libretro.core.contentInfoOverrideCount; i++) {
         char pattern[LIBRETRO_CONTENT_INFO_OVERRIDE_EXTS_LEN + 16];
-        GetLibretroFileExtensionPattern(LibretroCore.contentInfoOverrideExts[i], pattern, sizeof(pattern));
+        GetLibretroFileExtensionPattern(Libretro.core.contentInfoOverrideExts[i], pattern, sizeof(pattern));
         if (IsFileExtension(path, pattern)) {
-            if (persistent) *persistent = LibretroCore.contentInfoOverridePersistent[i];
-            return LibretroCore.contentInfoOverrideNeedFullpath[i];
+            if (persistent) *persistent = Libretro.core.contentInfoOverridePersistent[i];
+            return Libretro.core.contentInfoOverrideNeedFullpath[i];
         }
     }
-    return LibretroCore.needFullpath;
+    return Libretro.core.needFullpath;
 }
 
 /**
  * Load game data into the core, with full control over the path stored on
- * LibretroCore.contentPath and over persistent_data ownership.
+ * Libretro.core.contentPath and over persistent_data ownership.
  *
  * When @p persistent is true (typically from a CONTENT_INFO_OVERRIDE
  * declaring persistent_data), ownership of @p fileData transfers to
- * LibretroCore.persistentGameData and the buffer is released by
+ * Libretro.core.persistentGameData and the buffer is released by
  * UnloadLibretroGame(). When false, the caller retains ownership and may
  * free @p fileData immediately after this returns.
  *
  * @param fileData    ROM data. Must not be NULL.
  * @param dataSize    Size of @p fileData in bytes.
- * @param contentPath Optional path stored on LibretroCore.contentPath and
+ * @param contentPath Optional path stored on Libretro.core.contentPath and
  *                    surfaced via RETRO_ENVIRONMENT_GET_GAME_INFO_EXT. May
  *                    be NULL.
  * @param persistent  See RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE; when
@@ -2410,9 +2409,9 @@ static bool LoadLibretroGameFromMemoryEx(unsigned char* fileData, int dataSize, 
     }
 
     if (contentPath != NULL && contentPath[0] != '\0') {
-        TextCopy(LibretroCore.contentPath, contentPath);
+        TextCopy(Libretro.core.contentPath, contentPath);
     } else {
-        LibretroCore.contentPath[0] = '\0';
+        Libretro.core.contentPath[0] = '\0';
     }
 
     struct retro_game_info info;
@@ -2421,22 +2420,22 @@ static bool LoadLibretroGameFromMemoryEx(unsigned char* fileData, int dataSize, 
     info.size = (size_t)dataSize;
     info.meta = "";
     SetLibretroGameInfoExt(fileData, (size_t)dataSize);
-    if (!LibretroCore.retro_load_game(&info)) {
+    if (!Libretro.core.retro_load_game(&info)) {
         TraceLog(LOG_ERROR, "LIBRETRO: Failed to load game data with retro_load_game()");
-        LibretroCore.loaded = false;
+        Libretro.core.loaded = false;
         return false;
     }
 
     if (persistent) {
-        if (LibretroCore.persistentGameData != NULL && LibretroCore.persistentGameData != fileData) {
-            UnloadFileData(LibretroCore.persistentGameData);
+        if (Libretro.core.persistentGameData != NULL && Libretro.core.persistentGameData != fileData) {
+            UnloadFileData(Libretro.core.persistentGameData);
         }
-        LibretroCore.persistentGameData = fileData;
-        LibretroCore.persistentGameDataSize = dataSize;
+        Libretro.core.persistentGameData = fileData;
+        Libretro.core.persistentGameDataSize = dataSize;
     }
 
-    LibretroCore.loaded = InitLibretroAudioVideo();
-    if (!LibretroCore.loaded) return false;
+    Libretro.core.loaded = InitLibretroAudioVideo();
+    if (!Libretro.core.loaded) return false;
     TraceLog(LOG_INFO, "LIBRETRO: Loaded content from memory");
     return true;
 }
@@ -2446,7 +2445,7 @@ static bool LoadLibretroGameFromMemoryEx(unsigned char* fileData, int dataSize, 
  * @return Extension list string (e.g. "nes|fds"), or empty string if not reported.
  */
 static const char* GetLibretroValidExtensions(void) {
-    return LibretroCore.validExtensions;
+    return Libretro.core.validExtensions;
 }
 
 /**
@@ -2454,7 +2453,7 @@ static const char* GetLibretroValidExtensions(void) {
  * @return true if the core wants archives passed as-is.
  */
 static bool IsLibretroBlockExtract(void) {
-    return LibretroCore.blockExtract;
+    return Libretro.core.blockExtract;
 }
 
 /**
@@ -2480,11 +2479,11 @@ static bool LoadLibretroGame(const char* gameFile) {
         info.size = 0;
         info.path = NULL;
         info.meta = "";
-        LibretroCore.contentPath[0] = '\0';
+        Libretro.core.contentPath[0] = '\0';
         SetLibretroGameInfoExt(NULL, 0);
-        if (LibretroCore.retro_load_game(&info)) {
+        if (Libretro.core.retro_load_game(&info)) {
             TraceLog(LOG_INFO, "LIBRETRO: Loaded without content");
-            LibretroCore.loaded = true;
+            Libretro.core.loaded = true;
             return InitLibretroAudioVideo();
         }
         TraceLog(LOG_ERROR, "LIBRETRO: Failed to load core without content");
@@ -2493,7 +2492,7 @@ static bool LoadLibretroGame(const char* gameFile) {
 
     if (!FileExists(gameFile)) {
         TraceLog(LOG_ERROR, "LIBRETRO: Given content does not exist: %s", gameFile);
-        LibretroCore.loaded = false;
+        Libretro.core.loaded = false;
         return false;
     }
 
@@ -2505,17 +2504,17 @@ static bool LoadLibretroGame(const char* gameFile) {
         info.size = 0;
         info.path = gameFile;
         info.meta = "";
-        TextCopy(LibretroCore.contentPath, gameFile);
+        TextCopy(Libretro.core.contentPath, gameFile);
         SetLibretroGameInfoExt(NULL, 0);
-        if (LibretroCore.retro_load_game(&info)) {
+        if (Libretro.core.retro_load_game(&info)) {
             TraceLog(LOG_INFO, "LIBRETRO: Loaded content with full path: %s", gameFile);
-            LibretroCore.loaded = true;
+            Libretro.core.loaded = true;
             return InitLibretroAudioVideo();
         }
         TraceLog(LOG_ERROR, "LIBRETRO: Failed to load full path: %s", gameFile);
-        LibretroCore.loaded = false;
-        LibretroCore.contentPath[0] = '\0';
-        LibretroCore.gameInfoExtValid = false;
+        Libretro.core.loaded = false;
+        Libretro.core.contentPath[0] = '\0';
+        Libretro.core.gameInfoExtValid = false;
         return false;
     }
 
@@ -2523,7 +2522,7 @@ static bool LoadLibretroGame(const char* gameFile) {
     unsigned char* gameData = LoadFileData(gameFile, &size);
     if (gameData == NULL || size == 0) {
         TraceLog(LOG_ERROR, "LIBRETRO: Failed to load game data with LoadFileData()");
-        LibretroCore.loaded = false;
+        Libretro.core.loaded = false;
         UnloadFileData(gameData);
         return false;
     }
@@ -2539,7 +2538,7 @@ static bool LoadLibretroGame(const char* gameFile) {
  * Get the display name of the loaded core.
  * @return Library name string, or an empty string if no core is loaded. */
 static const char* GetLibretroName(void) {
-    return LibretroCore.libraryName;
+    return Libretro.core.libraryName;
 }
 
 /**
@@ -2547,10 +2546,10 @@ static const char* GetLibretroName(void) {
  * @return Content or core name string.
  */
 static const char* GetLibretroContentName(void) {
-    if (LibretroCore.contentPath[0] != '\0') {
-        return GetFileNameWithoutExt(LibretroCore.contentPath);
+    if (Libretro.core.contentPath[0] != '\0') {
+        return GetFileNameWithoutExt(Libretro.core.contentPath);
     }
-    return LibretroCore.libraryName;
+    return Libretro.core.libraryName;
 }
 
 /**
@@ -2558,7 +2557,7 @@ static const char* GetLibretroContentName(void) {
  * @return Version string reported by the core.
  */
 static const char* GetLibretroVersion(void) {
-    return LibretroCore.libraryVersion;
+    return Libretro.core.libraryVersion;
 }
 
 /**
@@ -2566,7 +2565,7 @@ static const char* GetLibretroVersion(void) {
  * @return true if content must be provided; false if the core can run standalone.
  */
 static bool IsLibretroGameRequired(void) {
-    return !LibretroCore.supportNoGame;
+    return !Libretro.core.supportNoGame;
 }
 
 /**
@@ -2594,29 +2593,29 @@ static bool InitLibretroEx(const char* core, bool peek) {
     // fields are intentionally not reset in ResetLibretroCoreState so that
     // the peek path can populate them and CloseLibretro doesn't wipe them
     // before ScanLibretroCoreDirectory reads them.
-    LibretroCore.corePath[0]        = '\0';
-    LibretroCore.libraryName[0]     = '\0';
-    LibretroCore.libraryVersion[0]  = '\0';
-    LibretroCore.validExtensions[0] = '\0';
-    LibretroCore.needFullpath       = false;
-    LibretroCore.blockExtract       = false;
-    LibretroCore.supportNoGame      = false;
-    LibretroCore.apiVersion         = 0;
-    LibretroCore.performanceLevel   = 0;
-    LibretroCore.pixelFormat        = RETRO_PIXEL_FORMAT_0RGB1555;
+    Libretro.core.corePath[0]        = '\0';
+    Libretro.core.libraryName[0]     = '\0';
+    Libretro.core.libraryVersion[0]  = '\0';
+    Libretro.core.validExtensions[0] = '\0';
+    Libretro.core.needFullpath       = false;
+    Libretro.core.blockExtract       = false;
+    Libretro.core.supportNoGame      = false;
+    Libretro.core.apiVersion         = 0;
+    Libretro.core.performanceLevel   = 0;
+    Libretro.core.pixelFormat        = RETRO_PIXEL_FORMAT_0RGB1555;
 
     // Open the dynamic library.
-    LibretroCore.handle = dylib_load(core);
-    if (!LibretroCore.handle) {
+    Libretro.core.handle = dylib_load(core);
+    if (!Libretro.core.handle) {
         TraceLog(LOG_ERROR, "LIBRETRO: Failed to load provided library");
         return false;
     }
 
     // Find the libretro API version.
     LoadLibretroMethod(retro_api_version);
-    LibretroCore.apiVersion = LibretroCore.retro_api_version();
-    TraceLog(LOG_INFO, "LIBRETRO: API version: %i", LibretroCore.apiVersion);
-    if (LibretroCore.apiVersion != 1) {
+    Libretro.core.apiVersion = Libretro.core.retro_api_version();
+    TraceLog(LOG_INFO, "LIBRETRO: API version: %i", Libretro.core.apiVersion);
+    if (Libretro.core.apiVersion != 1) {
         CloseLibretro();
         TraceLog(LOG_ERROR, "LIBRETRO: Incompatible API version");
         return false;
@@ -2625,17 +2624,17 @@ static bool InitLibretroEx(const char* core, bool peek) {
     // Retrieve the libretro core system information.
     LoadLibretroMethod(retro_get_system_info);
     struct retro_system_info systemInfo;
-    LibretroCore.retro_get_system_info(&systemInfo);
-    TextCopy(LibretroCore.libraryName, systemInfo.library_name);
-    TextCopy(LibretroCore.libraryVersion, systemInfo.library_version);
-    TextCopy(LibretroCore.validExtensions, systemInfo.valid_extensions);
-    LibretroCore.needFullpath = systemInfo.need_fullpath;
-    LibretroCore.blockExtract = systemInfo.block_extract;
+    Libretro.core.retro_get_system_info(&systemInfo);
+    TextCopy(Libretro.core.libraryName, systemInfo.library_name);
+    TextCopy(Libretro.core.libraryVersion, systemInfo.library_version);
+    TextCopy(Libretro.core.validExtensions, systemInfo.valid_extensions);
+    Libretro.core.needFullpath = systemInfo.need_fullpath;
+    Libretro.core.blockExtract = systemInfo.block_extract;
     TraceLog(LOG_INFO, "LIBRETRO: Core loaded successfully");
-    TraceLog(LOG_INFO, "    > Name:         %s", LibretroCore.libraryName);
-    TraceLog(LOG_INFO, "    > Version:      %s", LibretroCore.libraryVersion);
-    if (TextLength(LibretroCore.validExtensions) > 0) {
-        TraceLog(LOG_INFO, "    > Extensions:   %s", LibretroCore.validExtensions);
+    TraceLog(LOG_INFO, "    > Name:         %s", Libretro.core.libraryName);
+    TraceLog(LOG_INFO, "    > Version:      %s", Libretro.core.libraryVersion);
+    if (TextLength(Libretro.core.validExtensions) > 0) {
+        TraceLog(LOG_INFO, "    > Extensions:   %s", Libretro.core.validExtensions);
     }
 
     if (peek) {
@@ -2669,21 +2668,21 @@ static bool InitLibretroEx(const char* core, bool peek) {
     LoadLibretroMethod(retro_get_memory_size);
 
     // Initialize the core.
-    TextCopy(LibretroCore.corePath, core);
-    LibretroCore.shutdown = false;
-    LibretroCore.volume = 1.0f;
-    LibretroCore.speed = 1.0f;
+    TextCopy(Libretro.core.corePath, core);
+    Libretro.core.shutdown = false;
+    Libretro.volume = 1.0f;
+    Libretro.speed = 1.0f;
 
     // Set up the callbacks.
-    LibretroCore.retro_set_video_refresh(LibretroVideoRefresh);
-    LibretroCore.retro_set_input_poll(LibretroInputPoll);
-    LibretroCore.retro_set_input_state(LibretroInputState);
-    LibretroCore.retro_set_audio_sample(UpdateLibretroAudioSample);
-    LibretroCore.retro_set_audio_sample_batch(UpdateLibretroAudioSampleBatch);
-    LibretroCore.retro_set_environment(CallLibretroEnvironment);
+    Libretro.core.retro_set_video_refresh(LibretroVideoRefresh);
+    Libretro.core.retro_set_input_poll(LibretroInputPoll);
+    Libretro.core.retro_set_input_state(LibretroInputState);
+    Libretro.core.retro_set_audio_sample(UpdateLibretroAudioSample);
+    Libretro.core.retro_set_audio_sample_batch(UpdateLibretroAudioSampleBatch);
+    Libretro.core.retro_set_environment(CallLibretroEnvironment);
 
     // Initialize the core.
-    LibretroCore.retro_init();
+    Libretro.core.retro_init();
     return true;
 }
 
@@ -2704,10 +2703,10 @@ static bool InitLibretro(const char* core) {
  * @param tint Color tint applied to the framebuffer texture.
  */
 static void DrawLibretroTexture(int posX, int posY, Color tint) {
-    if (LibretroCore.loaded == false) {
+    if (Libretro.core.loaded == false) {
         return;
     }
-    DrawTexture(LibretroCore.texture, posX, posY, tint);
+    DrawTexture(Libretro.core.texture, posX, posY, tint);
 }
 
 /**
@@ -2716,10 +2715,10 @@ static void DrawLibretroTexture(int posX, int posY, Color tint) {
  * @param tint Color tint applied to the framebuffer texture.
  */
 static void DrawLibretroV(Vector2 position, Color tint) {
-    if (LibretroCore.loaded == false) {
+    if (Libretro.core.loaded == false) {
         return;
     }
-    DrawTextureV(LibretroCore.texture, position, tint);
+    DrawTextureV(Libretro.core.texture, position, tint);
 }
 
 /**
@@ -2730,10 +2729,10 @@ static void DrawLibretroV(Vector2 position, Color tint) {
  * @param tint Color tint applied to the framebuffer texture.
  */
 static void DrawLibretroEx(Vector2 position, float rotation, float scale, Color tint) {
-    if (LibretroCore.loaded == false) {
+    if (Libretro.core.loaded == false) {
         return;
     }
-    DrawTextureEx(LibretroCore.texture, position, rotation, scale, tint);
+    DrawTextureEx(Libretro.core.texture, position, rotation, scale, tint);
 }
 
 /**
@@ -2742,12 +2741,12 @@ static void DrawLibretroEx(Vector2 position, float rotation, float scale, Color 
  * @param tint Color tint applied to the framebuffer texture.
  */
 static void DrawLibretroPro(Rectangle destRec, Color tint) {
-    if (LibretroCore.loaded == false) {
+    if (Libretro.core.loaded == false) {
         return;
     }
-    Rectangle source = {0, 0, LibretroCore.width, LibretroCore.height};
+    Rectangle source = {0, 0, Libretro.core.width, Libretro.core.height};
     Vector2 origin = {0, 0};
-    DrawTexturePro(LibretroCore.texture, source, destRec, origin, 0, tint);
+    DrawTexturePro(Libretro.core.texture, source, destRec, origin, 0, tint);
 }
 
 /**
@@ -2755,17 +2754,17 @@ static void DrawLibretroPro(Rectangle destRec, Color tint) {
  * @return true if a message was drawn; false if there was nothing to display.
  */
 static bool DrawLibretroMessage(void) {
-    if (GetTime() > LibretroCore.osdEndTime) {
+    if (GetTime() > Libretro.core.osdEndTime) {
         return false;
     }
 
     int fontSize = 20;
     int padding = 8;
-    int textWidth = MeasureText(LibretroCore.osdMessage, fontSize);
+    int textWidth = MeasureText(Libretro.core.osdMessage, fontSize);
     int x = (GetScreenWidth() - textWidth) / 2;
     int y = GetScreenHeight() - fontSize - padding * 2;
     DrawRectangle(x - padding, y - padding, textWidth + padding * 2, fontSize + padding * 2, (Color){0, 0, 0, 180});
-    DrawText(LibretroCore.osdMessage, x, y, fontSize, WHITE);
+    DrawText(Libretro.core.osdMessage, x, y, fontSize, WHITE);
     return true;
 }
 
@@ -2774,17 +2773,17 @@ static bool DrawLibretroMessage(void) {
  * @param tint Color tint applied to the framebuffer texture.
  */
 static void DrawLibretroTint(Color tint) {
-    if (LibretroCore.loaded == false) {
+    if (Libretro.core.loaded == false) {
         return;
     }
 
-    float rotationDeg = (float)LibretroCore.rotation * 90.0f;
-    bool swapDims = (LibretroCore.rotation == 1 || LibretroCore.rotation == 3);
+    float rotationDeg = (float)Libretro.core.rotation * 90.0f;
+    bool swapDims = (Libretro.core.rotation == 1 || Libretro.core.rotation == 3);
 
     // Find the aspect ratio.
-    float aspect = LibretroCore.aspectRatio;
+    float aspect = Libretro.core.aspectRatio;
     if (aspect <= 0) {
-        aspect = (float)LibretroCore.width / (float)LibretroCore.height;
+        aspect = (float)Libretro.core.width / (float)Libretro.core.height;
     }
 
     // When rotated 90/270, the visual bounding box has the inverted aspect ratio.
@@ -2806,10 +2805,10 @@ static void DrawLibretroTint(Color tint) {
     // Draw centered with rotation around the dest rect's center.
     float cx = GetScreenWidth() / 2.0f;
     float cy = GetScreenHeight() / 2.0f;
-    Rectangle source = {0, 0, LibretroCore.width, LibretroCore.height};
+    Rectangle source = {0, 0, Libretro.core.width, Libretro.core.height};
     Rectangle dest = {cx, cy, (float)destW, (float)destH};
     Vector2 origin = {destW / 2.0f, destH / 2.0f};
-    DrawTexturePro(LibretroCore.texture, source, dest, origin, rotationDeg, tint);
+    DrawTexturePro(Libretro.core.texture, source, dest, origin, rotationDeg, tint);
 }
 
 /**
@@ -2824,8 +2823,8 @@ static void DrawLibretro(void) {
  * @param msg      Message text to display.
  * @param duration How long to show the message, in seconds. */
 static void SetLibretroMessage(const char* msg, float duration) {
-    TextCopy(LibretroCore.osdMessage, msg);
-    LibretroCore.osdEndTime = GetTime() + (double)duration;
+    TextCopy(Libretro.core.osdMessage, msg);
+    Libretro.core.osdEndTime = GetTime() + (double)duration;
 }
 
 /**
@@ -2835,9 +2834,9 @@ static void SetLibretroMessage(const char* msg, float duration) {
 static void SetLibretroVolume(float volume) {
     if (volume < 0) volume = 0.0f;
     else if (volume > 1.0f) volume = 1.0f;
-    LibretroCore.volume = volume;
-    if (IsAudioStreamValid(LibretroCore.audioStream)) {
-        SetAudioStreamVolume(LibretroCore.audioStream, volume);
+    Libretro.volume = volume;
+    if (IsAudioStreamValid(Libretro.core.audioStream)) {
+        SetAudioStreamVolume(Libretro.core.audioStream, volume);
     }
 }
 
@@ -2845,7 +2844,7 @@ static void SetLibretroVolume(float volume) {
  * Get the current audio output volume.
  * @return Volume level in the range [0.0, 1.0]. */
 static float GetLibretroVolume(void) {
-    return LibretroCore.volume;
+    return Libretro.volume;
 }
 
 /**
@@ -2853,11 +2852,11 @@ static float GetLibretroVolume(void) {
  * @param speed Multiplier relative to normal speed (1.0 = normal, >1.0 = fast-forward, <1.0 = slow-motion). */
 static void SetLibretroSpeed(float speed) {
     if (speed <= 0.0f) speed = 0.1f;
-    LibretroCore.speed = speed;
+    Libretro.speed = speed;
     if (speed > 1.0f) {
         SetTargetFPS(0);
     } else {
-        SetTargetFPS((int)(LibretroCore.fps * speed));
+        SetTargetFPS((int)(Libretro.core.fps * speed));
     }
 }
 
@@ -2865,7 +2864,7 @@ static void SetLibretroSpeed(float speed) {
  * Get the current emulation playback speed multiplier.
  * @return Current speed multiplier. */
 static float GetLibretroSpeed(void) {
-    return LibretroCore.speed;
+    return Libretro.speed;
 }
 
 /**
@@ -2882,10 +2881,10 @@ static float GetLibretroSpeed(void) {
  * @param enabled true to enable DRC, false to disable and restore unity pitch.
  */
 static void SetLibretroDynamicRateControl(bool enabled) {
-    LibretroCore.drcEnabled = enabled;
-    if (!enabled && IsAudioStreamValid(LibretroCore.audioStream)) {
-        LibretroCore.drcAdjustment = 1.0f;
-        SetAudioStreamPitch(LibretroCore.audioStream, 1.0f);
+    Libretro.core.drcEnabled = enabled;
+    if (!enabled && IsAudioStreamValid(Libretro.core.audioStream)) {
+        Libretro.core.drcAdjustment = 1.0f;
+        SetAudioStreamPitch(Libretro.core.audioStream, 1.0f);
     }
 }
 
@@ -2895,7 +2894,7 @@ static void SetLibretroDynamicRateControl(bool enabled) {
  * @return true if DRC is enabled, false otherwise.
  */
 static bool IsLibretroDynamicRateControlEnabled(void) {
-    return LibretroCore.drcEnabled;
+    return Libretro.core.drcEnabled;
 }
 
 /**
@@ -2903,7 +2902,7 @@ static bool IsLibretroDynamicRateControlEnabled(void) {
  * @return Rotation index.
  */
 static unsigned GetLibretroRotation(void) {
-    return LibretroCore.rotation;
+    return Libretro.core.rotation;
 }
 
 /**
@@ -2911,7 +2910,7 @@ static unsigned GetLibretroRotation(void) {
  * @return Width in pixels
  */
 static unsigned GetLibretroWidth(void) {
-    return LibretroCore.width;
+    return Libretro.core.width;
 }
 
 /**
@@ -2919,15 +2918,15 @@ static unsigned GetLibretroWidth(void) {
  * @return Height in pixels.
  */
 static unsigned GetLibretroHeight(void) {
-    return LibretroCore.height;
+    return Libretro.core.height;
 }
 
 static double GetLibretroFPS(void) {
-    return LibretroCore.fps > 0 ? (double)LibretroCore.fps : 60.0;
+    return Libretro.core.fps > 0 ? (double)Libretro.core.fps : 60.0;
 }
 
 static float GetLibretroAspectRatio(void) {
-    return LibretroCore.aspectRatio;
+    return Libretro.core.aspectRatio;
 }
 
 /**
@@ -2935,7 +2934,7 @@ static float GetLibretroAspectRatio(void) {
  * @return Texture2D containing the last rendered frame.
  */
 static Texture2D GetLibretroTexture(void) {
-    return LibretroCore.texture;
+    return Libretro.core.texture;
 }
 
 /**
@@ -2943,7 +2942,7 @@ static Texture2D GetLibretroTexture(void) {
  * @return true if a game/content is currently loaded.
  */
 static bool IsLibretroGameReady(void) {
-    return LibretroCore.loaded && LibretroCore.retro_run != NULL;
+    return Libretro.core.loaded && Libretro.core.retro_run != NULL;
 }
 
 /**
@@ -2952,8 +2951,8 @@ static bool IsLibretroGameReady(void) {
  * @return true if the core reset callback was called.
  */
 static bool ResetLibretro(void) {
-    if (IsLibretroReady() && LibretroCore.retro_reset) {
-        LibretroCore.retro_reset();
+    if (IsLibretroReady() && Libretro.core.retro_reset) {
+        Libretro.core.retro_reset();
         return true;
     }
     return false;
@@ -2966,12 +2965,12 @@ static bool ResetLibretro(void) {
  */
 static void* GetLibretroSRAMData(size_t* size) {
     if (!IsLibretroGameReady()) return NULL;
-    if (LibretroCore.retro_get_memory_data == NULL || LibretroCore.retro_get_memory_size == NULL) return NULL;
+    if (Libretro.core.retro_get_memory_data == NULL || Libretro.core.retro_get_memory_size == NULL) return NULL;
 
-    size_t sramSize = LibretroCore.retro_get_memory_size(RETRO_MEMORY_SAVE_RAM);
+    size_t sramSize = Libretro.core.retro_get_memory_size(RETRO_MEMORY_SAVE_RAM);
     if (sramSize == 0) return NULL;
 
-    void* data = LibretroCore.retro_get_memory_data(RETRO_MEMORY_SAVE_RAM);
+    void* data = Libretro.core.retro_get_memory_data(RETRO_MEMORY_SAVE_RAM);
     if (data == NULL) return NULL;
 
     if (size != NULL) *size = sramSize;
@@ -3000,21 +2999,21 @@ static bool SetLibretroSRAMData(const void* data, size_t size) {
  * Unload the currently loaded content without closing the core.
  */
 static void UnloadLibretroGame(void) {
-    if (LibretroCore.retro_unload_game != NULL) {
-        LibretroCore.retro_unload_game();
-        LibretroCore.retro_unload_game = NULL;
+    if (Libretro.core.retro_unload_game != NULL) {
+        Libretro.core.retro_unload_game();
+        Libretro.core.retro_unload_game = NULL;
     }
-    LibretroCore.retro_run = NULL;
-    LibretroCore.loaded = false;
-    LibretroCore.contentPath[0] = '\0';
-    LibretroCore.gameInfoExtValid = false;
-    memset(&LibretroCore.gameInfoExt, 0, sizeof(LibretroCore.gameInfoExt));
+    Libretro.core.retro_run = NULL;
+    Libretro.core.loaded = false;
+    Libretro.core.contentPath[0] = '\0';
+    Libretro.core.gameInfoExtValid = false;
+    memset(&Libretro.core.gameInfoExt, 0, sizeof(Libretro.core.gameInfoExt));
 
     // Release the persistent ROM buffer kept alive for persistent_data=true.
-    if (LibretroCore.persistentGameData != NULL) {
-        UnloadFileData(LibretroCore.persistentGameData);
-        LibretroCore.persistentGameData = NULL;
-        LibretroCore.persistentGameDataSize = 0;
+    if (Libretro.core.persistentGameData != NULL) {
+        UnloadFileData(Libretro.core.persistentGameData);
+        Libretro.core.persistentGameData = NULL;
+        Libretro.core.persistentGameDataSize = 0;
     }
 
     // Free memory map descriptors — these are game-specific and must not
@@ -3028,36 +3027,36 @@ static void UnloadLibretroGame(void) {
  */
 static void ResetLibretroCoreState(void) {
     // Core Variables
-    memset(LibretroCore.variableKeys,        0, sizeof(LibretroCore.variableKeys));
-    memset(LibretroCore.variableValues,      0, sizeof(LibretroCore.variableValues));
-    memset(LibretroCore.variableLabels,      0, sizeof(LibretroCore.variableLabels));
-    memset(LibretroCore.variableValuesList,  0, sizeof(LibretroCore.variableValuesList));
-    memset(LibretroCore.variableDisplayList, 0, sizeof(LibretroCore.variableDisplayList));
-    memset(LibretroCore.variableTooltips,    0, sizeof(LibretroCore.variableTooltips));
-    memset(LibretroCore.variableVisible,     0, sizeof(LibretroCore.variableVisible));
-    LibretroCore.variableCount          = 0;
-    LibretroCore.variableOptionsVersion = 0;
-    LibretroCore.variablesDirty         = false;
-    LibretroCore.variablesVisibilityDirty = false;
+    memset(Libretro.core.variableKeys,        0, sizeof(Libretro.core.variableKeys));
+    memset(Libretro.core.variableValues,      0, sizeof(Libretro.core.variableValues));
+    memset(Libretro.core.variableLabels,      0, sizeof(Libretro.core.variableLabels));
+    memset(Libretro.core.variableValuesList,  0, sizeof(Libretro.core.variableValuesList));
+    memset(Libretro.core.variableDisplayList, 0, sizeof(Libretro.core.variableDisplayList));
+    memset(Libretro.core.variableTooltips,    0, sizeof(Libretro.core.variableTooltips));
+    memset(Libretro.core.variableVisible,     0, sizeof(Libretro.core.variableVisible));
+    Libretro.core.variableCount          = 0;
+    Libretro.core.variableOptionsVersion = 0;
+    Libretro.core.variablesDirty         = false;
+    Libretro.core.variablesVisibilityDirty = false;
 
     // Audio & Video
-    LibretroCore.rotation    = 0;
-    LibretroCore.width       = 0;
-    LibretroCore.height      = 0;
-    LibretroCore.fps         = 0;
-    LibretroCore.sampleRate  = 0.0;
-    LibretroCore.aspectRatio = 0.0f;
-    LibretroCore.minimumAudioLatencyMs = 0;
-    memset(&LibretroCore.audio_buffer_status_callback, 0, sizeof(LibretroCore.audio_buffer_status_callback));
+    Libretro.core.rotation    = 0;
+    Libretro.core.width       = 0;
+    Libretro.core.height      = 0;
+    Libretro.core.fps         = 0;
+    Libretro.core.sampleRate  = 0.0;
+    Libretro.core.aspectRatio = 0.0f;
+    Libretro.core.minimumAudioLatencyMs = 0;
+    memset(&Libretro.core.audio_buffer_status_callback, 0, sizeof(Libretro.core.audio_buffer_status_callback));
 
     // VFS
-    memset(&LibretroCore.vfs_interface, 0, sizeof(LibretroCore.vfs_interface));
+    memset(&Libretro.core.vfs_interface, 0, sizeof(Libretro.core.vfs_interface));
 
     // Content Information
-    memset(LibretroCore.contentInfoOverrideExts,        0, sizeof(LibretroCore.contentInfoOverrideExts));
-    memset(LibretroCore.contentInfoOverrideNeedFullpath, 0, sizeof(LibretroCore.contentInfoOverrideNeedFullpath));
-    memset(LibretroCore.contentInfoOverridePersistent,   0, sizeof(LibretroCore.contentInfoOverridePersistent));
-    LibretroCore.contentInfoOverrideCount = 0;
+    memset(Libretro.core.contentInfoOverrideExts,        0, sizeof(Libretro.core.contentInfoOverrideExts));
+    memset(Libretro.core.contentInfoOverrideNeedFullpath, 0, sizeof(Libretro.core.contentInfoOverrideNeedFullpath));
+    memset(Libretro.core.contentInfoOverridePersistent,   0, sizeof(Libretro.core.contentInfoOverridePersistent));
+    Libretro.core.contentInfoOverrideCount = 0;
 
     // Runtime flags that should not survive a core close. shutdown is the
     // RETRO_ENVIRONMENT_SHUTDOWN request from the previous core; loaded is
@@ -3070,28 +3069,28 @@ static void ResetLibretroCoreState(void) {
     // and then calls CloseLibretro() before returning; the caller
     // (ScanLibretroCoreDirectory) reads them off the global afterwards. They
     // get re-freshened at the start of the next InitLibretroEx.
-    LibretroCore.loaded   = false;
-    LibretroCore.shutdown = false;
+    Libretro.core.loaded   = false;
+    Libretro.core.shutdown = false;
 
     // Performance Counter
-    LibretroCore.perf_counter_last = NULL;
+    Libretro.core.perf_counter_last = NULL;
 
-    LibretroCore.speed = 1.0f;
-    memset(LibretroCore.rumbleStrong, 0, sizeof(LibretroCore.rumbleStrong));
-    memset(LibretroCore.rumbleWeak,   0, sizeof(LibretroCore.rumbleWeak));
+    Libretro.speed = 1.0f;
+    memset(Libretro.core.rumbleStrong, 0, sizeof(Libretro.core.rumbleStrong));
+    memset(Libretro.core.rumbleWeak,   0, sizeof(Libretro.core.rumbleWeak));
 
     // Per-session counters / accumulators.
-    LibretroCore.gameTimeNSEC      = 0;
-    LibretroCore.singleSampleCount = 0;
-    LibretroCore.audioDropWarnCount = 0;
+    Libretro.core.gameTimeNSEC      = 0;
+    Libretro.core.singleSampleCount = 0;
+    Libretro.core.audioDropWarnCount = 0;
 
     // On-Screen Message
-    memset(LibretroCore.osdMessage, 0, sizeof(LibretroCore.osdMessage));
-    LibretroCore.osdEndTime = 0.0;
+    memset(Libretro.core.osdMessage, 0, sizeof(Libretro.core.osdMessage));
+    Libretro.core.osdEndTime = 0.0;
 
     // Dynamic Rate Control
-    LibretroCore.drcAdjustment = 1.0f;
-    LibretroCore.drcEnabled = true;
+    Libretro.core.drcAdjustment = 1.0f;
+    Libretro.core.drcEnabled = true;
 
     UnloadLibretroMemoryMaps();
 }
@@ -3106,44 +3105,44 @@ static void CloseLibretro(void) {
     }
 
     // Let the core know that the audio device has been deinitialized.
-    if (LibretroCore.audio_callback.set_state != NULL) {
-        LibretroCore.audio_callback.set_state(false);
-        memset(&LibretroCore.audio_callback, 0, sizeof(LibretroCore.audio_callback));
+    if (Libretro.core.audio_callback.set_state != NULL) {
+        Libretro.core.audio_callback.set_state(false);
+        memset(&Libretro.core.audio_callback, 0, sizeof(Libretro.core.audio_callback));
     }
 
     // Drop any callbacks the core registered into its own .text — dylib_close()
     // below invalidates those addresses, and a follow-up InitLibretro() with a
     // different core that doesn't re-register them would call freed memory.
-    LibretroCore.keyboard_event = NULL;
-    LibretroCore.options_update_display_callback = NULL;
-    memset(&LibretroCore.runloop_frame_time, 0, sizeof(LibretroCore.runloop_frame_time));
-    LibretroCore.runloop_frame_time_last = 0;
+    Libretro.core.keyboard_event = NULL;
+    Libretro.core.options_update_display_callback = NULL;
+    memset(&Libretro.core.runloop_frame_time, 0, sizeof(Libretro.core.runloop_frame_time));
+    Libretro.core.runloop_frame_time_last = 0;
 
     // Call retro_deinit() to deinitialize the core.
-    if (LibretroCore.retro_deinit != NULL) {
-        LibretroCore.retro_deinit();
-        LibretroCore.retro_deinit = NULL;
+    if (Libretro.core.retro_deinit != NULL) {
+        Libretro.core.retro_deinit();
+        Libretro.core.retro_deinit = NULL;
     }
 
     CloseLibretroAudio();
     CloseLibretroVideo();
 
-    if (LibretroCore.inputDescriptors != NULL) {
-        MemFree(LibretroCore.inputDescriptors);
-        LibretroCore.inputDescriptors = NULL;
-        LibretroCore.inputDescriptorCount = 0;
+    if (Libretro.core.inputDescriptors != NULL) {
+        MemFree(Libretro.core.inputDescriptors);
+        Libretro.core.inputDescriptors = NULL;
+        Libretro.core.inputDescriptorCount = 0;
     }
 
-    if (LibretroCore.controllerInfo != NULL) {
-        MemFree(LibretroCore.controllerInfo);
-        LibretroCore.controllerInfo = NULL;
-        LibretroCore.controllerPortCount = 0;
+    if (Libretro.core.controllerInfo != NULL) {
+        MemFree(Libretro.core.controllerInfo);
+        Libretro.core.controllerInfo = NULL;
+        Libretro.core.controllerPortCount = 0;
     }
 
     // Close the dynamically loaded handle.
-    if (LibretroCore.handle != NULL) {
-        dylib_close(LibretroCore.handle);
-        LibretroCore.handle = NULL;
+    if (Libretro.core.handle != NULL) {
+        dylib_close(Libretro.core.handle);
+        Libretro.core.handle = NULL;
     }
 
     ResetLibretroCoreState();
@@ -3595,11 +3594,11 @@ static void* GetLibretroSerializedData(unsigned int* size) {
         return NULL;
     }
 
-    if (LibretroCore.retro_serialize_size == NULL || LibretroCore.retro_serialize == NULL) {
+    if (Libretro.core.retro_serialize_size == NULL || Libretro.core.retro_serialize == NULL) {
         return NULL;
     }
 
-    size_t finalSize = LibretroCore.retro_serialize_size();
+    size_t finalSize = Libretro.core.retro_serialize_size();
     if (finalSize == 0) {
         return NULL;
     }
@@ -3612,7 +3611,7 @@ static void* GetLibretroSerializedData(unsigned int* size) {
         return NULL;
     }
 
-    if (LibretroCore.retro_serialize(saveData, finalSize)) {
+    if (Libretro.core.retro_serialize(saveData, finalSize)) {
         return saveData;
     }
     TraceLog(LOG_ERROR, "LIBRETRO: Failed to get retro_serialize");
@@ -3630,11 +3629,11 @@ static bool SetLibretroSerializedData(void* data, unsigned int size) {
         return false;
     }
 
-    if (LibretroCore.retro_unserialize == NULL) {
+    if (Libretro.core.retro_unserialize == NULL) {
         return false;
     }
 
-    return LibretroCore.retro_unserialize(data, (size_t)size);
+    return Libretro.core.retro_unserialize(data, (size_t)size);
 }
 
 #endif

--- a/lib/raylib-libretro-static.c
+++ b/lib/raylib-libretro-static.c
@@ -11,7 +11,7 @@
 *
 *   LICENSE: zlib/libpng
 *
-*   rLibretro is licensed under an unmodified zlib/libpng license, which is an OSI-certified,
+*   LibretroData is licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software:
 *
 *   Copyright (c) 2020 Rob Loach (@RobLoach)


### PR DESCRIPTION
Splits the monolithic `rLibretro`/`LibretroCore` global into two structs: `rLibretro` (persistent settings like directories, volume, speed) and `rLibretroCore` (`Libretro.core`) for per-load state that can be reset with `memset(0)`.

Fixes #175