### PR TITLE
Stamp sw.js cache version with release tag

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -174,6 +174,8 @@ jobs:
         run: cmake --build build --parallel
       - name: Install
         run: cmake --install build
+      - name: Stamp service worker version
+        run: sed -i "s/__VERSION__/${{ github.ref_name }}/g" install/sw.js
       - name: Package
         run: |
           cd install

--- a/bin/sw.js
+++ b/bin/sw.js
@@ -8,8 +8,9 @@
 *
 **********************************************************************************************/
 
-// Bump CACHE_VERSION whenever the app shell changes to evict the old cache.
-const CACHE_VERSION = 'raylib-libretro-v1';
+// CACHE_VERSION is replaced at release time with the tag (e.g. v1.2.3)
+// so each deployment evicts the previous cache on mobile devices.
+const CACHE_VERSION = 'raylib-libretro-__VERSION__';
 
 // Best-effort precache of the app shell. Big binaries (index.wasm / index.data)
 // are cached lazily on first fetch so a single 404 can't break installation.


### PR DESCRIPTION
Each release now injects the git tag into the service worker's `CACHE_VERSION`, forcing mobile browsers to evict the old cache and fetch the new build.

Fixes #253