### PR TITLE
Emscripten: open file picker on Load Game click

### DIFF
--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -73,9 +73,11 @@ extern struct android_app *GetAndroidApp(void);
 EMSCRIPTEN_KEEPALIVE
 bool LoadLibretroGameFromJS(const char* gameFile) {
     if (gameFile == NULL || gameFile[0] == '\0') return false;
-    if (IsLibretroReady()) {
-        return LoadLibretroGameFromPhysFS(gameFile);
-    }
+    // Save the SRAM, and close the game prior to loading the new one.
+    MenuSaveGameSRAM();
+    CloseLibretro();
+
+    // Load the game through the menu system.
     return MenuLoadGame(gameFile);
 }
 

--- a/bin/shell.html
+++ b/bin/shell.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en-us">
   <head>
     <meta charset="utf-8">

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -185,17 +185,23 @@ static void LibretroFlushPersistentStorage(void) {
 }
 
 EM_JS(void, LibretroMenuEmscriptenOpenFilePicker, (void), {
-    var input = document.createElement('input');
+    // Leverage an input element to pick a file.
+    let input = document.createElement('input');
     input.type = 'file';
     input.onchange = function(e) {
-        var file = e.target.files[0];
+        let file = e.target.files[0];
         if (!file) return;
-        var reader = new FileReader();
+
+        // Read in the file
+        let reader = new FileReader();
         reader.onload = function() {
-            var uint8Array = new Uint8Array(reader.result);
+            // Save the file to the internal file system.
+            let uint8Array = new Uint8Array(reader.result);
             FS.writeFile(file.name, uint8Array);
-            var lengthBytes = lengthBytesUTF8(file.name) + 1;
-            var ptr = _malloc(lengthBytes);
+
+            // Grab the filename, and ask raylib-libreto to load it.
+            let lengthBytes = lengthBytesUTF8(file.name) + 1;
+            let ptr = _malloc(lengthBytes);
             stringToUTF8(file.name, ptr, lengthBytes);
             Module._LoadLibretroGameFromJS(ptr);
             _free(ptr);
@@ -206,14 +212,14 @@ EM_JS(void, LibretroMenuEmscriptenOpenFilePicker, (void), {
 });
 
 static void LibretroMenuEmscriptenLoadGameClicked(nk_console* widget, void* user_data) {
-    (void)widget;
     (void)user_data;
+    (void)widget;
+    TraceLog(LOG_INFO, "LIBRETRO: Opening the file dialog");
     LibretroMenuEmscriptenOpenFilePicker();
 }
-
 #else
 #define LibretroFlushPersistentStorage() ((void)0)
-#endif
+#endif /* __EMSCRIPTEN__ */
 
 #define RAYLIB_NUKLEAR_IMPLEMENTATION
 #include "../vendor/raylib-nuklear/include/raylib-nuklear.h"

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -183,6 +183,34 @@ static void LibretroFlushPersistentStorage(void) {
         });
     });
 }
+
+EM_JS(void, LibretroMenuEmscriptenOpenFilePicker, (void), {
+    var input = document.createElement('input');
+    input.type = 'file';
+    input.onchange = function(e) {
+        var file = e.target.files[0];
+        if (!file) return;
+        var reader = new FileReader();
+        reader.onload = function() {
+            var uint8Array = new Uint8Array(reader.result);
+            FS.writeFile(file.name, uint8Array);
+            var lengthBytes = lengthBytesUTF8(file.name) + 1;
+            var ptr = _malloc(lengthBytes);
+            stringToUTF8(file.name, ptr, lengthBytes);
+            Module._LoadLibretroGameFromJS(ptr);
+            _free(ptr);
+        };
+        reader.readAsArrayBuffer(file);
+    };
+    input.click();
+});
+
+static void LibretroMenuEmscriptenLoadGameClicked(nk_console* widget, void* user_data) {
+    (void)widget;
+    (void)user_data;
+    LibretroMenuEmscriptenOpenFilePicker();
+}
+
 #else
 #define LibretroFlushPersistentStorage() ((void)0)
 #endif
@@ -904,9 +932,11 @@ static void MenuCoreDirChanged(nk_console* widget, void* user_data) {
 
 static void MenuContentDirChanged(nk_console* widget, void* user_data) {
     MenuDirChanged(widget, user_data);
+#ifndef __EMSCRIPTEN__
     if (menu.loadGameWidget && menu.fileBrowserStartDirectory[0] != '\0') {
         nk_console_file_set_directory(menu.loadGameWidget, menu.fileBrowserStartDirectory);
     }
+#endif
 }
 
 #define LIBRETRO_CORE_CACHE_SECTION "core_cache"
@@ -1372,11 +1402,15 @@ LibretroMenu* InitLibretroMenu(void) {
     }
 
     // Load Game
+#ifdef __EMSCRIPTEN__
+    menu.loadGameWidget = nk_console_button_onclick(menu.console, "Load Game", &LibretroMenuEmscriptenLoadGameClicked);
+#else
     menu.loadGameWidget = nk_console_file_action(menu.console, "Load Game", menu.loadGamePath, RAYLIB_LIBRETRO_VFS_MAX_PATH);
     nk_console_add_event_handler(menu.loadGameWidget, NK_CONSOLE_EVENT_CHANGED, &MenuGameFileChanged, menu.loadGamePath, NULL);
     if (menu.fileBrowserStartDirectory[0] != '\0') {
         nk_console_file_set_directory(menu.loadGameWidget, menu.fileBrowserStartDirectory);
     }
+#endif
     LibretroMenuUpdateLoadGameFilter(&menu);
 
     // Close Game
@@ -1816,6 +1850,10 @@ static unsigned int LibretroMenuAddExtension(char* list, unsigned int len, size_
 }
 
 static void LibretroMenuUpdateLoadGameFilter(LibretroMenu* m) {
+#ifdef __EMSCRIPTEN__
+    (void)m;
+    return;
+#endif
     if (!m || !m->loadGameWidget) return;
 
     // Collect the unique set of extensions from every cached core. Cores


### PR DESCRIPTION
Replaces the desktop file browser with a native browser file input dialog in emscripten builds. The selected file is written to the virtual filesystem and loaded via `Module._LoadLibretroGameFromJS`. Fixes #249