### PR TITLE
Add Analog to D-Pad gameplay setting

### DIFF
--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -77,7 +77,6 @@ typedef struct LibretroMenu {
     int themeSelectedIndex;
     float volumeSelected;
     bool rewindEnabled;
-    int analogToDpadIndex;
     nk_rune keyScreenshot;
     nk_rune keyRewind;
     nk_rune keyMenu;
@@ -677,7 +676,6 @@ static void MenuCommitSettings(nk_console* widget, void* user_data) {
     NK_UNUSED(widget);
     NK_UNUSED(user_data);
     LibretroMenuApplyKeyboardPlayer1();
-    LIBRETRO.analogToDpadIndex = menu.analogToDpadIndex;
     SaveLibretroAllSettings();
 }
 
@@ -1267,7 +1265,7 @@ LibretroMenu* InitLibretroMenu(void) {
             #endif
             nk_console_checkbox(gameplayMenu, "Rewind", &menu.rewindEnabled);
             nk_console* analogCombo = nk_console_combobox(gameplayMenu, "Analog to D-Pad",
-                "None|Left Analog|Right Analog", '|', &menu.analogToDpadIndex);
+                "None|Left Analog|Right Analog", '|', &LIBRETRO.analogToDpadIndex);
             analogCombo->tooltip = "Map an analog stick to D-Pad inputs";
             nk_console_combobox(gameplayMenu, "Save Slot",
                 "Slot 1|Slot 2|Slot 3|Slot 4|Slot 5|Slot 6|Slot 7|Slot 8|Slot 9|Slot 10",
@@ -1528,7 +1526,7 @@ static void LibretroMenuUpdateConfig(void) {
     rlconfig_set_int(menu.cfg, "raylib-libretro", "theme", menu.themeSelectedIndex);
     rlconfig_set_float(menu.cfg, "raylib-libretro", "volume", menu.volumeSelected);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "rewind", menu.rewindEnabled ? 1 : 0);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "analogToDpad", menu.analogToDpadIndex);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "analogToDpad", LIBRETRO.analogToDpadIndex);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "touchControls", menu.touchControls ? 1 : 0);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "touchHaptics", menu.touchHapticsEnabled ? 1 : 0);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "keyScreenshot", (int)menu.keyScreenshot);
@@ -1685,9 +1683,8 @@ static bool LoadLibretroMenuSettings(void) {
     SetLibretroVolume(menu.volumeSelected);
 
     menu.rewindEnabled = rlconfig_get_int(menu.cfg, "raylib-libretro", "rewind", 0) > 0;
-    menu.analogToDpadIndex = rlconfig_get_int(menu.cfg, "raylib-libretro", "analogToDpad", 0);
-    if (menu.analogToDpadIndex < 0 || menu.analogToDpadIndex > 2) menu.analogToDpadIndex = 0;
-    LIBRETRO.analogToDpadIndex = menu.analogToDpadIndex;
+    LIBRETRO.analogToDpadIndex = rlconfig_get_int(menu.cfg, "raylib-libretro", "analogToDpad", 0);
+    if (LIBRETRO.analogToDpadIndex < 0 || LIBRETRO.analogToDpadIndex > 2) LIBRETRO.analogToDpadIndex = 0;
 #if defined(PLATFORM_WEB)
     menu.touchControls = rlconfig_get_int(menu.cfg, "raylib-libretro", "touchControls", 1) > 0;
 #else

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -77,6 +77,7 @@ typedef struct LibretroMenu {
     int themeSelectedIndex;
     float volumeSelected;
     bool rewindEnabled;
+    int analogToDpadIndex;
     nk_rune keyScreenshot;
     nk_rune keyRewind;
     nk_rune keyMenu;
@@ -676,6 +677,7 @@ static void MenuCommitSettings(nk_console* widget, void* user_data) {
     NK_UNUSED(widget);
     NK_UNUSED(user_data);
     LibretroMenuApplyKeyboardPlayer1();
+    LIBRETRO.analogToDpadIndex = menu.analogToDpadIndex;
     SaveLibretroAllSettings();
 }
 
@@ -1264,6 +1266,9 @@ LibretroMenu* InitLibretroMenu(void) {
             nk_console_checkbox(gameplayMenu, "Touch Haptics", &menu.touchHapticsEnabled);
             #endif
             nk_console_checkbox(gameplayMenu, "Rewind", &menu.rewindEnabled);
+            nk_console* analogCombo = nk_console_combobox(gameplayMenu, "Analog to D-Pad",
+                "None|Left Analog|Right Analog", '|', &menu.analogToDpadIndex);
+            analogCombo->tooltip = "Map an analog stick to D-Pad inputs";
             nk_console_combobox(gameplayMenu, "Save Slot",
                 "Slot 1|Slot 2|Slot 3|Slot 4|Slot 5|Slot 6|Slot 7|Slot 8|Slot 9|Slot 10",
                 '|', &menu.saveSlotIndex);
@@ -1523,6 +1528,7 @@ static void LibretroMenuUpdateConfig(void) {
     rlconfig_set_int(menu.cfg, "raylib-libretro", "theme", menu.themeSelectedIndex);
     rlconfig_set_float(menu.cfg, "raylib-libretro", "volume", menu.volumeSelected);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "rewind", menu.rewindEnabled ? 1 : 0);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "analogToDpad", menu.analogToDpadIndex);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "touchControls", menu.touchControls ? 1 : 0);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "touchHaptics", menu.touchHapticsEnabled ? 1 : 0);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "keyScreenshot", (int)menu.keyScreenshot);
