### PR TITLE
Add gamepad hotkey bindings

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,6 +8,11 @@
     url = https://github.com/raysan5/raylib.git
     ignore = dirty
     branch = master
+[submodule "vendor/nuklear_console"]
+	path = vendor/nuklear_console
+	url = https://github.com/RobLoach/nuklear_console.git
+    ignore = dirty
+    branch = master
 [submodule "vendor/nuklear_gamepad"]
 	path = vendor/nuklear_gamepad
 	url = https://github.com/RobLoach/nuklear_gamepad.git
@@ -41,6 +46,3 @@
 	url = https://github.com/icculus/physfs.git
     ignore = dirty
     branch = main
-[submodule "vendor/nuklear_console"]
-	path = vendor/nuklear_console
-	url = https://github.com/RobLoach/nuklear_console.git

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -447,7 +447,7 @@ bool Update(void* userData) {
         bool rewinding = false;
 
         if (IsLibretroGameReady()) {
-            KeyboardKey rewindKey = NuklearKeyToKeyboardKey(data->menu->keyRewind);
+            KeyboardKey rewindKey = LibretroHotkeyToKeyboardKey(data->menu->keyRewind);
             rewinding = data->menu->rewindEnabled && (IsKeyDown(rewindKey) || LibretroHotkeyGPDown(data->menu->gamepadRewind));
 
             // Capture and playback both run at REWIND_CAPTURES_PER_SECOND.
@@ -499,8 +499,8 @@ bool Update(void* userData) {
                 }
 
                 // Fast Forward
-                KeyboardKey key = NuklearKeyToKeyboardKey(data->menu->keyFastForward);
-                KeyboardKey slowMotionKey = NuklearKeyToKeyboardKey(data->menu->keySlowMotion);
+                KeyboardKey key = LibretroHotkeyToKeyboardKey(data->menu->keyFastForward);
+                KeyboardKey slowMotionKey = LibretroHotkeyToKeyboardKey(data->menu->keySlowMotion);
                 if (IsKeyDown(key) || LibretroHotkeyGPDown(data->menu->gamepadFastForward)) {
                     if (IsKeyPressed(key) || LibretroHotkeyGPPressed(data->menu->gamepadFastForward)) {
                         // Halve the volume during fast-forward to soften the
@@ -578,7 +578,7 @@ bool Update(void* userData) {
     if (!menu.active) {
 
         // Screenshot
-        if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyScreenshot)) || LibretroHotkeyGPReleased(menu.gamepadScreenshot)) {
+        if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyScreenshot)) || LibretroHotkeyGPReleased(menu.gamepadScreenshot)) {
             const char* screenshotsDir = GetLibretroDirectory(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY);
             bool taken = false;
             for (int i = 1; i < 1000; i++) {
@@ -597,20 +597,20 @@ bool Update(void* userData) {
 
         // FullScreen toggle key won't work in Emscripten.
     #ifndef __EMSCRIPTEN__
-        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyFullscreen)) || LibretroHotkeyGPReleased(menu.gamepadFullscreen)) {
+        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyFullscreen)) || LibretroHotkeyGPReleased(menu.gamepadFullscreen)) {
             LibretroMenuFullscreenChanged(menu.console, NULL);
         }
     #endif
 
         // Cycle Shader Reverse
-        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyPrevShader)) || LibretroHotkeyGPReleased(menu.gamepadPrevShader)) {
+        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyPrevShader)) || LibretroHotkeyGPReleased(menu.gamepadPrevShader)) {
             CycleLibretroShaderReverse();
             SetLibretroMessage(GetLibretroShaderName(GetActiveLibretroShaderType()), 2.0);
             menu.shaderSelectedIndex = (int)GetActiveLibretroShaderType();
         }
 
         // Cycle Shader Next
-        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyNextShader)) || LibretroHotkeyGPReleased(menu.gamepadNextShader)) {
+        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyNextShader)) || LibretroHotkeyGPReleased(menu.gamepadNextShader)) {
             CycleLibretroShader();
             SetLibretroMessage(GetLibretroShaderName(GetActiveLibretroShaderType()), 2.0);
             // TODO: For some reason, cycling the shader doens't update the menu label.
@@ -618,29 +618,29 @@ bool Update(void* userData) {
         }
 
         // Save State
-        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keySaveState)) || LibretroHotkeyGPReleased(menu.gamepadSaveState)) {
+        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keySaveState)) || LibretroHotkeyGPReleased(menu.gamepadSaveState)) {
             LibretroMenuSaveStateClicked(menu.console, NULL);
         }
 
         // Load State
-        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyLoadState)) || LibretroHotkeyGPReleased(menu.gamepadLoadState)) {
+        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyLoadState)) || LibretroHotkeyGPReleased(menu.gamepadLoadState)) {
             LibretroMenuLoadStateClicked(menu.console, NULL);
         }
 
         // Prev Slot
-        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyPrevSlot)) || LibretroHotkeyGPReleased(menu.gamepadPrevSlot)) {
+        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyPrevSlot)) || LibretroHotkeyGPReleased(menu.gamepadPrevSlot)) {
             menu.saveSlotIndex = (menu.saveSlotIndex - 1 + 10) % 10;
             SetLibretroMessage(TextFormat("Save Slot: %d", menu.saveSlotIndex + 1), 2.0);
         }
 
         // Next Slot
-        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyNextSlot)) || LibretroHotkeyGPReleased(menu.gamepadNextSlot)) {
+        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyNextSlot)) || LibretroHotkeyGPReleased(menu.gamepadNextSlot)) {
             menu.saveSlotIndex = (menu.saveSlotIndex + 1) % 10;
             SetLibretroMessage(TextFormat("Save Slot: %d", menu.saveSlotIndex + 1), 2.0);
         }
 
         // Reset
