### PR TITLE
Add version to release asset filenames

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -26,11 +26,11 @@ jobs:
       - name: Package
         run: |
           cd install
-          zip -r ../raylib-libretro-linux-amd64.zip .
+          zip -r ../raylib-libretro-${{ github.ref_name }}-linux-amd64.zip .
       - name: Upload
         uses: softprops/action-gh-release@v2
         with:
-          files: raylib-libretro-linux-amd64.zip
+          files: raylib-libretro-${{ github.ref_name }}-linux-amd64.zip
           fail_on_unmatched_files: true
 
   build-linux-arm64:
@@ -50,11 +50,11 @@ jobs:
       - name: Package
         run: |
           cd install
-          zip -r ../raylib-libretro-linux-arm64.zip .
+          zip -r ../raylib-libretro-${{ github.ref_name }}-linux-arm64.zip .
       - name: Upload
         uses: softprops/action-gh-release@v2
         with:
-          files: raylib-libretro-linux-arm64.zip
+          files: raylib-libretro-${{ github.ref_name }}-linux-arm64.zip
           fail_on_unmatched_files: true
 
   build-windows:
@@ -70,11 +70,11 @@ jobs:
       - name: Install
         run: cmake --install build --config Release
       - name: Package
-        run: Compress-Archive -Path install\* -DestinationPath raylib-libretro-windows-amd64.zip
+        run: Compress-Archive -Path install\* -DestinationPath raylib-libretro-${{ github.ref_name }}-windows-amd64.zip
       - name: Upload
         uses: softprops/action-gh-release@v2
         with:
-          files: raylib-libretro-windows-amd64.zip
+          files: raylib-libretro-${{ github.ref_name }}-windows-amd64.zip
           fail_on_unmatched_files: true
 
   build-macos:
@@ -92,11 +92,11 @@ jobs:
       - name: Package
         run: |
           cd install
-          zip -r ../raylib-libretro-macos-arm64.zip .
+          zip -r ../raylib-libretro-${{ github.ref_name }}-macos-arm64.zip .
       - name: Upload
         uses: softprops/action-gh-release@v2
         with:
-          files: raylib-libretro-macos-arm64.zip
+          files: raylib-libretro-${{ github.ref_name }}-macos-arm64.zip
           fail_on_unmatched_files: true
 
   build-macos-x86_64:
@@ -114,11 +114,11 @@ jobs:
       - name: Package
         run: |
           cd install
-          zip -r ../raylib-libretro-macos-x86_64.zip .
+          zip -r ../raylib-libretro-${{ github.ref_name }}-macos-x86_64.zip .
       - name: Upload
         uses: softprops/action-gh-release@v2
         with:
-          files: raylib-libretro-macos-x86_64.zip
+          files: raylib-libretro-${{ github.ref_name }}-macos-x86_64.zip
           fail_on_unmatched_files: true
 
   build-android:
@@ -149,11 +149,11 @@ jobs:
         run: ./gradlew assembleRelease -PappVersionName="${TAG#v}" -PappVersionCode="$RUN_NUMBER"
       # The action names the asset after the file, so rename to the release name.
       - name: Rename APK
-        run: cp android/app/build/outputs/apk/release/app-release.apk raylib-libretro-android-arm64.apk
+        run: cp android/app/build/outputs/apk/release/app-release.apk raylib-libretro-${{ github.ref_name }}-android-arm64.apk
       - name: Upload
         uses: softprops/action-gh-release@v2
         with:
-          files: raylib-libretro-android-arm64.apk
+          files: raylib-libretro-${{ github.ref_name }}-android-arm64.apk
           fail_on_unmatched_files: true
 
   build-web:
@@ -179,11 +179,11 @@ jobs:
       - name: Package
         run: |
           cd install
-          zip -r ../raylib-libretro-web-wasm32.zip .
+          zip -r ../raylib-libretro-${{ github.ref_name }}-web-wasm32.zip .
       - name: Upload Release Asset
         uses: softprops/action-gh-release@v2
         with:
-          files: raylib-libretro-web-wasm32.zip
+          files: raylib-libretro-${{ github.ref_name }}-web-wasm32.zip
           fail_on_unmatched_files: true
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
Stamps `${{ github.ref_name }}` into every release artifact name so downloads are unambiguous by version. Fixes #252