@@ -1679,6 +1685,9 @@ static bool LoadLibretroMenuSettings(void) {
     SetLibretroVolume(menu.volumeSelected);
 
     menu.rewindEnabled = rlconfig_get_int(menu.cfg, "raylib-libretro", "rewind", 0) > 0;
+    menu.analogToDpadIndex = rlconfig_get_int(menu.cfg, "raylib-libretro", "analogToDpad", 0);
+    if (menu.analogToDpadIndex < 0 || menu.analogToDpadIndex > 2) menu.analogToDpadIndex = 0;
+    LIBRETRO.analogToDpadIndex = menu.analogToDpadIndex;
 #if defined(PLATFORM_WEB)
     menu.touchControls = rlconfig_get_int(menu.cfg, "raylib-libretro", "touchControls", 1) > 0;
 #else

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -119,6 +119,7 @@ static void LibretroMapPixelFormatARGB8888ToRGBA8888(void *output_, const void *
 static int LibretroRetroPixelFormatToPixelFormat(int pixelFormat);
 static int LibretroRetroJoypadButtonToGamepadButton(int button);
 static int LibretroRetroJoypadButtontoRetroKey(int button);
+static bool LibretroAnalogToDpadPressed(int port, int btn);
 static int LibretroRetroKeyToKeyboardKey(int key);
 static int LibretroMapRetroLogLevelToTraceLogType(int level);
 
@@ -344,6 +345,7 @@ typedef struct LibretroData {
     float speed;
     double speedAccumulator;
     int textureFilter; // TextureFilter
+    int analogToDpadIndex; // 0=None, 1=Left Analog, 2=Right Analog
     int keyboardPlayer1[16];
     char coreDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char saveDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
@@ -2120,6 +2122,7 @@ static int16_t LibretroInputState(unsigned port, unsigned device, unsigned index
                     } else if (gpAvail) {
                         pressed = IsGamepadButtonDown((int)port, LibretroRetroJoypadButtonToGamepadButton(btn));
                     }
+                    if (!pressed) pressed = LibretroAnalogToDpadPressed((int)port, btn);
                     if (pressed) mask |= (1 << btn);
                 }
                 return mask;
@@ -2142,18 +2145,20 @@ static int16_t LibretroInputState(unsigned port, unsigned device, unsigned index
                 }
                 int retroKey = LibretroRetroJoypadButtontoRetroKey(id);
                 if (retroKey == RETROK_UNKNOWN) {
-                    return 0;
+                    return LibretroAnalogToDpadPressed(0, id) ? 1 : 0;
                 }
                 int raylibKey = LibretroRetroKeyToKeyboardKey(retroKey);
-                return (raylibKey > 0) ? (int)IsKeyDown(raylibKey) : 0;
+                if (raylibKey > 0 && IsKeyDown(raylibKey)) return 1;
+                return LibretroAnalogToDpadPressed(0, id) ? 1 : 0;
             }
 
             // Port 1+: map to gamepad (port 1 → gamepad 1, port 2 → gamepad 2, ...).
             if (!IsGamepadAvailable(port)) {
-                return 0;
+                return LibretroAnalogToDpadPressed((int)port, id) ? 1 : 0;
             }
             int gamepadButton = LibretroRetroJoypadButtonToGamepadButton(id);
-            return (int)IsGamepadButtonDown(port, gamepadButton);
+            if (IsGamepadButtonDown(port, gamepadButton)) return 1;
+            return LibretroAnalogToDpadPressed((int)port, id) ? 1 : 0;
         }
 
         case RETRO_DEVICE_MOUSE: {
@@ -3780,6 +3785,21 @@ static int LibretroRetroJoypadButtonToGamepadButton(int button) {
     }
 
     return GAMEPAD_BUTTON_UNKNOWN;
+}
+
+static bool LibretroAnalogToDpadPressed(int port, int btn) {
+    if (LIBRETRO.analogToDpadIndex == 0 || !IsGamepadAvailable(port)) return false;
+    float axisX = GetGamepadAxisMovement(port,
+        LIBRETRO.analogToDpadIndex == 2 ? GAMEPAD_AXIS_RIGHT_X : GAMEPAD_AXIS_LEFT_X);
+    float axisY = GetGamepadAxisMovement(port,
+        LIBRETRO.analogToDpadIndex == 2 ? GAMEPAD_AXIS_RIGHT_Y : GAMEPAD_AXIS_LEFT_Y);
+    switch (btn) {
+        case RETRO_DEVICE_ID_JOYPAD_UP:    return axisY < -0.5f;
+        case RETRO_DEVICE_ID_JOYPAD_DOWN:  return axisY >  0.5f;
+        case RETRO_DEVICE_ID_JOYPAD_LEFT:  return axisX < -0.5f;
+        case RETRO_DEVICE_ID_JOYPAD_RIGHT: return axisX >  0.5f;
+        default: return false;
+    }
 }
 
 /**


### PR DESCRIPTION
Adds an Analog to D-Pad combobox (None / Left Analog / Right Analog) to the Gameplay settings menu with a tooltip. The selected analog stick's axes are mapped to D-Pad inputs when a game is running. Setting is persisted to config. Fixes #207