-        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyReset)) || LibretroHotkeyGPReleased(menu.gamepadReset)) {
+        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyReset)) || LibretroHotkeyGPReleased(menu.gamepadReset)) {
             if (IsLibretroGameReady()) {
                 ResetLibretro();
                 SetLibretroMessage("Reset", 2.0);
@@ -648,7 +648,7 @@ bool Update(void* userData) {
         }
 
         // Volume Up
-        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyVolumeUp)) || LibretroHotkeyGPReleased(menu.gamepadVolumeUp)) {
+        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyVolumeUp)) || LibretroHotkeyGPReleased(menu.gamepadVolumeUp)) {
             float vol = GetLibretroVolume() + 0.1f;
             SetLibretroVolume(vol);
             vol = GetLibretroVolume();
@@ -657,7 +657,7 @@ bool Update(void* userData) {
         }
 
         // Volume Down
-        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyVolumeDown)) || LibretroHotkeyGPReleased(menu.gamepadVolumeDown)) {
+        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyVolumeDown)) || LibretroHotkeyGPReleased(menu.gamepadVolumeDown)) {
             float vol = GetLibretroVolume() - 0.1f;
             SetLibretroVolume(vol);
             vol = GetLibretroVolume();
@@ -666,7 +666,7 @@ bool Update(void* userData) {
         }
 
         // Mute
-        else if (IsKeyPressed(NuklearKeyToKeyboardKey(menu.keyMute)) || LibretroHotkeyGPReleased(menu.gamepadMute)) {
+        else if (IsKeyPressed(LibretroHotkeyToKeyboardKey(menu.keyMute)) || LibretroHotkeyGPReleased(menu.gamepadMute)) {
             if (!data->muted) {
                 SetLibretroVolume(0.0f);
                 data->muted = true;

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -446,7 +446,7 @@ bool Update(void* userData) {
 
         if (IsLibretroGameReady()) {
             KeyboardKey rewindKey = NuklearKeyToKeyboardKey(data->menu->keyRewind);
-            rewinding = data->menu->rewindEnabled && IsKeyDown(rewindKey);
+            rewinding = data->menu->rewindEnabled && (IsKeyDown(rewindKey) || LibretroHotkeyGPDown(data->menu->gamepadRewind));
 
             // Capture and playback both run at REWIND_CAPTURES_PER_SECOND.
             if (data->menu->rewindEnabled) {
@@ -489,7 +489,7 @@ bool Update(void* userData) {
                             RewindBufferPush(&data->rewind, state, size);
                         }
                     }
-                    if (IsKeyReleased(rewindKey)) {
+                    if (IsKeyReleased(rewindKey) || LibretroHotkeyGPReleased(data->menu->gamepadRewind)) {
                         SetLibretroMessage(NULL, 0.0);
                     }
                 } else if (data->rewind.count > 0) {
@@ -499,8 +499,8 @@ bool Update(void* userData) {
                 // Fast Forward
                 KeyboardKey key = NuklearKeyToKeyboardKey(data->menu->keyFastForward);
                 KeyboardKey slowMotionKey = NuklearKeyToKeyboardKey(data->menu->keySlowMotion);
-                if (IsKeyDown(key)) {
-                    if (IsKeyPressed(key)) {
+                if (IsKeyDown(key) || LibretroHotkeyGPDown(data->menu->gamepadFastForward)) {
+                    if (IsKeyPressed(key) || LibretroHotkeyGPPressed(data->menu->gamepadFastForward)) {
                         // Halve the volume during fast-forward to soften the
                         // sped-up audio and ring-buffer overrun crackle.
                         SetLibretroVolume(data->menu->volumeSelected * 0.5f);
@@ -510,20 +510,20 @@ bool Update(void* userData) {
                     // The time accumulator in UpdateLibretro() scales by LIBRETRO.speed,
                     // so the single UpdateLibretro() call below runs the extra ticks.
                 }
-                else if (IsKeyReleased(key)) {
+                else if (IsKeyReleased(key) || LibretroHotkeyGPReleased(data->menu->gamepadFastForward)) {
                     SetLibretroVolume(data->menu->volumeSelected);
                     SetLibretroSpeed(1.0f);
                     SetLibretroMessage(NULL, 0.0);
                 }
 
                 // Slow Motion
-                else if (IsKeyDown(slowMotionKey)) {
-                    if (IsKeyPressed(slowMotionKey)) {
+                else if (IsKeyDown(slowMotionKey) || LibretroHotkeyGPDown(data->menu->gamepadSlowMotion)) {
+                    if (IsKeyPressed(slowMotionKey) || LibretroHotkeyGPPressed(data->menu->gamepadSlowMotion)) {
                         SetLibretroSpeed(data->menu->slowMotionSpeed);
                         SetLibretroMessage("Slow Motion", 1.0);
                     }
                 }
-                else if (IsKeyReleased(slowMotionKey)) {
+                else if (IsKeyReleased(slowMotionKey) || LibretroHotkeyGPReleased(data->menu->gamepadSlowMotion)) {
                     SetLibretroSpeed(1.0f);
                     SetLibretroMessage(NULL, 0.0);
                 }
@@ -576,7 +576,7 @@ bool Update(void* userData) {
     if (!menu.active) {
 
         // Screenshot
-        if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyScreenshot))) {
+        if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyScreenshot)) || LibretroHotkeyGPReleased(menu.gamepadScreenshot)) {
             const char* screenshotsDir = GetLibretroDirectory(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY);
             bool taken = false;
             for (int i = 1; i < 1000; i++) {
@@ -595,20 +595,20 @@ bool Update(void* userData) {
 
         // FullScreen toggle key won't work in Emscripten.
     #ifndef __EMSCRIPTEN__
-        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyFullscreen))) {
+        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyFullscreen)) || LibretroHotkeyGPReleased(menu.gamepadFullscreen)) {
             LibretroMenuFullscreenChanged(menu.console, NULL);
         }
     #endif
 
         // Cycle Shader Reverse
-        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyPrevShader))) {
+        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyPrevShader)) || LibretroHotkeyGPReleased(menu.gamepadPrevShader)) {
             CycleLibretroShaderReverse();
             SetLibretroMessage(GetLibretroShaderName(GetActiveLibretroShaderType()), 2.0);
             menu.shaderSelectedIndex = (int)GetActiveLibretroShaderType();
         }
 
         // Cycle Shader Next
-        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyNextShader))) {
+        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyNextShader)) || LibretroHotkeyGPReleased(menu.gamepadNextShader)) {
             CycleLibretroShader();
             SetLibretroMessage(GetLibretroShaderName(GetActiveLibretroShaderType()), 2.0);
             // TODO: For some reason, cycling the shader doens't update the menu label.
@@ -616,29 +616,29 @@ bool Update(void* userData) {
         }
 
         // Save State
-        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keySaveState))) {
+        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keySaveState)) || LibretroHotkeyGPReleased(menu.gamepadSaveState)) {
             LibretroMenuSaveStateClicked(menu.console, NULL);
         }
 
         // Load State
-        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyLoadState))) {
+        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyLoadState)) || LibretroHotkeyGPReleased(menu.gamepadLoadState)) {
             LibretroMenuLoadStateClicked(menu.console, NULL);
         }
 
         // Prev Slot
-        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyPrevSlot))) {
+        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyPrevSlot)) || LibretroHotkeyGPReleased(menu.gamepadPrevSlot)) {
             menu.saveSlotIndex = (menu.saveSlotIndex - 1 + 10) % 10;
             SetLibretroMessage(TextFormat("Save Slot: %d", menu.saveSlotIndex + 1), 2.0);
         }
 
         // Next Slot
-        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyNextSlot)) ) {
+        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyNextSlot)) || LibretroHotkeyGPReleased(menu.gamepadNextSlot)) {
             menu.saveSlotIndex = (menu.saveSlotIndex + 1) % 10;
             SetLibretroMessage(TextFormat("Save Slot: %d", menu.saveSlotIndex + 1), 2.0);
         }
 
         // Reset
-        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyReset))) {
+        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyReset)) || LibretroHotkeyGPReleased(menu.gamepadReset)) {
             if (IsLibretroGameReady()) {
                 ResetLibretro();
                 SetLibretroMessage("Reset", 2.0);
@@ -646,7 +646,7 @@ bool Update(void* userData) {
         }
 
         // Volume Up
-        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyVolumeUp))) {
+        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyVolumeUp)) || LibretroHotkeyGPReleased(menu.gamepadVolumeUp)) {
             float vol = GetLibretroVolume() + 0.1f;
             SetLibretroVolume(vol);
             vol = GetLibretroVolume();
@@ -655,7 +655,7 @@ bool Update(void* userData) {
         }
 
         // Volume Down
-        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyVolumeDown))) {
+        else if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyVolumeDown)) || LibretroHotkeyGPReleased(menu.gamepadVolumeDown)) {
             float vol = GetLibretroVolume() - 0.1f;
             SetLibretroVolume(vol);
             vol = GetLibretroVolume();
@@ -664,7 +664,7 @@ bool Update(void* userData) {
         }
 
         // Mute
-        else if (IsKeyPressed(NuklearKeyToKeyboardKey(menu.keyMute))) {
+        else if (IsKeyPressed(NuklearKeyToKeyboardKey(menu.keyMute)) || LibretroHotkeyGPReleased(menu.gamepadMute)) {
             if (!data->muted) {
                 SetLibretroVolume(0.0f);
                 data->muted = true;

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -677,6 +677,11 @@ bool Update(void* userData) {
                 SetLibretroMessage(TextFormat("Volume: %d%%", (int)(data->menu->volumeSelected * 10.0f + 0.5f) * 10), 1.0);
             }
         }
+
+        // Quit (keyboard is handled by SetExitKey; this covers the gamepad binding).
+        else if (LibretroHotkeyGPReleased(menu.gamepadQuit)) {
+            menu.shouldQuit = true;
+        }
     }
 
     return true;

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -1298,7 +1298,7 @@ static void LibretroMenuUpdateLoadGameFilter(LibretroMenu* m);
  * Maps each hot key in the Keys settings to the menu fields.
  */
 typedef struct LibretroMenuHotkey {
-    const char* name; /** The name of the hot key. */
+    const char* name; /** The name of the hot key, as shown in the menu. */
     enum nk_gamepad_button* gamepad; /** The gamepad button that's currently assigned. */
     nk_rune* key; /** The keyboard key that's currently assigned. */
     nk_rune default_key; /** The initial keyboard binding that will be set. Gamepad button defaults are ignored. */
@@ -1632,23 +1632,10 @@ LibretroMenu* InitLibretroMenu(void) {
                 "None|Select + Start|L1 + R1|L2 + R2|L3 + R3|Down + Select",
                 '|', &menu.menuComboIndex);
             menuCombo->tooltip = "Controller button combination to toggle the menu";
-            LibretroMenuAddHotkey(keysMenu, "Screenshot", &menu.gamepadScreenshot, &menu.keyScreenshot);
-            LibretroMenuAddHotkey(keysMenu, "Rewind", &menu.gamepadRewind, &menu.keyRewind);
-            LibretroMenuAddHotkey(keysMenu, "Menu", &menu.gamepadMenu, &menu.keyMenu);
-            LibretroMenuAddHotkey(keysMenu, "Save State", &menu.gamepadSaveState, &menu.keySaveState);
-            LibretroMenuAddHotkey(keysMenu, "Load State", &menu.gamepadLoadState, &menu.keyLoadState);
-            LibretroMenuAddHotkey(keysMenu, "Prev Slot", &menu.gamepadPrevSlot, &menu.keyPrevSlot);
-            LibretroMenuAddHotkey(keysMenu, "Next Slot", &menu.gamepadNextSlot, &menu.keyNextSlot);
-            LibretroMenuAddHotkey(keysMenu, "Fullscreen", &menu.gamepadFullscreen, &menu.keyFullscreen);
-            LibretroMenuAddHotkey(keysMenu, "Previous Shader", &menu.gamepadPrevShader, &menu.keyPrevShader);
-            LibretroMenuAddHotkey(keysMenu, "Next Shader", &menu.gamepadNextShader, &menu.keyNextShader);
-            LibretroMenuAddHotkey(keysMenu, "Reset", &menu.gamepadReset, &menu.keyReset);
-            LibretroMenuAddHotkey(keysMenu, "Quit", &menu.gamepadQuit, &menu.keyQuit);
-            LibretroMenuAddHotkey(keysMenu, "Volume Up", &menu.gamepadVolumeUp, &menu.keyVolumeUp);
-            LibretroMenuAddHotkey(keysMenu, "Volume Down", &menu.gamepadVolumeDown, &menu.keyVolumeDown);
-            LibretroMenuAddHotkey(keysMenu, "Mute", &menu.gamepadMute, &menu.keyMute);
-            LibretroMenuAddHotkey(keysMenu, "Fast Forward", &menu.gamepadFastForward, &menu.keyFastForward);
-            LibretroMenuAddHotkey(keysMenu, "Slow Motion", &menu.gamepadSlowMotion, &menu.keySlowMotion);
+            for (int i = 0; i < (int)(sizeof(LibretroMenuHotkeys) / sizeof(LibretroMenuHotkeys[0])); i++) {
+                const LibretroMenuHotkey* hk = &LibretroMenuHotkeys[i];
+                LibretroMenuAddHotkey(keysMenu, hk->name, hk->gamepad, hk->key);
+            }
         }
 
         // Keyboard Controls (Player 1)
@@ -2108,44 +2095,19 @@ static void LibretroMenuUpdateConfig(void) {
     rlconfig_set_int(menu.cfg, "raylib-libretro", "touchControls", menu.touchControls ? 1 : 0);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "touchHaptics", menu.touchHapticsEnabled ? 1 : 0);
 
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyScreenshot", (int)menu.keyScreenshot);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyRewind", (int)menu.keyRewind);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyMenu", (int)menu.keyMenu);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "keySaveState", (int)menu.keySaveState);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyLoadState", (int)menu.keyLoadState);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyPrevSlot",  (int)menu.keyPrevSlot);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyNextSlot",  (int)menu.keyNextSlot);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "saveSlot", menu.saveSlotIndex);
     rlconfig_set(menu.cfg, "raylib-libretro", "username", LIBRETRO.username);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyFullscreen", (int)menu.keyFullscreen);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyPrevShader", (int)menu.keyPrevShader);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyNextShader",  (int)menu.keyNextShader);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyReset",       (int)menu.keyReset);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyQuit",       (int)menu.keyQuit);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyVolumeUp",    (int)menu.keyVolumeUp);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyVolumeDown",  (int)menu.keyVolumeDown);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyMute",        (int)menu.keyMute);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "keyFastForward", (int)menu.keyFastForward);
     rlconfig_set_float(menu.cfg, "raylib-libretro", "fastForwardSpeed", menu.fastForwardSpeed);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "keySlowMotion", (int)menu.keySlowMotion);
     rlconfig_set_float(menu.cfg, "raylib-libretro", "slowMotionSpeed", menu.slowMotionSpeed);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadScreenshot",  (int)menu.gamepadScreenshot);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadRewind",      (int)menu.gamepadRewind);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadMenu",        (int)menu.gamepadMenu);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadSaveState",   (int)menu.gamepadSaveState);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadLoadState",   (int)menu.gamepadLoadState);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadPrevSlot",    (int)menu.gamepadPrevSlot);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadNextSlot",    (int)menu.gamepadNextSlot);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadFullscreen",  (int)menu.gamepadFullscreen);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadPrevShader",  (int)menu.gamepadPrevShader);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadNextShader",  (int)menu.gamepadNextShader);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadReset",       (int)menu.gamepadReset);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadQuit",        (int)menu.gamepadQuit);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadVolumeUp",    (int)menu.gamepadVolumeUp);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadVolumeDown",  (int)menu.gamepadVolumeDown);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadMute",        (int)menu.gamepadMute);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadFastForward", (int)menu.gamepadFastForward);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadSlowMotion",  (int)menu.gamepadSlowMotion);
