### PR TITLE
Replace LibretroTouchFadeColor with raylib's ColorTint + Fade

### DIFF
--- a/include/raylib-libretro-touch.h
+++ b/include/raylib-libretro-touch.h
@@ -266,11 +266,6 @@ static Vector2 LibretroTouchDpadLockedPos = {0};
 static double LibretroTouchLastActiveTime = -1.0;  // -1 = never touched
 static float  LibretroTouchAlpha = 1.0f;
 
-static Color LibretroTouchFadeColor(Color c, float a) {
-    c.a = (unsigned char)(c.a * a);
-    return c;
-}
-
 /**
  * If available, will vibrate the device from using the on-screen controls.
  */
@@ -434,6 +429,7 @@ void DrawLibretroTouchControls(void) {
         LibretroTouchAlpha = Lerp(LibretroTouchAlpha, target, GetFrameTime() * 4.0f);
     }
     float alpha = LibretroTouchAlpha;
+    Color fadeTint = Fade(WHITE, alpha);
 
     // D-pad: filled circle with 8 directional arrow indicators.
     // Arrows are drawn with tip pointing outward; a triangle whose base sits at
@@ -455,7 +451,7 @@ void DrawLibretroTouchControls(void) {
         Vector2 dc; float dr;
         LibretroTouchDpadInfo(&dc, &dr);
 
-        DrawCircleV(dc, dr, LibretroTouchFadeColor((Color){ 40, 40, 40, 160 }, alpha));
+        DrawCircleV(dc, dr, ColorTint((Color){ 40, 40, 40, 160 }, fadeTint));
 
         float arrowDist = dr * 0.60f;
         float arrowSize = dr * 0.22f;
@@ -463,8 +459,8 @@ void DrawLibretroTouchControls(void) {
         for (int d = 0; d < 8; d++) {
             bool b1 = LIBRETRO.core.virtualJoypadState[dirs[d].b1] || LibretroTouchIsPhysicalButtonDown(dirs[d].b1);
             bool b2 = (dirs[d].b2 < 0) || LIBRETRO.core.virtualJoypadState[dirs[d].b2] || LibretroTouchIsPhysicalButtonDown(dirs[d].b2);
-            Color arrowColor = LibretroTouchFadeColor(
-                (b1 && b2) ? (Color){ 255, 255, 255, 230 } : (Color){ 180, 180, 180, 100 }, alpha);
+            Color arrowColor = ColorTint(
+                (b1 && b2) ? (Color){ 255, 255, 255, 230 } : (Color){ 180, 180, 180, 100 }, fadeTint);
             float ca = cosf(dirs[d].angle), sa = sinf(dirs[d].angle);
             Vector2 tip = { dc.x + ca*(arrowDist + arrowSize), dc.y + sa*(arrowDist + arrowSize) };
             Vector2 rb  = { dc.x + ca*arrowDist + sa*arrowSize, dc.y + sa*arrowDist - ca*arrowSize };
@@ -472,7 +468,7 @@ void DrawLibretroTouchControls(void) {
             DrawTriangle(tip, rb, lb, arrowColor);
         }
 
-        DrawCircleV(dc, dr * 0.18f, LibretroTouchFadeColor((Color){ 60, 60, 60, 200 }, alpha));
+        DrawCircleV(dc, dr * 0.18f, ColorTint((Color){ 60, 60, 60, 200 }, fadeTint));
 
         // Direction indicator: a dot on the inner edge showing where the locked
         // press is pointing. Hidden when in the dead zone or not locked.
@@ -484,7 +480,7 @@ void DrawLibretroTouchControls(void) {
                 Vector2 dir = { ddx / dist, ddy / dist };
                 Vector2 indicatorPos = { dc.x + dir.x * dr * 0.82f, dc.y + dir.y * dr * 0.82f };
                 DrawCircleV(indicatorPos, dr * 0.12f,
-                    LibretroTouchFadeColor((Color){ 255, 255, 255, 220 }, alpha));
+                    ColorTint((Color){ 255, 255, 255, 220 }, fadeTint));
             }
         }
     }
@@ -507,7 +503,7 @@ void DrawLibretroTouchControls(void) {
         } else {
             DrawRectangleRounded(btns[i].rect, 0.5f, 6, c);
         }
-        Color textColor = LibretroTouchFadeColor(WHITE, alpha);
+        Color textColor = fadeTint;
         if (isMenuLike) textColor.a = (unsigned char)(180 * alpha);
         Font font = GetLibretroTouchFont();
         float fs = btns[i].rect.height * 0.4f;
@@ -527,8 +523,8 @@ void DrawLibretroTouchControls(void) {
     if (IsMouseButtonDown(MOUSE_BUTTON_LEFT) && CheckCollisionPointRec(GetMousePosition(), guide)) {
         hovered = true;
     }
-    Color gc = hovered ? LibretroTouchFadeColor(GRAY, alpha)
-                       : LibretroTouchFadeColor((Color){80, 80, 80, 160}, alpha);
+    Color gc = hovered ? ColorTint(GRAY, fadeTint)
+                       : ColorTint((Color){80, 80, 80, 160}, fadeTint);
     DrawRectangleRounded(guide, 0.3f, 4, gc);
 
     float barW = guide.width  * 0.50f;
@@ -539,7 +535,7 @@ void DrawLibretroTouchControls(void) {
     float bx   = gcx - barW * 0.5f;
     for (int row = -1; row <= 1; row++) {
         Rectangle bar = { bx, gcy + row * gap - barH * 0.5f, barW, barH };
-        DrawRectangleRounded(bar, 1.0f, 4, LibretroTouchFadeColor(WHITE, alpha));
+        DrawRectangleRounded(bar, 1.0f, 4, fadeTint);
     }
 }
 


### PR DESCRIPTION
Computes a fade tint once per frame via `Fade(WHITE, alpha)` and applies it to each touch-control color with `ColorTint`, removing the bespoke `LibretroTouchFadeColor` helper. Fixes #176