### PR TITLE
Preserve mute state across core swaps

### DIFF
--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -569,7 +569,6 @@ static bool MenuInitCore(const char* corePath) {
     LibretroApplyDirectories();
     if (!InitLibretro(corePath)) return false;
     LoadLibretroCoreOptions();
-    SetLibretroVolume(menu.volumeSelected);
     return true;
 }
 


### PR DESCRIPTION
Removes the redundant `SetLibretroVolume(menu.volumeSelected)` call in `MenuInitCore` that fired after loading each new core. After #180 the volume already persists in `LIBRETRO.volume` across core loads, and `menu.volumeSelected` doesn't track the muted state — so re-applying it unmuted the audio every time a different core was loaded. Fixes #186