+
+    // Hotkey bindings (keyboard + gamepad), keyed by name as "key<Name>"/"gamepad<Name>".
+    for (int i = 0; i < (int)(sizeof(LibretroMenuHotkeys) / sizeof(LibretroMenuHotkeys[0])); i++) {
+        const LibretroMenuHotkey* hk = &LibretroMenuHotkeys[i];
+        const char* shortName = TextReplace(hk->name, " ", "");
+        rlconfig_set_int(menu.cfg, "raylib-libretro", TextFormat("key%s", shortName), (int)*hk->key);
+        rlconfig_set_int(menu.cfg, "raylib-libretro", TextFormat("gamepad%s", shortName), (int)*hk->gamepad);
+    }
+
     rlconfig_set(menu.cfg, "raylib-libretro", "coreDirectory", LibretroResolveAbsoluteDirectory(menu.coreDirectory));
     rlconfig_set(menu.cfg, "raylib-libretro", "saveDirectory", LibretroResolveAbsoluteDirectory(menu.saveDirectory));
     rlconfig_set(menu.cfg, "raylib-libretro", "coreAssetsDirectory", LibretroResolveAbsoluteDirectory(menu.coreAssetsDirectory));
@@ -2309,53 +2271,28 @@ static bool LoadLibretroMenuSettings(void) {
     menu.touchControls = rlconfig_get_int(menu.cfg, "raylib-libretro", "touchControls", 0) > 0;
 #endif
     menu.touchHapticsEnabled = rlconfig_get_int(menu.cfg, "raylib-libretro", "touchHaptics", 1) > 0;
-    menu.keyScreenshot = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyScreenshot", (int)menu.keyScreenshot);
-    menu.keyRewind     = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyRewind",     (int)menu.keyRewind);
-    menu.keyMenu       = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyMenu",       (int)menu.keyMenu);
-    menu.keySaveState  = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keySaveState",  (int)menu.keySaveState);
-    menu.keyLoadState  = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyLoadState",  (int)menu.keyLoadState);
-    menu.keyPrevSlot   = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyPrevSlot",   (int)menu.keyPrevSlot);
-    menu.keyNextSlot   = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyNextSlot",   (int)menu.keyNextSlot);
     menu.saveSlotIndex = rlconfig_get_int(menu.cfg, "raylib-libretro", "saveSlot", 0);
     if (menu.saveSlotIndex < 0 || menu.saveSlotIndex > 9) menu.saveSlotIndex = 0;
     const char* username = rlconfig_get(menu.cfg, "raylib-libretro", "username");
     if (username) TextCopy(LIBRETRO.username, username);
-    menu.keyFullscreen = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyFullscreen", (int)menu.keyFullscreen);
-    menu.keyPrevShader = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyPrevShader", (int)menu.keyPrevShader);
-    menu.keyNextShader  = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyNextShader",  (int)menu.keyNextShader);
-    menu.keyReset       = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyReset",       (int)menu.keyReset);
-    menu.keyQuit       = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyQuit",       (int)menu.keyQuit);
+
+    // Hotkey bindings (keyboard + gamepad), keyed by name as "key<Name>"/"gamepad<Name>".
+    for (int i = 0; i < (int)(sizeof(LibretroMenuHotkeys) / sizeof(LibretroMenuHotkeys[0])); i++) {
+        const LibretroMenuHotkey* hk = &LibretroMenuHotkeys[i];
+        const char* shortName = TextReplace(hk->name, " ", "");
+        *hk->key = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", TextFormat("key%s", shortName), (int)*hk->key);
+        *hk->gamepad = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", TextFormat("gamepad%s", shortName), (int)*hk->gamepad);
+    }
     SetExitKey(LibretroHotkeyToKeyboardKey(menu.keyQuit));
-    menu.keyVolumeUp    = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyVolumeUp",    (int)menu.keyVolumeUp);
-    menu.keyVolumeDown  = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyVolumeDown",  (int)menu.keyVolumeDown);
-    menu.keyMute        = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyMute",        (int)menu.keyMute);
-    menu.keyFastForward = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyFastForward", (int)menu.keyFastForward);
+
     menu.fastForwardSpeed = rlconfig_get_float(menu.cfg, "raylib-libretro", "fastForwardSpeed", menu.fastForwardSpeed);
     if (menu.fastForwardSpeed < 1.1f) menu.fastForwardSpeed = 1.1f;
     if (menu.fastForwardSpeed > 10.0f) menu.fastForwardSpeed = 10.0f;
-    menu.keySlowMotion = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keySlowMotion", (int)menu.keySlowMotion);
     menu.slowMotionSpeed = rlconfig_get_float(menu.cfg, "raylib-libretro", "slowMotionSpeed", menu.slowMotionSpeed);
     // Migrate the legacy x10 integer storage (1..9) to the 0.1..0.9 float scale.
     if (menu.slowMotionSpeed > 0.95f) menu.slowMotionSpeed /= 10.0f;
     if (menu.slowMotionSpeed < 0.1f) menu.slowMotionSpeed = 0.1f;
     if (menu.slowMotionSpeed > 0.9f) menu.slowMotionSpeed = 0.9f;
-    menu.gamepadScreenshot  = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadScreenshot",  (int)NK_GAMEPAD_BUTTON_INVALID);
-    menu.gamepadRewind      = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadRewind",      (int)NK_GAMEPAD_BUTTON_INVALID);
-    menu.gamepadMenu        = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadMenu",        (int)NK_GAMEPAD_BUTTON_INVALID);
-    menu.gamepadSaveState   = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadSaveState",   (int)NK_GAMEPAD_BUTTON_INVALID);
-    menu.gamepadLoadState   = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadLoadState",   (int)NK_GAMEPAD_BUTTON_INVALID);
-    menu.gamepadPrevSlot    = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadPrevSlot",    (int)NK_GAMEPAD_BUTTON_INVALID);
-    menu.gamepadNextSlot    = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadNextSlot",    (int)NK_GAMEPAD_BUTTON_INVALID);
-    menu.gamepadFullscreen  = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadFullscreen",  (int)NK_GAMEPAD_BUTTON_INVALID);
-    menu.gamepadPrevShader  = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadPrevShader",  (int)NK_GAMEPAD_BUTTON_INVALID);
-    menu.gamepadNextShader  = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadNextShader",  (int)NK_GAMEPAD_BUTTON_INVALID);
-    menu.gamepadReset       = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadReset",       (int)NK_GAMEPAD_BUTTON_INVALID);
-    menu.gamepadQuit        = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadQuit",        (int)NK_GAMEPAD_BUTTON_INVALID);
-    menu.gamepadVolumeUp    = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadVolumeUp",    (int)NK_GAMEPAD_BUTTON_INVALID);
-    menu.gamepadVolumeDown  = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadVolumeDown",  (int)NK_GAMEPAD_BUTTON_INVALID);
-    menu.gamepadMute        = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadMute",        (int)NK_GAMEPAD_BUTTON_INVALID);
-    menu.gamepadFastForward = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadFastForward", (int)NK_GAMEPAD_BUTTON_INVALID);
-    menu.gamepadSlowMotion  = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadSlowMotion",  (int)NK_GAMEPAD_BUTTON_INVALID);
 
     const char* coreDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "coreDirectory");
     if (coreDirectory) TextCopy(menu.coreDirectory, coreDirectory);

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -1516,40 +1516,23 @@ LibretroMenu* InitLibretroMenu(void) {
                 "None|Select + Start|L1 + R1|L2 + R2|L3 + R3|Down + Select",
                 '|', &menu.menuComboIndex);
             menuCombo->tooltip = "Controller button combination to toggle the menu";
