### PR TITLE
Replace InitLibretroEx peek boolean with dedicated PeekLibretroCoreInfo

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -72,8 +72,11 @@ int main(int argc, char* argv[]) {
 #### `bool InitLibretro(const char* core)`
 Load a libretro core from the given shared library path (`.so`, `.dll`, or `.dylib`). Returns `true` on success. Must be called before any other API function.
 
-#### `bool InitLibretroEx(const char* core, bool peek)`
-Like `InitLibretro()`, but when `peek` is `true` the core is inspected for metadata without fully initialising it.
+#### `bool InitLibretroEx(const char* core)`
+Same as `InitLibretro()`. Exposed separately so future variants can extend initialization without breaking the simpler entry point.
+
+#### `bool PeekLibretroCoreInfo(const char* core)`
+Open the core's dylib and populate identity fields (`libraryName`, `libraryVersion`, `validExtensions`, `needFullpath`, `blockExtract`) via `retro_get_system_info`, without performing a full init. The dylib is left open so the caller can read fields off `LIBRETRO.core`; the caller is responsible for calling `CloseLibretro()` to release it.
 
 #### `bool LoadLibretroGame(const char* gameFile)`
 Load content (ROM, disk image, etc.) from `gameFile`. Pass `NULL` for cores that do not require content. Returns `true` on success.

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -444,7 +444,7 @@ static void ScanLibretroCoreDirectory(void) {
     int coreIndex = 0;
     for (unsigned int i = 0; i < files.count; i++) {
         if (!IsLibretroCoreFile(files.paths[i])) continue;
-        if (!InitLibretroEx(files.paths[i], true)) continue;
+        if (!PeekLibretroCoreInfo(files.paths[i])) continue;
         if (TextLength(LIBRETRO.core.validExtensions) == 0) {
             CloseLibretro();
             continue;

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -51,7 +51,8 @@ extern "C" {
 //------------------------------------------------------------------------------------
 
 static bool InitLibretro(const char* core);
-static bool InitLibretroEx(const char* core, bool peek);
+static bool InitLibretroEx(const char* core);
+static bool PeekLibretroCoreInfo(const char* core);
 static bool LoadLibretroGame(const char* gameFile);
 static bool IsLibretroReady(void);
 static bool IsLibretroGameReady(void);
@@ -2573,12 +2574,17 @@ static bool IsLibretroGameRequired(void) {
 }
 
 /**
- * Load a libretro core, optionally in peek mode (metadata only, no full init).
+ * Load a libretro core's dylib and populate its identity fields
+ * (libraryName, libraryVersion, validExtensions, needFullpath, blockExtract)
+ * via retro_get_system_info, without performing a full init.
+ *
+ * The dylib is left open so the caller can read identity fields off
+ * LIBRETRO.core. The caller is responsible for calling CloseLibretro().
+ *
  * @param core Path to the core shared library.
- * @param peek When true, only system info is queried; the core is not fully initialized.
  * @return true on success.
  */
-static bool InitLibretroEx(const char* core, bool peek) {
+static bool PeekLibretroCoreInfo(const char* core) {
     // Avoid initializing twice.
     if (IsLibretroReady()) {
         TraceLog(LOG_INFO, "LIBRETRO: Core already loaded, use CloseLibretro()");
@@ -2623,11 +2629,17 @@ static bool InitLibretroEx(const char* core, bool peek) {
     if (TextLength(LIBRETRO.core.validExtensions) > 0) {
         TraceLog(LOG_INFO, "    > Extensions:   %s", LIBRETRO.core.validExtensions);
     }
+    return true;
+}
 
-    if (peek) {
-        // Leave the dylib open so the caller can read identity fields off
-        // LIBRETRO.core. The caller is responsible for CloseLibretro().
-        return true;
+/**
+ * Load a libretro core and fully initialize it for playback.
+ * @param core Path to the core shared library.
+ * @return true on success.
+ */
+static bool InitLibretroEx(const char* core) {
+    if (!PeekLibretroCoreInfo(core)) {
+        return false;
     }
 
     // Load all other libretro methods.
@@ -2677,7 +2689,7 @@ static bool InitLibretroEx(const char* core, bool peek) {
  * @note Call InitAudioDevice() and InitWindow() before this function.
  */
 static bool InitLibretro(const char* core) {
-    return InitLibretroEx(core, false);
+    return InitLibretroEx(core);
 }
 
 /**

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -51,7 +51,6 @@ extern "C" {
 //------------------------------------------------------------------------------------
 
 static bool InitLibretro(const char* core);
-static bool InitLibretroEx(const char* core);
 static bool PeekLibretroCoreInfo(const char* core);
 static bool LoadLibretroGame(const char* gameFile);
 static bool IsLibretroReady(void);
@@ -2633,11 +2632,12 @@ static bool PeekLibretroCoreInfo(const char* core) {
 }
 
 /**
- * Load a libretro core and fully initialize it for playback.
- * @param core Path to the core shared library.
- * @return true on success.
+ * Load a libretro core shared library and initialize it.
+ * @param core Path to the core .so/.dll/.dylib file.
+ * @return true on success, false if the library could not be loaded or initialized.
+ * @note Call InitAudioDevice() and InitWindow() before this function.
  */
-static bool InitLibretroEx(const char* core) {
+static bool InitLibretro(const char* core) {
     if (!PeekLibretroCoreInfo(core)) {
         return false;
     }
@@ -2680,16 +2680,6 @@ static bool InitLibretroEx(const char* core) {
     // Initialize the core.
     LIBRETRO.core.retro_init();
     return true;
-}
-
-/**
- * Load a libretro core shared library and initialize it.
- * @param core Path to the core .so/.dll/.dylib file.
- * @return true on success, false if the library could not be loaded or initialized.
- * @note Call InitAudioDevice() and InitWindow() before this function.
- */
-static bool InitLibretro(const char* core) {
-    return InitLibretroEx(core);
 }
 
 /**


### PR DESCRIPTION
Splits the dylib-load-then-read-system-info portion of `InitLibretroEx` into a new `PeekLibretroCoreInfo(core)` helper, drops the `peek` boolean from `InitLibretroEx(core)`, and updates the menu's core-scan call site to use the new helper. Fixes #183