### PR TITLE
Mute audio during fast-forward/slow-motion

### DIFF
--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -2862,6 +2862,10 @@ static void SetLibretroSpeed(float speed) {
     } else {
         SetTargetFPS((int)(LIBRETRO.core.fps * speed));
     }
+    if (IsAudioStreamValid(LIBRETRO.core.audioStream)) {
+        float streamVolume = (speed == 1.0f) ? LIBRETRO.volume : 0.0f;
+        SetAudioStreamVolume(LIBRETRO.core.audioStream, streamVolume);
+    }
 }
 
 /**


### PR DESCRIPTION
Mutes the audio stream whenever the emulation speed deviates from 1.0× (fast-forward, slow-motion, or rewind), and restores it when returning to normal speed. Fixes #195