-            nk_console_key(keysMenu, "Screenshot", &menu.keyScreenshot);
-            nk_console_input_gamepad(keysMenu, "Screenshot (GP)", 0, NULL, &menu.gamepadScreenshot);
-            nk_console_key(keysMenu, "Rewind", &menu.keyRewind);
-            nk_console_input_gamepad(keysMenu, "Rewind (GP)", 0, NULL, &menu.gamepadRewind);
-            nk_console_key(keysMenu, "Menu", &menu.keyMenu);
-            nk_console_input_gamepad(keysMenu, "Menu (GP)", 0, NULL, &menu.gamepadMenu);
-            nk_console_key(keysMenu, "Save State", &menu.keySaveState);
-            nk_console_input_gamepad(keysMenu, "Save State (GP)", 0, NULL, &menu.gamepadSaveState);
-            nk_console_key(keysMenu, "Load State", &menu.keyLoadState);
-            nk_console_input_gamepad(keysMenu, "Load State (GP)", 0, NULL, &menu.gamepadLoadState);
-            nk_console_key(keysMenu, "Prev Slot", &menu.keyPrevSlot);
-            nk_console_input_gamepad(keysMenu, "Prev Slot (GP)", 0, NULL, &menu.gamepadPrevSlot);
-            nk_console_key(keysMenu, "Next Slot", &menu.keyNextSlot);
-            nk_console_input_gamepad(keysMenu, "Next Slot (GP)", 0, NULL, &menu.gamepadNextSlot);
-            nk_console_key(keysMenu, "Fullscreen", &menu.keyFullscreen);
-            nk_console_input_gamepad(keysMenu, "Fullscreen (GP)", 0, NULL, &menu.gamepadFullscreen);
-            nk_console_key(keysMenu, "Previous Shader", &menu.keyPrevShader);
-            nk_console_input_gamepad(keysMenu, "Prev Shader (GP)", 0, NULL, &menu.gamepadPrevShader);
-            nk_console_key(keysMenu, "Next Shader", &menu.keyNextShader);
-            nk_console_input_gamepad(keysMenu, "Next Shader (GP)", 0, NULL, &menu.gamepadNextShader);
-            nk_console_key(keysMenu, "Reset", &menu.keyReset);
-            nk_console_input_gamepad(keysMenu, "Reset (GP)", 0, NULL, &menu.gamepadReset);
-            nk_console_key(keysMenu, "Quit", &menu.keyQuit);
-            nk_console_input_gamepad(keysMenu, "Quit (GP)", 0, NULL, &menu.gamepadQuit);
-            nk_console_key(keysMenu, "Volume Up", &menu.keyVolumeUp);
-            nk_console_input_gamepad(keysMenu, "Volume Up (GP)", 0, NULL, &menu.gamepadVolumeUp);
-            nk_console_key(keysMenu, "Volume Down", &menu.keyVolumeDown);
-            nk_console_input_gamepad(keysMenu, "Volume Down (GP)", 0, NULL, &menu.gamepadVolumeDown);
-            nk_console_key(keysMenu, "Mute", &menu.keyMute);
-            nk_console_input_gamepad(keysMenu, "Mute (GP)", 0, NULL, &menu.gamepadMute);
-            nk_console_key(keysMenu, "Fast Forward", &menu.keyFastForward);
-            nk_console_input_gamepad(keysMenu, "Fast Forward (GP)", 0, NULL, &menu.gamepadFastForward);
-            nk_console_key(keysMenu, "Slow Motion", &menu.keySlowMotion);
-            nk_console_input_gamepad(keysMenu, "Slow Motion (GP)", 0, NULL, &menu.gamepadSlowMotion);
+            nk_console_input(keysMenu, "Screenshot", -1, NULL, &menu.gamepadScreenshot, &menu.keyScreenshot, NULL);
+            nk_console_input(keysMenu, "Rewind", -1, NULL, &menu.gamepadRewind, &menu.keyRewind, NULL);
+            nk_console_input(keysMenu, "Menu", -1, NULL, &menu.gamepadMenu, &menu.keyMenu, NULL);
+            nk_console_input(keysMenu, "Save State", -1, NULL, &menu.gamepadSaveState, &menu.keySaveState, NULL);
+            nk_console_input(keysMenu, "Load State", -1, NULL, &menu.gamepadLoadState, &menu.keyLoadState, NULL);
+            nk_console_input(keysMenu, "Prev Slot", -1, NULL, &menu.gamepadPrevSlot, &menu.keyPrevSlot, NULL);
+            nk_console_input(keysMenu, "Next Slot", -1, NULL, &menu.gamepadNextSlot, &menu.keyNextSlot, NULL);
+            nk_console_input(keysMenu, "Fullscreen", -1, NULL, &menu.gamepadFullscreen, &menu.keyFullscreen, NULL);
+            nk_console_input(keysMenu, "Previous Shader", -1, NULL, &menu.gamepadPrevShader, &menu.keyPrevShader, NULL);
+            nk_console_input(keysMenu, "Next Shader", -1, NULL, &menu.gamepadNextShader, &menu.keyNextShader, NULL);
+            nk_console_input(keysMenu, "Reset", -1, NULL, &menu.gamepadReset, &menu.keyReset, NULL);
+            nk_console_input(keysMenu, "Quit", -1, NULL, &menu.gamepadQuit, &menu.keyQuit, NULL);
+            nk_console_input(keysMenu, "Volume Up", -1, NULL, &menu.gamepadVolumeUp, &menu.keyVolumeUp, NULL);
+            nk_console_input(keysMenu, "Volume Down", -1, NULL, &menu.gamepadVolumeDown, &menu.keyVolumeDown, NULL);
+            nk_console_input(keysMenu, "Mute", -1, NULL, &menu.gamepadMute, &menu.keyMute, NULL);
+            nk_console_input(keysMenu, "Fast Forward", -1, NULL, &menu.gamepadFastForward, &menu.keyFastForward, NULL);
+            nk_console_input(keysMenu, "Slow Motion", -1, NULL, &menu.gamepadSlowMotion, &menu.keySlowMotion, NULL);
         }
 
         // Keyboard Controls (Player 1)

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -108,6 +108,23 @@ typedef struct LibretroMenu {
     float fastForwardSpeed;
     nk_rune keySlowMotion;
     float slowMotionSpeed;
+    enum nk_gamepad_button gamepadScreenshot;
+    enum nk_gamepad_button gamepadRewind;
+    enum nk_gamepad_button gamepadMenu;
+    enum nk_gamepad_button gamepadSaveState;
+    enum nk_gamepad_button gamepadLoadState;
+    enum nk_gamepad_button gamepadPrevSlot;
+    enum nk_gamepad_button gamepadNextSlot;
+    enum nk_gamepad_button gamepadFullscreen;
+    enum nk_gamepad_button gamepadPrevShader;
+    enum nk_gamepad_button gamepadNextShader;
+    enum nk_gamepad_button gamepadReset;
+    enum nk_gamepad_button gamepadQuit;
+    enum nk_gamepad_button gamepadVolumeUp;
+    enum nk_gamepad_button gamepadVolumeDown;
+    enum nk_gamepad_button gamepadMute;
+    enum nk_gamepad_button gamepadFastForward;
+    enum nk_gamepad_button gamepadSlowMotion;
     int optionSelectedIndices[LIBRETRO_MAX_CORE_VARIABLES];    // per-option combobox index
     nk_bool optionCheckboxValues[LIBRETRO_MAX_CORE_VARIABLES]; // per-option checkbox state for enabled/disabled options
     char coreDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
@@ -1263,6 +1280,23 @@ LibretroMenu* InitLibretroMenu(void) {
     menu.menuComboIndex = LIBRETRO_MENU_COMBO_SELECT_START;
     menu.keySlowMotion = (nk_rune)'G';
     menu.slowMotionSpeed = 0.5f;
+    menu.gamepadScreenshot  = NK_GAMEPAD_BUTTON_INVALID;
+    menu.gamepadRewind      = NK_GAMEPAD_BUTTON_INVALID;
+    menu.gamepadMenu        = NK_GAMEPAD_BUTTON_INVALID;
+    menu.gamepadSaveState   = NK_GAMEPAD_BUTTON_INVALID;
+    menu.gamepadLoadState   = NK_GAMEPAD_BUTTON_INVALID;
+    menu.gamepadPrevSlot    = NK_GAMEPAD_BUTTON_INVALID;
+    menu.gamepadNextSlot    = NK_GAMEPAD_BUTTON_INVALID;
+    menu.gamepadFullscreen  = NK_GAMEPAD_BUTTON_INVALID;
+    menu.gamepadPrevShader  = NK_GAMEPAD_BUTTON_INVALID;
+    menu.gamepadNextShader  = NK_GAMEPAD_BUTTON_INVALID;
+    menu.gamepadReset       = NK_GAMEPAD_BUTTON_INVALID;
+    menu.gamepadQuit        = NK_GAMEPAD_BUTTON_INVALID;
+    menu.gamepadVolumeUp    = NK_GAMEPAD_BUTTON_INVALID;
+    menu.gamepadVolumeDown  = NK_GAMEPAD_BUTTON_INVALID;
+    menu.gamepadMute        = NK_GAMEPAD_BUTTON_INVALID;
+    menu.gamepadFastForward = NK_GAMEPAD_BUTTON_INVALID;
+    menu.gamepadSlowMotion  = NK_GAMEPAD_BUTTON_INVALID;
     menu.keyboardP1[RETRO_DEVICE_ID_JOYPAD_B]      = (nk_rune)'Z';
     menu.keyboardP1[RETRO_DEVICE_ID_JOYPAD_Y]      = (nk_rune)'A';
     menu.keyboardP1[RETRO_DEVICE_ID_JOYPAD_SELECT] = (nk_rune)NK_KEY_SHIFT;
@@ -1483,22 +1517,39 @@ LibretroMenu* InitLibretroMenu(void) {
                 '|', &menu.menuComboIndex);
             menuCombo->tooltip = "Controller button combination to toggle the menu";
             nk_console_key(keysMenu, "Screenshot", &menu.keyScreenshot);
+            nk_console_input_gamepad(keysMenu, "Screenshot (GP)", 0, NULL, &menu.gamepadScreenshot);
             nk_console_key(keysMenu, "Rewind", &menu.keyRewind);
+            nk_console_input_gamepad(keysMenu, "Rewind (GP)", 0, NULL, &menu.gamepadRewind);
             nk_console_key(keysMenu, "Menu", &menu.keyMenu);
+            nk_console_input_gamepad(keysMenu, "Menu (GP)", 0, NULL, &menu.gamepadMenu);
             nk_console_key(keysMenu, "Save State", &menu.keySaveState);
+            nk_console_input_gamepad(keysMenu, "Save State (GP)", 0, NULL, &menu.gamepadSaveState);
             nk_console_key(keysMenu, "Load State", &menu.keyLoadState);
+            nk_console_input_gamepad(keysMenu, "Load State (GP)", 0, NULL, &menu.gamepadLoadState);
             nk_console_key(keysMenu, "Prev Slot", &menu.keyPrevSlot);
+            nk_console_input_gamepad(keysMenu, "Prev Slot (GP)", 0, NULL, &menu.gamepadPrevSlot);
             nk_console_key(keysMenu, "Next Slot", &menu.keyNextSlot);
+            nk_console_input_gamepad(keysMenu, "Next Slot (GP)", 0, NULL, &menu.gamepadNextSlot);
             nk_console_key(keysMenu, "Fullscreen", &menu.keyFullscreen);
+            nk_console_input_gamepad(keysMenu, "Fullscreen (GP)", 0, NULL, &menu.gamepadFullscreen);
             nk_console_key(keysMenu, "Previous Shader", &menu.keyPrevShader);
+            nk_console_input_gamepad(keysMenu, "Prev Shader (GP)", 0, NULL, &menu.gamepadPrevShader);
             nk_console_key(keysMenu, "Next Shader", &menu.keyNextShader);
+            nk_console_input_gamepad(keysMenu, "Next Shader (GP)", 0, NULL, &menu.gamepadNextShader);
             nk_console_key(keysMenu, "Reset", &menu.keyReset);
+            nk_console_input_gamepad(keysMenu, "Reset (GP)", 0, NULL, &menu.gamepadReset);
             nk_console_key(keysMenu, "Quit", &menu.keyQuit);
+            nk_console_input_gamepad(keysMenu, "Quit (GP)", 0, NULL, &menu.gamepadQuit);
             nk_console_key(keysMenu, "Volume Up", &menu.keyVolumeUp);
+            nk_console_input_gamepad(keysMenu, "Volume Up (GP)", 0, NULL, &menu.gamepadVolumeUp);
             nk_console_key(keysMenu, "Volume Down", &menu.keyVolumeDown);
+            nk_console_input_gamepad(keysMenu, "Volume Down (GP)", 0, NULL, &menu.gamepadVolumeDown);
             nk_console_key(keysMenu, "Mute", &menu.keyMute);
+            nk_console_input_gamepad(keysMenu, "Mute (GP)", 0, NULL, &menu.gamepadMute);
             nk_console_key(keysMenu, "Fast Forward", &menu.keyFastForward);
+            nk_console_input_gamepad(keysMenu, "Fast Forward (GP)", 0, NULL, &menu.gamepadFastForward);
             nk_console_key(keysMenu, "Slow Motion", &menu.keySlowMotion);
+            nk_console_input_gamepad(keysMenu, "Slow Motion (GP)", 0, NULL, &menu.gamepadSlowMotion);
         }
 
         // Keyboard Controls (Player 1)
@@ -1975,6 +2026,23 @@ static void LibretroMenuUpdateConfig(void) {
     rlconfig_set_float(menu.cfg, "raylib-libretro", "fastForwardSpeed", menu.fastForwardSpeed);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "keySlowMotion", (int)menu.keySlowMotion);
     rlconfig_set_float(menu.cfg, "raylib-libretro", "slowMotionSpeed", menu.slowMotionSpeed);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadScreenshot",  (int)menu.gamepadScreenshot);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadRewind",      (int)menu.gamepadRewind);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadMenu",        (int)menu.gamepadMenu);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadSaveState",   (int)menu.gamepadSaveState);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadLoadState",   (int)menu.gamepadLoadState);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadPrevSlot",    (int)menu.gamepadPrevSlot);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadNextSlot",    (int)menu.gamepadNextSlot);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadFullscreen",  (int)menu.gamepadFullscreen);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadPrevShader",  (int)menu.gamepadPrevShader);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadNextShader",  (int)menu.gamepadNextShader);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadReset",       (int)menu.gamepadReset);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadQuit",        (int)menu.gamepadQuit);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadVolumeUp",    (int)menu.gamepadVolumeUp);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadVolumeDown",  (int)menu.gamepadVolumeDown);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadMute",        (int)menu.gamepadMute);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadFastForward", (int)menu.gamepadFastForward);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "gamepadSlowMotion",  (int)menu.gamepadSlowMotion);
     rlconfig_set(menu.cfg, "raylib-libretro", "coreDirectory", LibretroResolveAbsoluteDirectory(menu.coreDirectory));
     rlconfig_set(menu.cfg, "raylib-libretro", "saveDirectory", LibretroResolveAbsoluteDirectory(menu.saveDirectory));
     rlconfig_set(menu.cfg, "raylib-libretro", "coreAssetsDirectory", LibretroResolveAbsoluteDirectory(menu.coreAssetsDirectory));
