### PR TITLE
Add RETRO_DEVICE_JOYPAD_MULTITAP support

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -97,7 +97,7 @@ A roadmap of some interesting features to consider.
 - [ ] Per-core / per-game input remap files (`.rmp` compatible)
 - [ ] Mouse (`RETRO_DEVICE_MOUSE`) fully wired through
 - [ ] Light gun (`RETRO_DEVICE_LIGHTGUN`) with cursor capture
-- [ ] Multitap (`RETRO_DEVICE_JOYPAD_MULTITAP`)
+- [x] Multitap (`RETRO_DEVICE_JOYPAD_MULTITAP`)
 - [ ] On-screen overlay touch layouts (PNG, auto-scale, snap-to-edges)
 - [ ] Analog stick deadzone + sensitivity per port
 - [ ] Game-Focus mode (pass all keys through, ignore hotkeys)

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -196,10 +196,11 @@ static Font GetLibretroMenuFont(void);
 #include <emscripten.h>
 #include <emscripten/html5.h>
 
-// Push MEMFS -> IDBFS so any writes under /userdata survive a page reload.
-// Called at every commit point (settings save, save state, etc.) because
-// Firefox aggressively kills the JS context on tab close and won't reliably
-// complete an async syncfs queued from pagehide.
+/**
+ * Push the memory file system to IBDFS so that any writes under /userdata are captured.
+ *
+ * This is called at commit points, like when the user is leaving the settings menu, or saving the state.
+ */
 static void LibretroFlushPersistentStorage(void) {
     EM_ASM({
         FS.syncfs(false, function (err) {
@@ -248,9 +249,7 @@ static void LibretroMenuEmscriptenLoadGameClicked(nk_console* widget, void* user
 #define RAYLIB_NUKLEAR_IMPLEMENTATION
 #include "../vendor/raylib-nuklear/include/raylib-nuklear.h"
 
-// rlGetVersion() for the About screen's renderer line. Header-only include
-// (no RLGL_IMPLEMENTATION); the symbol is provided by the linked raylib.
-#include "rlgl.h"
+#include "rlgl.h" // rlGetVersion()
 
 #define NK_GAMEPAD_IMPLEMENTATION
 #define NK_GAMEPAD_RAYLIB
@@ -272,8 +271,9 @@ static void LibretroMenuEmscriptenLoadGameClicked(nk_console* widget, void* user
 #define RAYLIB_LIBRETRO_CFG_FILE "raylib-libretro.cfg"
 #endif
 
-// App version. Defined by the build (CMake passes the project version); falls
-// back to "dev" for ad-hoc builds that include this header directly.
+/**
+ * The version is set by a define, defaults to DEV.
+ */
 #ifndef RAYLIB_LIBRETRO_VERSION
 #define RAYLIB_LIBRETRO_VERSION "dev"
 #endif
@@ -293,12 +293,16 @@ static void LibretroMenuEmscriptenLoadGameClicked(nk_console* widget, void* user
 #define RAYLIB_LIBRETRO_PLATFORM "Unknown"
 #endif
 
-// Number of increments a float settings slider divides its range into.
+/**
+ * Number of increments a float settings slider divides its range into.
+ */
 #ifndef RAYLIB_LIBRETRO_MENU_SLIDER_STEPS
 #define RAYLIB_LIBRETRO_MENU_SLIDER_STEPS 20.0f
 #endif
 
-// Step size that divides [min, max] into RAYLIB_LIBRETRO_MENU_SLIDER_STEPS steps.
+/**
+ * Step size that divides [min, max] into RAYLIB_LIBRETRO_MENU_SLIDER_STEPS steps.
+ */
 #define RAYLIB_LIBRETRO_MENU_SLIDER_STEP(min, max) (((max) - (min)) / RAYLIB_LIBRETRO_MENU_SLIDER_STEPS)
 
 #if defined(__cplusplus)
@@ -326,6 +330,9 @@ static KeyboardKey LibretroHotkeyToKeyboardKey(nk_rune key) {
     return NuklearKeyToKeyboardKey(special != NK_KEY_NONE ? (nk_rune)special : key);
 }
 
+/**
+ * Menu callback when one of the settings has been changed.
+ */
 static void LibretroMenuSettingChanged(nk_console* widget, void* user_data) {
     (void)widget;
     (void)user_data;
@@ -661,8 +668,9 @@ static void SetLibretroMenuStyle(LibretroMenuStyle style) {
     }
 }
 
-// Map the "FPS" combobox index to a SetTargetFPS() value. "Auto" follows the
-// monitor refresh rate; "Unlimited" returns 0 (no cap).
+/**
+ * Make the FPS combobox index to a SetTargetFPS() call. Auto uses the monitor refresh rate.
+ */
 static int LibretroMenuResolveTargetFps(void) {
     switch (menu.fpsIndex) {
         case 1: return 30;
@@ -679,18 +687,18 @@ static int LibretroMenuResolveTargetFps(void) {
     }
 }
 
-// Apply the current VSYNC + FPS selection to the window. Emulation speed is
-// driven by the time accumulator in UpdateLibretro(), so these only govern how
-// often the frontend renders/polls; "Auto" doubles as a busy-loop safety cap
-// when a compositor or driver ignores the vsync hint.
+/**
+ * Apply the mouse cursor show/hide settings.
+ */
 static void LibretroMenuApplyCursorSettings(void) {
     if (menu.active) {
-        ShowCursor();
-        EnableCursor();
-    } else {
-        if (menu.hideCursor) HideCursor(); else ShowCursor();
-        if (menu.lockCursor) DisableCursor(); else EnableCursor();
+        if (menu.hideCursor) ShowCursor();
+        if (menu.lockCursor) EnableCursor();
+        return;
     }
+
+    if (menu.hideCursor) HideCursor();
+    if (menu.lockCursor) DisableCursor();
 }
 
 void ShowLibretroMenu(void) {
@@ -715,6 +723,9 @@ bool IsLibretroMenuShown(void) {
     return menu.active;
 }
 
+/**
+ * Applies the video VSYNC/FPS settings.
+ */
 static void LibretroMenuApplyVideoSettings(void) {
     if (menu.vsync) {
         SetWindowState(FLAG_VSYNC_HINT);
@@ -770,7 +781,9 @@ static void LibretroMenuFullscreenChanged(nk_console* widget, void* user_data) {
 #endif
 }
 
-// Human-readable name for raylib's active rendering backend (rlgl.h enum).
+/**
+ * Human-readable name for raylib's active rendering backend (rlgl.h enum).
+ */
 static const char* LibretroMenuRendererName(void) {
     switch (rlGetVersion()) {
         case RL_OPENGL_11:       return "OpenGL 1.1";
@@ -784,7 +797,9 @@ static const char* LibretroMenuRendererName(void) {
     }
 }
 
-// Human-readable name for the core's framebuffer pixel format.
+/**
+ * Human-readable name for the core's framebuffer pixel format.
+ */
 static const char* LibretroMenuPixelFormatName(enum retro_pixel_format fmt) {
     switch (fmt) {
         case RETRO_PIXEL_FORMAT_0RGB1555: return "0RGB1555";
@@ -919,30 +934,17 @@ static void LibretroMenuResetCheatsClicked(nk_console* widget, void* user_data) 
     }
 }
 
-// Fired when the user navigates back from Settings or Core Options. This is
-// the natural commit point: anything the user just touched in those submenus
-// is now part of the loaded state, so write the cfg out and flush IDBFS so
-// the change survives a page reload / tab close on the web.
+/**
+ * Fired when the user navigates back from Settings or Core Options.
+ *
+ * This is the natural commit point: anything the user just touched in those submenus is now part of the loaded state, so write the cfg out and flush IDBFS so the change survives a page reload / tab close on the web.
+ */
 static void MenuCommitSettings(nk_console* widget, void* user_data) {
     NK_UNUSED(widget);
     NK_UNUSED(user_data);
     LibretroMenuApplyKeyboardPlayer1();
     SaveLibretroAllSettings();
 }
-
-// Close Game has been removed for now, since it's not really needed.
-// static void MenuCloseGameClicked(nk_console* widget, void* user_data) {
-//     NK_UNUSED(widget);
-//     NK_UNUSED(user_data);
-//     if (!IsLibretroReady()) {
-//         return;
-//     }
-//     if (IsLibretroGameReady()) {
-//         UnloadLibretroGame();
-//     }
-//     CloseLibretro();
-//     UpdateLibretroMenuVisibility();
-// }
 
 static void ScanLibretroCoreDirectory(void);
 
@@ -1807,8 +1809,11 @@ static bool LibretroMenuTokenIsFalsy(const char* tok) {
            TextIsEqual(tok, "0");
 }
 
-// Called when a core option combobox selection changes.
-// user_data is the option index cast to (void*).
+/**
+ * Called when a core option combobox selection changes.
+ *
+ * @param user_data The option index cast to (void*).
+ */
 static void LibretroMenuOptionChanged(nk_console* widget, void* user_data) {
     (void)widget;
     unsigned i = (unsigned)(uintptr_t)user_data;
@@ -1821,10 +1826,11 @@ static void LibretroMenuOptionChanged(nk_console* widget, void* user_data) {
     }
 }
 
-// Called when a core option boolean checkbox changes.
-// user_data is the option index cast to (void*). Writes back the actual token
-// the core declared (e.g. "on"/"off", "enabled"/"disabled") rather than
-// assuming a fixed pair, so non-"enabled|disabled" booleans work too.
+/**
+ * Called when a core option boolean checkbox changes.
+ *
+ * @param user_data The option index cast to (void*). Writes back the actual token the core declared (e.g. "on"/"off", "enabled"/"disabled") rather than assuming a fixed pair, so non-"enabled|disabled" booleans work too.
+ */
 static void LibretroMenuOptionCheckboxChanged(nk_console* widget, void* user_data) {
     (void)widget;
     unsigned i = (unsigned)(uintptr_t)user_data;
@@ -1857,9 +1863,11 @@ static int LibretroMenuFindTokenIndex(const char* str, const char* value) {
     return 0;
 }
 
-// Returns true if value is an exact token in the pipe-delimited list (e.g.
-// "a|b|c"). Unlike LibretroMenuFindTokenIndex, this distinguishes "not present"
-// from "present at index 0", so it can validate a saved option value.
+/**
+ * Returns true if value is an exact token in the pipe-delimited list (e.g. "a|b|c").
+ *
+ * Unlike LibretroMenuFindTokenIndex, this distinguishes "not present" from "present at index 0", so it can validate a saved option value.
+ */
 static bool LibretroMenuValueInList(const char* valuesList, const char* value) {
     const char* p = valuesList;
     while (p && *p) {
@@ -1875,8 +1883,11 @@ static bool LibretroMenuValueInList(const char* valuesList, const char* value) {
     return false;
 }
 
-// Returns true if the values are exactly a boolean pair (one truthy, one falsy
-// token in either order) — e.g. "enabled|disabled", "off|on", "true|false".
+/**
+ * Returns true if the values are exactly a boolean pair.
+ *
+ * One truthy, one falsy token in either order, like "enabled|disabled", "off|on", "true|false".
+ */
 static bool LibretroMenuIsBooleanOption(const char* valuesList) {
     if (!valuesList || !*valuesList) return false;
     char tok0[LIBRETRO_CORE_VARIABLE_VALUE_LEN] = {0};
@@ -1890,8 +1901,9 @@ static bool LibretroMenuIsBooleanOption(const char* valuesList) {
            (LibretroMenuTokenIsFalsy(tok0)  && LibretroMenuTokenIsTruthy(tok1));
 }
 
-// Returns the registered category index for option i, or -1 if it has no
-// category (or references a category the core never declared — treated flat).
+/**
+ * Returns the registered category index for option i, or -1 if it has no category (or references a category the core never declared — treated flat).
+ */
 static int LibretroMenuOptionCategory(unsigned i) {
     if (LIBRETRO.core.variableCategoryKeys[i][0] == '\0') return -1;
     for (unsigned c = 0; c < LIBRETRO.core.categoryCount; c++) {
@@ -1902,7 +1914,9 @@ static int LibretroMenuOptionCategory(unsigned i) {
     return -1;
 }
 
-// Build the checkbox/combobox widget for option i under the given parent node.
+/**
+ * Build the checkbox/combobox widget for option i under the given parent node.
+ */
 static void LibretroMenuBuildOptionWidget(LibretroMenu* m, nk_console* parent, unsigned i) {
     const char* label = TextLength(LIBRETRO.core.variableLabels[i]) > 0
         ? LIBRETRO.core.variableLabels[i]
@@ -1945,8 +1959,9 @@ static void LibretroMenuResetCoreOptionsClicked(nk_console* widget, void* user_d
     nk_console_navigate_back(widget->parent);
 }
 
-// Append an extension token to the pipe-separated list if it is not already
-// present and there is room. Returns the updated list length.
+/**
+ * Append an extension token to the pipe-separated list if it is not already present and there is room. Returns the updated list length.
+ */
 static unsigned int LibretroMenuAddExtension(char* list, unsigned int len, size_t cap,
                                              const char* tok, unsigned int tokLen) {
     if (tokLen == 0) return len;

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -2263,11 +2263,9 @@ bool LoadLibretroCoreOptions(void) {
 #endif
 }
 
-// Persist the per-port device selections for the current core. These live in a
-// dedicated "<core>.controllers" section, keyed by port, so they survive
-// independently of the core's option values (which occupy the bare "<core>"
-// section and get cleared/rewritten wholesale). Keyed by core because the
-// device ids are core-specific.
+/**
+ * Save the configured port devices to the config in [core.controllers]
+ */
 static bool SaveLibretroPortDevices(void) {
 #ifdef RAYLIB_LIBRETRO_CONFIG_H
     if (!menu.cfg) return false;
@@ -2277,9 +2275,6 @@ static bool SaveLibretroPortDevices(void) {
     const struct retro_controller_info* info = GetLibretroControllerInfo(&count);
     if (!info || count == 0) return false;
 
-    // Copy the section name into stable storage; rlconfig calls below use
-    // TextFormat for the keys, which rotates the same buffer pool. Sized to hold
-    // the longest possible libraryName (200) plus the suffix without overflow.
     char section[256];
     TextCopy(section, TextFormat("%s.controllers", coreName));
     rlconfig_clear_section(menu.cfg, section);
@@ -2309,8 +2304,7 @@ static bool LoadLibretroPortDevices(void) {
         if (info[port].num_types <= 1) continue;
         int saved = rlconfig_get_int(menu.cfg, section, TextFormat("port%u", port), -1);
         if (saved < 0) continue;
-        // Only apply a device the core still offers for this port; a core update
-        // may have renamed or dropped the saved device id.
+        // Only apply a device the core still offers for this port; a core update may have renamed or dropped the saved device id.
         for (unsigned i = 0; i < info[port].num_types; i++) {
             if (info[port].types[i].id == (unsigned)saved) {
                 SetLibretroPortDevice(port, (unsigned)saved);

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -77,6 +77,8 @@ typedef struct LibretroMenu {
     nk_console* optionsMenu;              // "Core Options" submenu node
     nk_console* controllersMenu;          // "Controllers" submenu node
     int portDeviceIndex[16];              // per-port combobox selection index
+    char portDeviceOptions[16][512];      // per-port pipe-separated device list (must outlive the combobox)
+    char portDeviceLabel[16][16];         // per-port "Port N" label (must outlive the combobox)
     nk_console* loadGameWidget;
     nk_console* saveStateButton;
     nk_console* loadStateButton;
@@ -176,6 +178,8 @@ void BuildLibretroMenuOptions(LibretroMenu* menu); // Populate "Core Options" wi
 void BuildLibretroMenuControllers(LibretroMenu* menu); // Populate "Controllers" with per-port device comboboxes.
 bool LoadLibretroCoreOptions(void);    // Apply saved core options from config to the loaded core.
 bool SaveLibretroAllSettings(void);    // Save menu settings + core options in a single file write.
+static bool SaveLibretroPortDevices(void); // Persist per-port device selections for the loaded core.
+static bool LoadLibretroPortDevices(void); // Apply saved per-port device selections for the loaded core.
 static Font GetLibretroMenuFont(void);
 
 #if defined(__cplusplus)
@@ -1258,6 +1262,7 @@ static bool MenuLoadGame(const char* gamePath) {
     }
 
     BuildLibretroMenuOptions(&menu);
+    LoadLibretroPortDevices();
     BuildLibretroMenuControllers(&menu);
     HideLibretroMenu();
     MenuLoadGameSRAM();
@@ -2118,11 +2123,13 @@ void BuildLibretroMenuControllers(LibretroMenu* m) {
     for (unsigned port = 0; port < count && port < 16; port++) {
         if (info[port].num_types <= 1) continue;
 
-        char options[512];
+        // nk_console_combobox stores pointers into these strings rather than
+        // copying them, so they must persist for the lifetime of the widget.
+        char* options = m->portDeviceOptions[port];
         options[0] = '\0';
         for (unsigned i = 0; i < info[port].num_types; i++) {
-            if (i > 0) strncat(options, "|", sizeof(options) - strlen(options) - 1);
-            strncat(options, info[port].types[i].desc, sizeof(options) - strlen(options) - 1);
+            if (i > 0) strncat(options, "|", sizeof(m->portDeviceOptions[port]) - strlen(options) - 1);
+            strncat(options, info[port].types[i].desc, sizeof(m->portDeviceOptions[port]) - strlen(options) - 1);
         }
 
         unsigned currentDevice = GetLibretroPortDevice(port);
@@ -2134,8 +2141,9 @@ void BuildLibretroMenuControllers(LibretroMenu* m) {
             }
         }
 
+        TextCopy(m->portDeviceLabel[port], TextFormat("Port %u", port + 1));
         nk_console* widget = nk_console_combobox(m->controllersMenu,
-            TextFormat("Port %u", port + 1), options, '|', &m->portDeviceIndex[port]);
+            m->portDeviceLabel[port], options, '|', &m->portDeviceIndex[port]);
         nk_console_add_event_handler(widget, NK_CONSOLE_EVENT_CHANGED,
             LibretroMenuPortDeviceChanged, (void*)(uintptr_t)port, NULL);
         anyWidget = true;
@@ -2255,6 +2263,69 @@ bool LoadLibretroCoreOptions(void) {
 #endif
 }
 
+// Persist the per-port device selections for the current core. These live in a
+// dedicated "<core>.controllers" section, keyed by port, so they survive
+// independently of the core's option values (which occupy the bare "<core>"
+// section and get cleared/rewritten wholesale). Keyed by core because the
+// device ids are core-specific.
+static bool SaveLibretroPortDevices(void) {
+#ifdef RAYLIB_LIBRETRO_CONFIG_H
+    if (!menu.cfg) return false;
+    const char* coreName = LIBRETRO.core.libraryName;
+    if (!coreName || !coreName[0]) return false;
+    unsigned count = 0;
+    const struct retro_controller_info* info = GetLibretroControllerInfo(&count);
+    if (!info || count == 0) return false;
+
+    // Copy the section name into stable storage; rlconfig calls below use
+    // TextFormat for the keys, which rotates the same buffer pool. Sized to hold
+    // the longest possible libraryName (200) plus the suffix without overflow.
+    char section[256];
+    TextCopy(section, TextFormat("%s.controllers", coreName));
+    rlconfig_clear_section(menu.cfg, section);
+    for (unsigned port = 0; port < count && port < 16; port++) {
+        if (info[port].num_types <= 1) continue;
+        rlconfig_set_int(menu.cfg, section, TextFormat("port%u", port), (int)GetLibretroPortDevice(port));
+    }
+    return true;
+#else
+    return false;
+#endif
+}
+
+static bool LoadLibretroPortDevices(void) {
+#ifdef RAYLIB_LIBRETRO_CONFIG_H
+    if (!menu.cfg) return false;
+    const char* coreName = LIBRETRO.core.libraryName;
+    if (!coreName || !coreName[0]) return false;
+    unsigned count = 0;
+    const struct retro_controller_info* info = GetLibretroControllerInfo(&count);
+    if (!info || count == 0) return false;
+
+    char section[256];
+    TextCopy(section, TextFormat("%s.controllers", coreName));
+    int loaded = 0;
+    for (unsigned port = 0; port < count && port < 16; port++) {
+        if (info[port].num_types <= 1) continue;
+        int saved = rlconfig_get_int(menu.cfg, section, TextFormat("port%u", port), -1);
+        if (saved < 0) continue;
+        // Only apply a device the core still offers for this port; a core update
+        // may have renamed or dropped the saved device id.
+        for (unsigned i = 0; i < info[port].num_types; i++) {
+            if (info[port].types[i].id == (unsigned)saved) {
+                SetLibretroPortDevice(port, (unsigned)saved);
+                loaded++;
+                break;
+            }
+        }
+    }
+    TraceLog(LOG_INFO, "MENU: Loaded %d controller port device(s) from %s", loaded, RAYLIB_LIBRETRO_CFG_FILE);
+    return loaded > 0;
+#else
+    return false;
+#endif
+}
+
 #ifdef __EMSCRIPTEN__
 EMSCRIPTEN_KEEPALIVE // expose to JS as Module._SaveLibretroAllSettings
 #endif
@@ -2269,6 +2340,7 @@ bool SaveLibretroAllSettings(void) {
             rlconfig_set(menu.cfg, coreName, LIBRETRO.core.variableKeys[i], LIBRETRO.core.variableValues[i]);
         }
     }
+    SaveLibretroPortDevices();
     bool ok = rlconfig_save(menu.cfg, RAYLIB_LIBRETRO_CFG_FILE);
     TraceLog(LOG_INFO, "MENU: Saved all settings to %s", RAYLIB_LIBRETRO_CFG_FILE);
     MenuSaveGameSRAM();

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -75,6 +75,8 @@ typedef struct LibretroMenu {
     nk_bool vsync;
     int fpsIndex;                         // index into the "FPS" combobox (Auto/30/60/120/144/240/Unlimited)
     nk_console* optionsMenu;              // "Core Options" submenu node
+    nk_console* controllersMenu;          // "Controllers" submenu node
+    int portDeviceIndex[16];              // per-port combobox selection index
     nk_console* loadGameWidget;
     nk_console* saveStateButton;
     nk_console* loadStateButton;
@@ -171,6 +173,7 @@ void HideLibretroMenu(void);      // Hide the menu and apply cursor settings.
 void ToggleLibretroMenu(void);    // Toggle menu visibility.
 bool IsLibretroMenuShown(void);   // Returns true if the menu is currently visible.
 void BuildLibretroMenuOptions(LibretroMenu* menu); // Populate "Core Options" with comboboxes from the loaded core.
+void BuildLibretroMenuControllers(LibretroMenu* menu); // Populate "Controllers" with per-port device comboboxes.
 bool LoadLibretroCoreOptions(void);    // Apply saved core options from config to the loaded core.
 bool SaveLibretroAllSettings(void);    // Save menu settings + core options in a single file write.
 static Font GetLibretroMenuFont(void);
@@ -1255,6 +1258,7 @@ static bool MenuLoadGame(const char* gamePath) {
     }
 
     BuildLibretroMenuOptions(&menu);
+    BuildLibretroMenuControllers(&menu);
     HideLibretroMenu();
     MenuLoadGameSRAM();
     return true;
@@ -1701,6 +1705,17 @@ LibretroMenu* InitLibretroMenu(void) {
                 nk_console_button_onclick(menu.optionsMenu, "Core Options", &nk_console_button_back),
                 NK_SYMBOL_TRIANGLE_UP);
         }
+
+        // Controllers (per-port device selection, populated by BuildLibretroMenuControllers)
+        menu.controllersMenu = nk_console_button(settings, "Controllers");
+        nk_console_add_event(menu.controllersMenu, NK_CONSOLE_EVENT_BACK, &MenuCommitSettings);
+        nk_console_button_set_symbol(menu.controllersMenu, NK_SYMBOL_TRIANGLE_RIGHT);
+        {
+            nk_console_button_set_symbol(
+                nk_console_button_onclick(menu.controllersMenu, "Controllers", &nk_console_button_back),
+                NK_SYMBOL_TRIANGLE_UP);
+        }
+        menu.controllersMenu->visible = nk_false;
     }
 
     // About
@@ -2073,6 +2088,62 @@ void BuildLibretroMenuOptions(LibretroMenu* m) {
     nk_console_button_set_symbol(resetButton, NK_SYMBOL_TRIANGLE_LEFT);
 }
 
+static void LibretroMenuPortDeviceChanged(nk_console* widget, void* user_data) {
+    NK_UNUSED(widget);
+    unsigned port = (unsigned)(uintptr_t)user_data;
+    unsigned count;
+    const struct retro_controller_info* info = GetLibretroControllerInfo(&count);
+    if (!info || port >= count) return;
+    unsigned idx = (unsigned)menu.portDeviceIndex[port];
+    if (idx >= info[port].num_types) return;
+    SetLibretroPortDevice(port, info[port].types[idx].id);
+}
+
+void BuildLibretroMenuControllers(LibretroMenu* m) {
+    if (!m || !m->controllersMenu) return;
+    nk_console_free_children(m->controllersMenu);
+
+    nk_console_button_set_symbol(
+        nk_console_button_onclick(m->controllersMenu, "Controllers", &nk_console_button_back),
+        NK_SYMBOL_TRIANGLE_UP);
+
+    unsigned count = 0;
+    const struct retro_controller_info* info = GetLibretroControllerInfo(&count);
+    if (!info || count == 0) {
+        m->controllersMenu->visible = nk_false;
+        return;
+    }
+
+    bool anyWidget = false;
+    for (unsigned port = 0; port < count && port < 16; port++) {
+        if (info[port].num_types <= 1) continue;
+
+        char options[512];
+        options[0] = '\0';
+        for (unsigned i = 0; i < info[port].num_types; i++) {
+            if (i > 0) strncat(options, "|", sizeof(options) - strlen(options) - 1);
+            strncat(options, info[port].types[i].desc, sizeof(options) - strlen(options) - 1);
+        }
+
+        unsigned currentDevice = GetLibretroPortDevice(port);
+        m->portDeviceIndex[port] = 0;
+        for (unsigned i = 0; i < info[port].num_types; i++) {
+            if (info[port].types[i].id == currentDevice) {
+                m->portDeviceIndex[port] = (int)i;
+                break;
+            }
+        }
+
+        nk_console* widget = nk_console_combobox(m->controllersMenu,
+            TextFormat("Port %u", port + 1), options, '|', &m->portDeviceIndex[port]);
+        nk_console_add_event_handler(widget, NK_CONSOLE_EVENT_CHANGED,
+            LibretroMenuPortDeviceChanged, (void*)(uintptr_t)port, NULL);
+        anyWidget = true;
+    }
+
+    m->controllersMenu->visible = (nk_bool)anyWidget;
+}
+
 static void LibretroMenuUpdateConfig(void) {
 #ifdef RAYLIB_LIBRETRO_CONFIG_H
     if (!menu.cfg) return;
@@ -2376,6 +2447,9 @@ static void UpdateLibretroMenuVisibility(void) {
     } else if (menu.optionsMenu) {
         menu.optionsMenu->visible = nk_false;
     }
+    if (menu.controllersMenu && !IsLibretroReady()) {
+        menu.controllersMenu->visible = nk_false;
+    }
     if (menu.saveStateButton) {
         menu.saveStateButton->parent->visible = gameReady;
     }
@@ -2457,6 +2531,7 @@ void UpdateLibretroMenu(void) {// If there is no menu, skip.
             LIBRETRO.core.options_update_display_callback();
         }
         BuildLibretroMenuOptions(&menu);
+        BuildLibretroMenuControllers(&menu);
         LIBRETRO.core.variablesVisibilityDirty = false;
         lastBuiltVariableCount = LIBRETRO.core.variableCount;
         TextCopy(lastBuiltCoreName, LIBRETRO.core.libraryName);

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -787,11 +787,18 @@ static bool SetLibretroRumbleState(unsigned port, enum retro_rumble_effect effec
         return false;
     }
     float normalized = (float)strength / 65535.0f;
-    if (effect == RETRO_RUMBLE_STRONG) {
-        LIBRETRO.core.rumbleStrong[port] = normalized;
-    } else {
-        LIBRETRO.core.rumbleWeak[port] = normalized;
+    float* slot = (effect == RETRO_RUMBLE_STRONG)
+        ? &LIBRETRO.core.rumbleStrong[port]
+        : &LIBRETRO.core.rumbleWeak[port];
+
+    // Cores call this every frame, almost always with the value unchanged
+    // (commonly 0). Skip the hardware update when nothing changed so we don't
+    // spam SetGamepadVibration(). The compare is exact: normalized is derived
+    // deterministically from the same integer strength each frame.
+    if (*slot == normalized) {
+        return true;
     }
+    *slot = normalized;
     SetGamepadVibration((int)port, LIBRETRO.core.rumbleStrong[port], LIBRETRO.core.rumbleWeak[port], 3600.0f);
     return true;
 }

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -178,7 +178,9 @@ static int LibretroMapRetroLogLevelToTraceLogType(int level);
 #define RETRO_DEVICE_JOYPAD_MULTITAP RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_JOYPAD, 1)
 #endif
 
-// Dynamic loading methods.
+/**
+ * Load a symbol from the libretro handle.
+ */
 #define LoadLibretroMethodHandle(V, S) do {\
     function_t func = dylib_proc(LIBRETRO.core.symbols.handle, #S); \
     memcpy(&V, &func, sizeof(func)); \
@@ -187,6 +189,10 @@ static int LibretroMapRetroLogLevelToTraceLogType(int level);
         return false; \
     }\
 } while (0)
+
+/**
+ * Loads a method from the libretro core handle.
+ */
 #define LoadLibretroMethod(S) LoadLibretroMethodHandle(LIBRETRO.core.symbols.S, S)
 
 /**

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -110,6 +110,8 @@ static bool LoadLibretroGameFromMemoryEx(unsigned char* fileData, int dataSize,
     const char* contentPath, bool persistent);
 static void SetLibretroDynamicRateControl(bool enabled);
 static bool IsLibretroDynamicRateControlEnabled(void);
+static bool SetLibretroPortDevice(unsigned port, unsigned device);
+static unsigned GetLibretroPortDevice(unsigned port);
 
 static void LibretroPixelFormatARGB1555ToRGB565(void *output_, const void *input_,
         int width, int height,
@@ -170,6 +172,11 @@ static int LibretroMapRetroLogLevelToTraceLogType(int level);
  * The amount of controller ports with rumble support.
  */
 #define RAYLIB_LIBRETRO_RUMBLE_PORTS 4
+
+// Four joypads multiplexed through one port; index (0-3) selects the sub-controller.
+#ifndef RETRO_DEVICE_JOYPAD_MULTITAP
+#define RETRO_DEVICE_JOYPAD_MULTITAP RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_JOYPAD, 1)
+#endif
 
 // Dynamic loading methods.
 #define LoadLibretroMethodHandle(V, S) do {\
@@ -342,6 +349,9 @@ typedef struct LibretroCoreData {
 
     // Virtual joypad state injected by touch controls (port 0 only).
     bool virtualJoypadState[16];
+
+    // Per-port device type; default RETRO_DEVICE_JOYPAD. Set via SetLibretroPortDevice().
+    unsigned portDeviceMap[16];
 
     // Memory map from RETRO_ENVIRONMENT_SET_MEMORY_MAPS (owned copy).
     struct retro_memory_descriptor *memoryMapDescriptors;
@@ -2144,14 +2154,20 @@ static int16_t LibretroInputState(unsigned port, unsigned device, unsigned index
             }
             return 0;
         }
+        case RETRO_DEVICE_JOYPAD_MULTITAP:
         case RETRO_DEVICE_JOYPAD: {
+            // Multitap maps index (0-3) to a sub-controller: physical pad = port*4 + index.
+            bool isMultitap = (device == RETRO_DEVICE_JOYPAD_MULTITAP)
+                              || (LIBRETRO.core.portDeviceMap[port] == RETRO_DEVICE_JOYPAD_MULTITAP);
+            unsigned physicalPad = isMultitap ? (port * 4 + index) : port;
+
             // Return a bitmask of all buttons when requested.
             if (id == RETRO_DEVICE_ID_JOYPAD_MASK) {
                 int16_t mask = 0;
-                bool gpAvail = IsGamepadAvailable((int)port);
+                bool gpAvail = IsGamepadAvailable((int)physicalPad);
                 for (int btn = 0; btn < 16; btn++) {
                     bool pressed = false;
-                    if (port == 0) {
+                    if (physicalPad == 0) {
                         if (btn < 16 && LIBRETRO.core.virtualJoypadState[btn]) {
                             pressed = true;
                         } else if (gpAvail) {
@@ -2171,16 +2187,16 @@ static int16_t LibretroInputState(unsigned port, unsigned device, unsigned index
                             }
                         }
                     } else if (gpAvail) {
-                        pressed = IsGamepadButtonDown((int)port, LibretroRetroJoypadButtonToGamepadButton(btn));
+                        pressed = IsGamepadButtonDown((int)physicalPad, LibretroRetroJoypadButtonToGamepadButton(btn));
                     }
-                    if (!pressed) pressed = LibretroAnalogToDpadPressed((int)port, btn);
+                    if (!pressed) pressed = LibretroAnalogToDpadPressed((int)physicalPad, btn);
                     if (pressed) mask |= (1 << btn);
                 }
                 return mask;
             }
 
-            // Port 0: gamepad if available, otherwise keyboard.
-            if (port == 0) {
+            // Physical pad 0: virtual joypad (touch) then gamepad then keyboard.
+            if (physicalPad == 0) {
                 if (id < 16 && LIBRETRO.core.virtualJoypadState[id]) {
                     return 1;
                 }
@@ -2203,13 +2219,13 @@ static int16_t LibretroInputState(unsigned port, unsigned device, unsigned index
                 return LibretroAnalogToDpadPressed(0, id) ? 1 : 0;
             }
 
-            // Port 1+: map to gamepad (port 1 → gamepad 1, port 2 → gamepad 2, ...).
-            if (!IsGamepadAvailable(port)) {
-                return LibretroAnalogToDpadPressed((int)port, id) ? 1 : 0;
+            // Physical pad 1+: map directly to that gamepad index.
+            if (!IsGamepadAvailable((int)physicalPad)) {
+                return LibretroAnalogToDpadPressed((int)physicalPad, id) ? 1 : 0;
             }
             int gamepadButton = LibretroRetroJoypadButtonToGamepadButton(id);
-            if (IsGamepadButtonDown(port, gamepadButton)) return 1;
-            return LibretroAnalogToDpadPressed((int)port, id) ? 1 : 0;
+            if (IsGamepadButtonDown((int)physicalPad, gamepadButton)) return 1;
+            return LibretroAnalogToDpadPressed((int)physicalPad, id) ? 1 : 0;
         }
 
         case RETRO_DEVICE_MOUSE: {
@@ -3220,6 +3236,37 @@ static bool IsLibretroDynamicRateControlEnabled(void) {
 }
 
 /**
+ * Set the input device type for a controller port and notify the core.
+ * Use RETRO_DEVICE_JOYPAD_MULTITAP to enable multitap on a port; the input_state
+ * index then selects the sub-controller (0-3), mapping to physical gamepad port*4+index.
+ * @param port Controller port (0-15).
+ * @param device Device type (e.g. RETRO_DEVICE_JOYPAD, RETRO_DEVICE_JOYPAD_MULTITAP).
+ * @return true on success, false if port is out of range.
+ */
+static bool SetLibretroPortDevice(unsigned port, unsigned device) {
+    if (port >= 16) {
+        return false;
+    }
+    LIBRETRO.core.portDeviceMap[port] = device;
+    if (IsLibretroReady() && LIBRETRO.core.symbols.retro_set_controller_port_device != NULL) {
+        LIBRETRO.core.symbols.retro_set_controller_port_device(port, device);
+    }
+    return true;
+}
+
+/**
+ * Get the input device type currently assigned to a controller port.
+ * @param port Controller port (0-15).
+ * @return Device type, or RETRO_DEVICE_NONE if port is out of range.
+ */
+static unsigned GetLibretroPortDevice(unsigned port) {
+    if (port >= 16) {
+        return RETRO_DEVICE_NONE;
+    }
+    return LIBRETRO.core.portDeviceMap[port];
+}
+
+/**
  * Get the current display rotation index (0=0°, 1=90°, 2=180°, 3=270°).
  * @return Rotation index.
  */
@@ -3453,6 +3500,9 @@ static void CloseLibretro(void) {
     // Non-zero defaults.
     LIBRETRO.core.drcAdjustment = 1.0f;
     LIBRETRO.core.drcEnabled = true;
+    for (int i = 0; i < 16; i++) {
+        LIBRETRO.core.portDeviceMap[i] = RETRO_DEVICE_JOYPAD;
+    }
 }
 
 /**


### PR DESCRIPTION
Implements multitap input and a Controllers menu for per-port device selection.

- Defines `RETRO_DEVICE_JOYPAD_MULTITAP` and routes input via `port * 4 + index`
- `portDeviceMap[16]` tracks the device type per port (default: `RETRO_DEVICE_JOYPAD`)
- `SetLibretroPortDevice()` / `GetLibretroPortDevice()` public API
- Controllers submenu under Settings: populated from `retro_controller_info` advertised by the core, showing the core's own device description strings per port