### PR TITLE
Speed up Screenshots

### DIFF
--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -578,23 +578,31 @@ bool Update(void* userData) {
     if (!menu.active) {
 
         // Screenshot
-        if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyScreenshot)) || LibretroHotkeyGPReleased(menu.gamepadScreenshot)) {
+        if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyScreenshot)) || LibretroHotkeyGPReleased(menu.gamepadScreenshot) && IsLibretroGameReady()) {
             const char* screenshotsDir = GetLibretroDirectory(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY);
             const char* contentName = GetLibretroContentName();
             const char* baseName = (contentName && contentName[0] != '\0') ? contentName : "screenshot";
-            bool taken = false;
+            bool foundSlot = false;
             for (int i = 1; i < 1000; i++) {
                 const char* screenshotName = TextFormat("%s/%s-%i.png", screenshotsDir, baseName, i);
                 if (!FileExists(screenshotName)) {
-                    Image screenshot = LoadImageFromTexture(GetLibretroTexture());
-                    ExportImage(screenshot, screenshotName);
-                    UnloadImage(screenshot);
-                    SetLibretroMessage(TextFormat("Screenshot: %s", screenshotName), 2.0);
-                    taken = true;
+                    //Image screenshot = LoadImageFromScreen();
+                    //Image screenshot = LoadImageFromTexture(GetLibretroTexture());
+                    Image screenshot = LoadImageFromLibretro();
+                    foundSlot = true;
+                    if (ExportImage(screenshot, screenshotName)) {
+                        SetLibretroMessage(TextFormat("Screenshot: %s", screenshotName), 2.0);
+                    }
+                    else {
+                        SetLibretroMessage(TextFormat("Screenshot failed: %s", screenshotName), 2.0);
+                    }
+                    if (screenshot.data != NULL) {
+                        UnloadImage(screenshot);
+                    }
                     break;
                 }
             }
-            if (!taken) {
+            if (!foundSlot) {
                 SetLibretroMessage("Screenshot slots full", 2.0);
             }
         }

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -586,7 +586,7 @@ bool Update(void* userData) {
             for (int i = 1; i < 1000; i++) {
                 const char* screenshotName = TextFormat("%s/%s-%i.png", screenshotsDir, baseName, i);
                 if (!FileExists(screenshotName)) {
-                    Image screenshot = LoadImageFromScreen();
+                    Image screenshot = LoadImageFromTexture(GetLibretroTexture());
                     ExportImage(screenshot, screenshotName);
                     UnloadImage(screenshot);
                     SetLibretroMessage(TextFormat("Screenshot: %s", screenshotName), 2.0);

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -580,11 +580,15 @@ bool Update(void* userData) {
         // Screenshot
         if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyScreenshot)) || LibretroHotkeyGPReleased(menu.gamepadScreenshot)) {
             const char* screenshotsDir = GetLibretroDirectory(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY);
+            const char* contentName = GetLibretroContentName();
+            const char* baseName = (contentName && contentName[0] != '\0') ? contentName : "screenshot";
             bool taken = false;
             for (int i = 1; i < 1000; i++) {
-                const char* screenshotName = TextFormat("%s/screenshot-%i.png", screenshotsDir, i);
+                const char* screenshotName = TextFormat("%s/%s-%i.png", screenshotsDir, baseName, i);
                 if (!FileExists(screenshotName)) {
-                    TakeScreenshot(screenshotName);
+                    Image screenshot = LoadImageFromScreen();
+                    ExportImage(screenshot, screenshotName);
+                    UnloadImage(screenshot);
                     SetLibretroMessage(TextFormat("Screenshot: %s", screenshotName), 2.0);
                     taken = true;
                     break;

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -73,6 +73,7 @@ static unsigned GetLibretroWidth(void);
 static unsigned GetLibretroHeight(void);
 static int GetLibretroRotation(void);
 static Texture2D GetLibretroTexture(void);
+static Image LoadImageFromLibretro();
 static bool IsLibretroGameRequired(void);
 static bool ResetLibretro(void);
 static bool SetLibretroCheat(unsigned index, bool enabled, const char* code);
@@ -3264,6 +3265,36 @@ static float GetLibretroAspectRatio(void) {
  */
 static Texture2D GetLibretroTexture(void) {
     return LIBRETRO.core.texture;
+}
+
+/**
+ * Load an image of the current screen of the core framebuffer.
+ *
+ * The image must be called with UnloadImage() to clear the memory.
+ *
+ * @return Essentially a screenshot of the libretro game. Empty image otherwise.
+ */
+static Image LoadImageFromLibretro() {
+    if (!IsLibretroGameReady() || LIBRETRO.core.frameBuffer == NULL || LIBRETRO.core.frameBufferSize == 0) {
+        Image empty = {0};
+        return empty;
+    }
+
+    Image image = {0};
+    image.width = (int)LIBRETRO.core.width;
+    image.height = (int)LIBRETRO.core.height;
+    image.mipmaps = 1;
+    image.format = LibretroRetroPixelFormatToPixelFormat(LIBRETRO.core.pixelFormat);
+
+    // Copy the pre-converted frame buffer into a newly allocated image data buffer.
+    image.data = MemAlloc((unsigned int)LIBRETRO.core.frameBufferSize);
+    if (image.data == NULL) {
+        Image empty = {0};
+        return empty;
+    }
+    memcpy(image.data, LIBRETRO.core.frameBuffer, LIBRETRO.core.frameBufferSize);
+
+    return image;
 }
 
 /**


### PR DESCRIPTION
Replaces `TakeScreenshot()` with `LoadImageFromTexture(GetLibretroTexture())` to capture only the game's framebuffer (no UI overlay), and names the file after the loaded content when available. Fixes #254