@@ -2168,6 +2236,23 @@ static bool LoadLibretroMenuSettings(void) {
     if (menu.slowMotionSpeed > 0.95f) menu.slowMotionSpeed /= 10.0f;
     if (menu.slowMotionSpeed < 0.1f) menu.slowMotionSpeed = 0.1f;
     if (menu.slowMotionSpeed > 0.9f) menu.slowMotionSpeed = 0.9f;
+    menu.gamepadScreenshot  = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadScreenshot",  (int)NK_GAMEPAD_BUTTON_INVALID);
+    menu.gamepadRewind      = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadRewind",      (int)NK_GAMEPAD_BUTTON_INVALID);
+    menu.gamepadMenu        = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadMenu",        (int)NK_GAMEPAD_BUTTON_INVALID);
+    menu.gamepadSaveState   = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadSaveState",   (int)NK_GAMEPAD_BUTTON_INVALID);
+    menu.gamepadLoadState   = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadLoadState",   (int)NK_GAMEPAD_BUTTON_INVALID);
+    menu.gamepadPrevSlot    = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadPrevSlot",    (int)NK_GAMEPAD_BUTTON_INVALID);
+    menu.gamepadNextSlot    = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadNextSlot",    (int)NK_GAMEPAD_BUTTON_INVALID);
+    menu.gamepadFullscreen  = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadFullscreen",  (int)NK_GAMEPAD_BUTTON_INVALID);
+    menu.gamepadPrevShader  = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadPrevShader",  (int)NK_GAMEPAD_BUTTON_INVALID);
+    menu.gamepadNextShader  = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadNextShader",  (int)NK_GAMEPAD_BUTTON_INVALID);
+    menu.gamepadReset       = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadReset",       (int)NK_GAMEPAD_BUTTON_INVALID);
+    menu.gamepadQuit        = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadQuit",        (int)NK_GAMEPAD_BUTTON_INVALID);
+    menu.gamepadVolumeUp    = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadVolumeUp",    (int)NK_GAMEPAD_BUTTON_INVALID);
+    menu.gamepadVolumeDown  = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadVolumeDown",  (int)NK_GAMEPAD_BUTTON_INVALID);
+    menu.gamepadMute        = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadMute",        (int)NK_GAMEPAD_BUTTON_INVALID);
+    menu.gamepadFastForward = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadFastForward", (int)NK_GAMEPAD_BUTTON_INVALID);
+    menu.gamepadSlowMotion  = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", "gamepadSlowMotion",  (int)NK_GAMEPAD_BUTTON_INVALID);
 
     const char* coreDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "coreDirectory");
     if (coreDirectory) TextCopy(menu.coreDirectory, coreDirectory);
