### PR TITLE
android: fix window size on open

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
             android:name="android.app.NativeActivity"
             android:label="@string/app_name"
             android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
-            android:configChanges="orientation|keyboardHidden|screenSize"
+            android:configChanges="orientation|keyboardHidden|screenSize|screenLayout|smallestScreenSize|density|uiMode"
             android:screenOrientation="landscape"
             android:exported="true">
             <meta-data android:name="android.app.lib_name" android:value="main"/>

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -313,6 +313,10 @@ bool Init(void** userData, int argc, char** argv) {
 #if defined(__ANDROID__)
     // Fix up directories, install bundled cores, and request storage access.
     SetupAndroidEnvironment(data->menu);
+    // On Android the display size is known only after the native window attaches,
+    // which happens before Init() but after the App struct's width/height is used.
+    // Resizing here ensures the framebuffer matches the actual display resolution.
+    SetWindowSize(GetScreenWidth(), GetScreenHeight());
 #endif
 
     // Parse the command line arguments.


### PR DESCRIPTION
Resize to actual display dimensions in Init() after the native window attaches on Android, and add missing configChanges attributes to prevent activity recreation on screen changes. Fixes #237