@@ -2259,6 +2344,16 @@ static void UpdateLibretroMenuVisibility(void) {
     if (menu.cheatsMenuButton) menu.cheatsMenuButton->visible = gameReady;
 }
 
+static nk_bool LibretroHotkeyGPReleased(enum nk_gamepad_button btn) {
+    return btn != NK_GAMEPAD_BUTTON_INVALID && nk_gamepad_is_button_released(&menu.gamepads, -1, btn);
+}
+static nk_bool LibretroHotkeyGPDown(enum nk_gamepad_button btn) {
+    return btn != NK_GAMEPAD_BUTTON_INVALID && nk_gamepad_is_button_down(&menu.gamepads, -1, btn);
+}
+static nk_bool LibretroHotkeyGPPressed(enum nk_gamepad_button btn) {
+    return btn != NK_GAMEPAD_BUTTON_INVALID && nk_gamepad_is_button_pressed(&menu.gamepads, -1, btn);
+}
+
 void UpdateLibretroMenu(void) {
     if (menu.ctx == NULL) {
         return;
@@ -2280,7 +2375,7 @@ void UpdateLibretroMenu(void) {
     }
 
     // Menu Key
-    if (IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyMenu)) && !menu.active) {
+    if ((IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyMenu)) || LibretroHotkeyGPReleased(menu.gamepadMenu)) && !menu.active) {
         ShowLibretroMenu();
     }
 

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -311,6 +311,14 @@ static Font GetLibretroMenuFont(void) {
     return menu.font;
 }
 
+/**
+ * Ports a given input nk_rune to a raylib KeyboardKey.
+ */
+static KeyboardKey LibretroHotkeyToKeyboardKey(nk_rune key) {
+    enum nk_keys special = nk_console_input_rune_to_keys(key);
+    return NuklearKeyToKeyboardKey(special != NK_KEY_NONE ? (nk_rune)special : key);
+}
+
 static void LibretroMenuSettingChanged(nk_console* widget, void* user_data) {
     (void)widget;
     (void)user_data;
@@ -321,7 +329,7 @@ static void LibretroMenuSettingChanged(nk_console* widget, void* user_data) {
         LIBRETRO.textureFilter = menu.textureFilterIndex;
         InitLibretroVideo();
     }
-    SetExitKey(NuklearKeyToKeyboardKey(menu.keyQuit));
+    SetExitKey(LibretroHotkeyToKeyboardKey(menu.keyQuit));
 }
 
 static LibretroMenu* GetLibretroMenu(void) {
@@ -1286,61 +1294,118 @@ static void LibretroMenuLoadStateClicked(nk_console* widget, void* user_data) {
 
 static void LibretroMenuUpdateLoadGameFilter(LibretroMenu* m);
 
+/**
+ * Maps each hot key in the Keys settings to the menu fields.
+ */
+typedef struct LibretroMenuHotkey {
+    const char* name; /** The name of the hot key. */
+    enum nk_gamepad_button* gamepad; /** The gamepad button that's currently assigned. */
+    nk_rune* key; /** The keyboard key that's currently assigned. */
+    nk_rune default_key; /** The initial keyboard binding that will be set. Gamepad button defaults are ignored. */
+} LibretroMenuHotkey;
+
+/**
+ * Set of menu hot keys that will be built into input widgets in the Hot Keys menu.
+ */
+static const LibretroMenuHotkey LibretroMenuHotkeys[] = {
+    { "Screenshot",      &menu.gamepadScreenshot,  &menu.keyScreenshot,  NK_CONSOLE_KEY_F8 },
+    { "Rewind",          &menu.gamepadRewind,      &menu.keyRewind,      (nk_rune)'R' },
+    { "Menu",            &menu.gamepadMenu,        &menu.keyMenu,        NK_CONSOLE_KEY_ESCAPE },
+    { "Save State",      &menu.gamepadSaveState,   &menu.keySaveState,   NK_CONSOLE_KEY_F2 },
+    { "Load State",      &menu.gamepadLoadState,   &menu.keyLoadState,   NK_CONSOLE_KEY_F4 },
+    { "Prev Slot",       &menu.gamepadPrevSlot,    &menu.keyPrevSlot,    NK_CONSOLE_KEY_NONE },
+    { "Next Slot",       &menu.gamepadNextSlot,    &menu.keyNextSlot,    NK_CONSOLE_KEY_NONE },
+    { "Fullscreen",      &menu.gamepadFullscreen,  &menu.keyFullscreen,  NK_CONSOLE_KEY_F11 },
+    { "Previous Shader", &menu.gamepadPrevShader,  &menu.keyPrevShader,  NK_CONSOLE_KEY_F9 },
+    { "Next Shader",     &menu.gamepadNextShader,  &menu.keyNextShader,  NK_CONSOLE_KEY_F10 },
+    { "Reset",           &menu.gamepadReset,       &menu.keyReset,       NK_CONSOLE_KEY_NONE },
+    { "Quit",            &menu.gamepadQuit,        &menu.keyQuit,        NK_CONSOLE_KEY_NONE },
+    { "Volume Up",       &menu.gamepadVolumeUp,    &menu.keyVolumeUp,    (nk_rune)'=' },
+    { "Volume Down",     &menu.gamepadVolumeDown,  &menu.keyVolumeDown,  (nk_rune)'-' },
+    { "Mute",            &menu.gamepadMute,        &menu.keyMute,        (nk_rune)'M' },
+    { "Fast Forward",    &menu.gamepadFastForward, &menu.keyFastForward, (nk_rune)'F' },
+    { "Slow Motion",     &menu.gamepadSlowMotion,  &menu.keySlowMotion,  (nk_rune)'G' },
+};
+
+/**
+ * Event that's triggered when a menu hot key was changed.
+ */
+static void LibretroMenuHotkeyChanged(nk_console* widget, void* user_data) {
+    NK_UNUSED(user_data);
+    if (widget == NULL || widget->data == NULL) {
+        return;
+    }
+
+    nk_console_input_data* data = (nk_console_input_data*)widget->data;
+    nk_bool isKey = nk_console_input_is_key(widget);
+    nk_bool isGamepad = nk_console_input_is_gamepad(widget);
+    if (!isKey && !isGamepad) {
+        return; // The binding was cleared; nothing to deconflict.
+    }
+
+    // Check if there were any conflicts with other keys/buttons.
+    for (int i = 0; i < (int)(sizeof(LibretroMenuHotkeys) / sizeof(LibretroMenuHotkeys[0])); i++) {
+        const LibretroMenuHotkey* hk = &LibretroMenuHotkeys[i];
+
+        // Skip the binding that was just changed (matched by output pointer).
+        if (hk->gamepad == data->out_gamepad_button || hk->key == data->out_key) {
+            continue;
+        }
+
+        // Check if the key conflicts.
+        if (isKey && hk->key != NULL && *hk->key == *data->out_key) {
+            *hk->key = NK_CONSOLE_KEY_NONE; // Unbind it.
+            nk_console_show_message(menu.console,
+                TextFormat("%s has been unbound", hk->name));
+        }
+        // Check if the gamepad button conflicts.
+        else if (isGamepad && hk->gamepad != NULL && *hk->gamepad == *data->out_gamepad_button) {
+            *hk->gamepad = NK_GAMEPAD_BUTTON_INVALID; // Unbind it.
+            nk_console_show_message(menu.console,
+                TextFormat("%s has been unbound", hk->name));
+        }
+    }
+}
+
+/**
+ * Creates a Hot Key widget in the Hot Key menu.
+ */
+static nk_console* LibretroMenuAddHotkey(nk_console* parent, const char* label, enum nk_gamepad_button* gamepad, nk_rune* key) {
+    nk_console* widget = nk_console_input(parent, label, -1, NULL, gamepad, key, NULL);
+    nk_console_add_event(widget, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuHotkeyChanged);
+    return widget;
+}
+
 LibretroMenu* InitLibretroMenu(void) {
+    int fontSize = 13;
     int screenWidth = GetScreenWidth();
-    //int menuScale = (screenWidth >= 2560) ? 3 : (screenWidth >= 1280) ? 2 : 1;
-    int fontSize = 13;// * menuScale;
+
+    // Create the menu.
     menu = (LibretroMenu){0};
     menu.themeSelectedIndex = LIBRETRO_MENU_STYLE_CATPPUCCIN_MOCHA;
     menu.volumeSelected = 1.0f;
     menu.vsync = nk_true;
     menu.fpsIndex = 0; // Auto
-    menu.keyScreenshot  = (nk_rune)NK_KEY_F8;
-    menu.keyRewind      = (nk_rune)'R';
-    menu.keyMenu        = (nk_rune)NK_KEY_TEXT_RESET_MODE;
-    menu.keySaveState   = (nk_rune)NK_KEY_F2;
-    menu.keyLoadState   = (nk_rune)NK_KEY_F4;
-    menu.keyPrevSlot    = (nk_rune)NK_KEY_NONE;
-    menu.keyNextSlot    = (nk_rune)NK_KEY_NONE;
     menu.saveSlotIndex  = 0;
-    menu.keyFullscreen  = (nk_rune)NK_KEY_F11;
-    menu.keyPrevShader  = (nk_rune)NK_KEY_F9;
-    menu.keyNextShader  = (nk_rune)NK_KEY_F10;
-    menu.keyReset       = (nk_rune)NK_KEY_NONE;
-    menu.keyQuit        = (nk_rune)NK_KEY_NONE;
-    menu.keyVolumeUp    = (nk_rune)'=';
-    menu.keyVolumeDown  = (nk_rune)'-';
-    menu.keyMute        = (nk_rune)'M';
-    menu.keyFastForward = (nk_rune)'F';
     menu.fastForwardSpeed = 3.0f;
     menu.menuComboIndex = LIBRETRO_MENU_COMBO_SELECT_START;
-    menu.keySlowMotion = (nk_rune)'G';
     menu.slowMotionSpeed = 0.5f;
-    menu.gamepadScreenshot  = NK_GAMEPAD_BUTTON_INVALID;
-    menu.gamepadRewind      = NK_GAMEPAD_BUTTON_INVALID;
-    menu.gamepadMenu        = NK_GAMEPAD_BUTTON_INVALID;
-    menu.gamepadSaveState   = NK_GAMEPAD_BUTTON_INVALID;
-    menu.gamepadLoadState   = NK_GAMEPAD_BUTTON_INVALID;
-    menu.gamepadPrevSlot    = NK_GAMEPAD_BUTTON_INVALID;
-    menu.gamepadNextSlot    = NK_GAMEPAD_BUTTON_INVALID;
-    menu.gamepadFullscreen  = NK_GAMEPAD_BUTTON_INVALID;
-    menu.gamepadPrevShader  = NK_GAMEPAD_BUTTON_INVALID;
-    menu.gamepadNextShader  = NK_GAMEPAD_BUTTON_INVALID;
-    menu.gamepadReset       = NK_GAMEPAD_BUTTON_INVALID;
-    menu.gamepadQuit        = NK_GAMEPAD_BUTTON_INVALID;
-    menu.gamepadVolumeUp    = NK_GAMEPAD_BUTTON_INVALID;
-    menu.gamepadVolumeDown  = NK_GAMEPAD_BUTTON_INVALID;
-    menu.gamepadMute        = NK_GAMEPAD_BUTTON_INVALID;
-    menu.gamepadFastForward = NK_GAMEPAD_BUTTON_INVALID;
-    menu.gamepadSlowMotion  = NK_GAMEPAD_BUTTON_INVALID;
+
+    // Default hotkey bindings.
+    for (int i = 0; i < (int)(sizeof(LibretroMenuHotkeys) / sizeof(LibretroMenuHotkeys[0])); i++) {
+        *LibretroMenuHotkeys[i].key = LibretroMenuHotkeys[i].default_key;
+        *LibretroMenuHotkeys[i].gamepad = NK_GAMEPAD_BUTTON_INVALID;
+    }
+
+    // Default Keyboard Controls
     menu.keyboardP1[RETRO_DEVICE_ID_JOYPAD_B]      = (nk_rune)'Z';
     menu.keyboardP1[RETRO_DEVICE_ID_JOYPAD_Y]      = (nk_rune)'A';
-    menu.keyboardP1[RETRO_DEVICE_ID_JOYPAD_SELECT] = (nk_rune)NK_KEY_SHIFT;
-    menu.keyboardP1[RETRO_DEVICE_ID_JOYPAD_START]  = (nk_rune)NK_KEY_ENTER;
-    menu.keyboardP1[RETRO_DEVICE_ID_JOYPAD_UP]     = (nk_rune)NK_KEY_UP;
-    menu.keyboardP1[RETRO_DEVICE_ID_JOYPAD_DOWN]   = (nk_rune)NK_KEY_DOWN;
-    menu.keyboardP1[RETRO_DEVICE_ID_JOYPAD_LEFT]   = (nk_rune)NK_KEY_LEFT;
-    menu.keyboardP1[RETRO_DEVICE_ID_JOYPAD_RIGHT]  = (nk_rune)NK_KEY_RIGHT;
+    menu.keyboardP1[RETRO_DEVICE_ID_JOYPAD_SELECT] = NK_CONSOLE_KEY_SHIFT;
+    menu.keyboardP1[RETRO_DEVICE_ID_JOYPAD_START]  = NK_CONSOLE_KEY_ENTER;
+    menu.keyboardP1[RETRO_DEVICE_ID_JOYPAD_UP]     = NK_CONSOLE_KEY_UP;
+    menu.keyboardP1[RETRO_DEVICE_ID_JOYPAD_DOWN]   = NK_CONSOLE_KEY_DOWN;
+    menu.keyboardP1[RETRO_DEVICE_ID_JOYPAD_LEFT]   = NK_CONSOLE_KEY_LEFT;
+    menu.keyboardP1[RETRO_DEVICE_ID_JOYPAD_RIGHT]  = NK_CONSOLE_KEY_RIGHT;
     menu.keyboardP1[RETRO_DEVICE_ID_JOYPAD_A]      = (nk_rune)'X';
     menu.keyboardP1[RETRO_DEVICE_ID_JOYPAD_X]      = (nk_rune)'S';
     menu.keyboardP1[RETRO_DEVICE_ID_JOYPAD_L]      = (nk_rune)'Q';
@@ -1349,26 +1414,33 @@ LibretroMenu* InitLibretroMenu(void) {
     menu.keyboardP1[RETRO_DEVICE_ID_JOYPAD_R2]     = (nk_rune)'R';
     menu.keyboardP1[RETRO_DEVICE_ID_JOYPAD_L3]     = (nk_rune)'D';
     menu.keyboardP1[RETRO_DEVICE_ID_JOYPAD_R3]     = (nk_rune)'F';
+
+    // Font
     menu.font = LoadFontFromNuklear(fontSize);
     if (!IsFontValid(menu.font)) {
+        TraceLog(LOG_ERROR, "LIBRETRO: Error loading menu font");
         return NULL;
     }
 
+    // Nuklear
     menu.ctx = InitNuklearEx(menu.font, (float)fontSize);
-    //menu.ctx = InitNuklear(32);
     if (!menu.ctx) {
+        TraceLog(LOG_ERROR, "LIBRETRO: Error building Nuklear menu");
         UnloadFont(menu.font);
         return NULL;
     }
 
+    // Nuklear Console
     menu.console = nk_console_init(menu.ctx);
     if (!menu.console) {
         UnloadFont(menu.font);
         UnloadNuklear(menu.ctx);
         menu.ctx = NULL;
+        TraceLog(LOG_ERROR, "LIBRETRO: Error building Nuklear menu");
         return NULL;
     }
 
+    // Gamepads
     nk_gamepad_init(&menu.gamepads, menu.ctx, (void*)&menu.console);
     nk_console_set_gamepads(menu.console, &menu.gamepads);
 
@@ -1378,6 +1450,8 @@ LibretroMenu* InitLibretroMenu(void) {
 #ifdef RAYLIB_LIBRETRO_CONFIG_H
     menu.cfg = rlconfig_load(FileExists(RAYLIB_LIBRETRO_CFG_FILE) ? RAYLIB_LIBRETRO_CFG_FILE : NULL);
 #endif
+
+    // Directories
     TextCopy(menu.coreDirectory, "cores");
     TextCopy(menu.saveDirectory, "saves");
     TextCopy(menu.systemDirectory, "system");
@@ -1388,6 +1462,8 @@ LibretroMenu* InitLibretroMenu(void) {
     TextCopy(menu.saveDirectory,   "/userdata/saves");
     TextCopy(menu.systemDirectory, "/userdata/system");
 #endif
+
+    // Menu Settings
     LoadLibretroMenuSettings();
     LibretroApplyDirectories();
     ScanLibretroCoreDirectory();
@@ -1556,23 +1632,23 @@ LibretroMenu* InitLibretroMenu(void) {
                 "None|Select + Start|L1 + R1|L2 + R2|L3 + R3|Down + Select",
                 '|', &menu.menuComboIndex);
             menuCombo->tooltip = "Controller button combination to toggle the menu";
-            nk_console_input(keysMenu, "Screenshot", -1, NULL, &menu.gamepadScreenshot, &menu.keyScreenshot, NULL);
-            nk_console_input(keysMenu, "Rewind", -1, NULL, &menu.gamepadRewind, &menu.keyRewind, NULL);
-            nk_console_input(keysMenu, "Menu", -1, NULL, &menu.gamepadMenu, &menu.keyMenu, NULL);
-            nk_console_input(keysMenu, "Save State", -1, NULL, &menu.gamepadSaveState, &menu.keySaveState, NULL);
-            nk_console_input(keysMenu, "Load State", -1, NULL, &menu.gamepadLoadState, &menu.keyLoadState, NULL);
-            nk_console_input(keysMenu, "Prev Slot", -1, NULL, &menu.gamepadPrevSlot, &menu.keyPrevSlot, NULL);
-            nk_console_input(keysMenu, "Next Slot", -1, NULL, &menu.gamepadNextSlot, &menu.keyNextSlot, NULL);
-            nk_console_input(keysMenu, "Fullscreen", -1, NULL, &menu.gamepadFullscreen, &menu.keyFullscreen, NULL);
-            nk_console_input(keysMenu, "Previous Shader", -1, NULL, &menu.gamepadPrevShader, &menu.keyPrevShader, NULL);
-            nk_console_input(keysMenu, "Next Shader", -1, NULL, &menu.gamepadNextShader, &menu.keyNextShader, NULL);
-            nk_console_input(keysMenu, "Reset", -1, NULL, &menu.gamepadReset, &menu.keyReset, NULL);
-            nk_console_input(keysMenu, "Quit", -1, NULL, &menu.gamepadQuit, &menu.keyQuit, NULL);
-            nk_console_input(keysMenu, "Volume Up", -1, NULL, &menu.gamepadVolumeUp, &menu.keyVolumeUp, NULL);
-            nk_console_input(keysMenu, "Volume Down", -1, NULL, &menu.gamepadVolumeDown, &menu.keyVolumeDown, NULL);
-            nk_console_input(keysMenu, "Mute", -1, NULL, &menu.gamepadMute, &menu.keyMute, NULL);
-            nk_console_input(keysMenu, "Fast Forward", -1, NULL, &menu.gamepadFastForward, &menu.keyFastForward, NULL);
-            nk_console_input(keysMenu, "Slow Motion", -1, NULL, &menu.gamepadSlowMotion, &menu.keySlowMotion, NULL);
+            LibretroMenuAddHotkey(keysMenu, "Screenshot", &menu.gamepadScreenshot, &menu.keyScreenshot);
+            LibretroMenuAddHotkey(keysMenu, "Rewind", &menu.gamepadRewind, &menu.keyRewind);
+            LibretroMenuAddHotkey(keysMenu, "Menu", &menu.gamepadMenu, &menu.keyMenu);
+            LibretroMenuAddHotkey(keysMenu, "Save State", &menu.gamepadSaveState, &menu.keySaveState);
+            LibretroMenuAddHotkey(keysMenu, "Load State", &menu.gamepadLoadState, &menu.keyLoadState);
+            LibretroMenuAddHotkey(keysMenu, "Prev Slot", &menu.gamepadPrevSlot, &menu.keyPrevSlot);
+            LibretroMenuAddHotkey(keysMenu, "Next Slot", &menu.gamepadNextSlot, &menu.keyNextSlot);
+            LibretroMenuAddHotkey(keysMenu, "Fullscreen", &menu.gamepadFullscreen, &menu.keyFullscreen);
+            LibretroMenuAddHotkey(keysMenu, "Previous Shader", &menu.gamepadPrevShader, &menu.keyPrevShader);
+            LibretroMenuAddHotkey(keysMenu, "Next Shader", &menu.gamepadNextShader, &menu.keyNextShader);
+            LibretroMenuAddHotkey(keysMenu, "Reset", &menu.gamepadReset, &menu.keyReset);
+            LibretroMenuAddHotkey(keysMenu, "Quit", &menu.gamepadQuit, &menu.keyQuit);
+            LibretroMenuAddHotkey(keysMenu, "Volume Up", &menu.gamepadVolumeUp, &menu.keyVolumeUp);
+            LibretroMenuAddHotkey(keysMenu, "Volume Down", &menu.gamepadVolumeDown, &menu.keyVolumeDown);
+            LibretroMenuAddHotkey(keysMenu, "Mute", &menu.gamepadMute, &menu.keyMute);
+            LibretroMenuAddHotkey(keysMenu, "Fast Forward", &menu.gamepadFastForward, &menu.keyFastForward);
+            LibretroMenuAddHotkey(keysMenu, "Slow Motion", &menu.gamepadSlowMotion, &menu.keySlowMotion);
         }
 
         // Keyboard Controls (Player 1)
@@ -2084,7 +2160,7 @@ static void LibretroMenuUpdateConfig(void) {
 
 static void LibretroMenuApplyKeyboardPlayer1(void) {
     for (int i = 0; i < 16; i++) {
-        LIBRETRO.keyboardPlayer1[i] = (int)NuklearKeyToKeyboardKey(menu.keyboardP1[i]);
+        LIBRETRO.keyboardPlayer1[i] = (int)LibretroHotkeyToKeyboardKey(menu.keyboardP1[i]);
     }
 }
 
@@ -2249,7 +2325,7 @@ static bool LoadLibretroMenuSettings(void) {
     menu.keyNextShader  = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyNextShader",  (int)menu.keyNextShader);
     menu.keyReset       = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyReset",       (int)menu.keyReset);
     menu.keyQuit       = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyQuit",       (int)menu.keyQuit);
-    SetExitKey(NuklearKeyToKeyboardKey(menu.keyQuit));
+    SetExitKey(LibretroHotkeyToKeyboardKey(menu.keyQuit));
     menu.keyVolumeUp    = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyVolumeUp",    (int)menu.keyVolumeUp);
     menu.keyVolumeDown  = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyVolumeDown",  (int)menu.keyVolumeDown);
     menu.keyMute        = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", "keyMute",        (int)menu.keyMute);
@@ -2381,10 +2457,13 @@ static nk_bool LibretroHotkeyGPPressed(enum nk_gamepad_button btn) {
     return btn != NK_GAMEPAD_BUTTON_INVALID && nk_gamepad_is_button_pressed(&menu.gamepads, -1, btn);
 }
 
-void UpdateLibretroMenu(void) {
+void UpdateLibretroMenu(void) {// If there is no menu, skip.
     if (menu.ctx == NULL) {
         return;
     }
+
+    // Update the gamepad state, so that menu inputs can still be found.
+    nk_gamepad_update(nk_console_get_gamepads(menu.console));
 
     // Menu Guide Button
     if (IsGamepadButtonReleased(0, GAMEPAD_BUTTON_MIDDLE) ||
@@ -2402,7 +2481,7 @@ void UpdateLibretroMenu(void) {
     }
 
     // Menu Key
-    if ((IsKeyReleased(NuklearKeyToKeyboardKey(menu.keyMenu)) || LibretroHotkeyGPReleased(menu.gamepadMenu)) && !menu.active) {
+    if ((IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyMenu)) || LibretroHotkeyGPReleased(menu.gamepadMenu)) && !menu.active) {
         ShowLibretroMenu();
     }
 
@@ -2463,7 +2542,6 @@ void UpdateLibretroMenu(void) {
     }
 
     // Input & Update
-    nk_gamepad_update(nk_console_get_gamepads(menu.console));
     UpdateNuklear(menu.ctx);
 
     // Render


### PR DESCRIPTION
Adds gamepad button bindings for all hotkey actions alongside existing keyboard bindings. Each action in the Hot Keys menu now has a corresponding gamepad input widget. Fixes #247