### PR TITLE
Reduce struct duplication between LibretroMenu and LibretroData

### DIFF
--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -153,6 +153,7 @@ typedef struct {
     float rewindTimer;  // seconds accumulated toward the next rewind capture/step
     bool muted;
     bool pendingMenuOpen;
+    float savedVolume;  // volume saved before fast-forward halves it
 } AppData;
 
 // Breadcrumb logging through startup. On Android these go to logcat (and the
@@ -535,8 +536,8 @@ bool Update(void* userData) {
         bool rewinding = false;
 
         if (IsLibretroGameReady()) {
-            KeyboardKey rewindKey = LibretroHotkeyToKeyboardKey(data->menu->keyRewind);
-            rewinding = data->menu->rewindEnabled && (IsKeyDown(rewindKey) || LibretroHotkeyGPDown(data->menu->gamepadRewind));
+            KeyboardKey rewindKey = LibretroHotkeyToKeyboardKey(data->menu->hotkeys[LIBRETRO_HOTKEY_REWIND].key);
+            rewinding = data->menu->rewindEnabled && (IsKeyDown(rewindKey) || LibretroHotkeyGPDown(data->menu->hotkeys[LIBRETRO_HOTKEY_REWIND].gamepad));
 
             // Capture and playback both run at REWIND_CAPTURES_PER_SECOND.
             if (data->menu->rewindEnabled) {
@@ -579,7 +580,7 @@ bool Update(void* userData) {
                             RewindBufferPush(&data->rewind, state, size);
                         }
                     }
-                    if (IsKeyReleased(rewindKey) || LibretroHotkeyGPReleased(data->menu->gamepadRewind)) {
+                    if (IsKeyReleased(rewindKey) || LibretroHotkeyGPReleased(data->menu->hotkeys[LIBRETRO_HOTKEY_REWIND].gamepad)) {
                         SetLibretroMessage(NULL, 0.0);
                     }
                 } else if (data->rewind.count > 0) {
@@ -587,33 +588,34 @@ bool Update(void* userData) {
                 }
 
                 // Fast Forward
-                KeyboardKey key = LibretroHotkeyToKeyboardKey(data->menu->keyFastForward);
-                KeyboardKey slowMotionKey = LibretroHotkeyToKeyboardKey(data->menu->keySlowMotion);
-                if (IsKeyDown(key) || LibretroHotkeyGPDown(data->menu->gamepadFastForward)) {
-                    if (IsKeyPressed(key) || LibretroHotkeyGPPressed(data->menu->gamepadFastForward)) {
+                KeyboardKey key = LibretroHotkeyToKeyboardKey(data->menu->hotkeys[LIBRETRO_HOTKEY_FAST_FORWARD].key);
+                KeyboardKey slowMotionKey = LibretroHotkeyToKeyboardKey(data->menu->hotkeys[LIBRETRO_HOTKEY_SLOW_MOTION].key);
+                if (IsKeyDown(key) || LibretroHotkeyGPDown(data->menu->hotkeys[LIBRETRO_HOTKEY_FAST_FORWARD].gamepad)) {
+                    if (IsKeyPressed(key) || LibretroHotkeyGPPressed(data->menu->hotkeys[LIBRETRO_HOTKEY_FAST_FORWARD].gamepad)) {
                         // Halve the volume during fast-forward to soften the
                         // sped-up audio and ring-buffer overrun crackle.
-                        SetLibretroVolume(data->menu->volumeSelected * 0.5f);
+                        data->savedVolume = LIBRETRO.volume;
+                        SetLibretroVolume(LIBRETRO.volume * 0.5f);
                         SetLibretroSpeed(data->menu->fastForwardSpeed);
                         SetLibretroMessage("Fast Forward", 1.0);
                     }
                     // The time accumulator in UpdateLibretro() scales by LIBRETRO.speed,
                     // so the single UpdateLibretro() call below runs the extra ticks.
                 }
-                else if (IsKeyReleased(key) || LibretroHotkeyGPReleased(data->menu->gamepadFastForward)) {
-                    SetLibretroVolume(data->menu->volumeSelected);
+                else if (IsKeyReleased(key) || LibretroHotkeyGPReleased(data->menu->hotkeys[LIBRETRO_HOTKEY_FAST_FORWARD].gamepad)) {
+                    SetLibretroVolume(data->savedVolume);
                     SetLibretroSpeed(1.0f);
                     SetLibretroMessage(NULL, 0.0);
                 }
 
                 // Slow Motion
-                else if (IsKeyDown(slowMotionKey) || LibretroHotkeyGPDown(data->menu->gamepadSlowMotion)) {
-                    if (IsKeyPressed(slowMotionKey) || LibretroHotkeyGPPressed(data->menu->gamepadSlowMotion)) {
+                else if (IsKeyDown(slowMotionKey) || LibretroHotkeyGPDown(data->menu->hotkeys[LIBRETRO_HOTKEY_SLOW_MOTION].gamepad)) {
+                    if (IsKeyPressed(slowMotionKey) || LibretroHotkeyGPPressed(data->menu->hotkeys[LIBRETRO_HOTKEY_SLOW_MOTION].gamepad)) {
                         SetLibretroSpeed(data->menu->slowMotionSpeed);
                         SetLibretroMessage("Slow Motion", 1.0);
                     }
                 }
-                else if (IsKeyReleased(slowMotionKey) || LibretroHotkeyGPReleased(data->menu->gamepadSlowMotion)) {
+                else if (IsKeyReleased(slowMotionKey) || LibretroHotkeyGPReleased(data->menu->hotkeys[LIBRETRO_HOTKEY_SLOW_MOTION].gamepad)) {
                     SetLibretroSpeed(1.0f);
                     SetLibretroMessage(NULL, 0.0);
                 }
@@ -666,7 +668,7 @@ bool Update(void* userData) {
     if (!menu.active) {
 
         // Screenshot
-        if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyScreenshot)) || LibretroHotkeyGPReleased(menu.gamepadScreenshot) && IsLibretroGameReady()) {
+        if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.hotkeys[LIBRETRO_HOTKEY_SCREENSHOT].key)) || LibretroHotkeyGPReleased(menu.hotkeys[LIBRETRO_HOTKEY_SCREENSHOT].gamepad) && IsLibretroGameReady()) {
             const char* screenshotsDir = GetLibretroDirectory(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY);
             const char* contentName = GetLibretroContentName();
             const char* baseName = (contentName && contentName[0] != '\0') ? contentName : "screenshot";
@@ -697,20 +699,20 @@ bool Update(void* userData) {
 
         // FullScreen toggle key won't work in Emscripten.
     #ifndef __EMSCRIPTEN__
-        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyFullscreen)) || LibretroHotkeyGPReleased(menu.gamepadFullscreen)) {
+        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.hotkeys[LIBRETRO_HOTKEY_FULLSCREEN].key)) || LibretroHotkeyGPReleased(menu.hotkeys[LIBRETRO_HOTKEY_FULLSCREEN].gamepad)) {
             LibretroMenuFullscreenChanged(menu.console, NULL);
         }
     #endif
 
         // Cycle Shader Reverse
-        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyPrevShader)) || LibretroHotkeyGPReleased(menu.gamepadPrevShader)) {
+        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.hotkeys[LIBRETRO_HOTKEY_PREV_SHADER].key)) || LibretroHotkeyGPReleased(menu.hotkeys[LIBRETRO_HOTKEY_PREV_SHADER].gamepad)) {
             CycleLibretroShaderReverse();
             SetLibretroMessage(GetLibretroShaderName(GetActiveLibretroShaderType()), 2.0);
             menu.shaderSelectedIndex = (int)GetActiveLibretroShaderType();
         }
 
         // Cycle Shader Next
-        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyNextShader)) || LibretroHotkeyGPReleased(menu.gamepadNextShader)) {
+        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.hotkeys[LIBRETRO_HOTKEY_NEXT_SHADER].key)) || LibretroHotkeyGPReleased(menu.hotkeys[LIBRETRO_HOTKEY_NEXT_SHADER].gamepad)) {
             CycleLibretroShader();
             SetLibretroMessage(GetLibretroShaderName(GetActiveLibretroShaderType()), 2.0);
             // TODO: For some reason, cycling the shader doens't update the menu label.
@@ -718,29 +720,29 @@ bool Update(void* userData) {
         }
 
         // Save State
-        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keySaveState)) || LibretroHotkeyGPReleased(menu.gamepadSaveState)) {
+        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.hotkeys[LIBRETRO_HOTKEY_SAVE_STATE].key)) || LibretroHotkeyGPReleased(menu.hotkeys[LIBRETRO_HOTKEY_SAVE_STATE].gamepad)) {
             LibretroMenuSaveStateClicked(menu.console, NULL);
         }
 
         // Load State
-        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyLoadState)) || LibretroHotkeyGPReleased(menu.gamepadLoadState)) {
+        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.hotkeys[LIBRETRO_HOTKEY_LOAD_STATE].key)) || LibretroHotkeyGPReleased(menu.hotkeys[LIBRETRO_HOTKEY_LOAD_STATE].gamepad)) {
             LibretroMenuLoadStateClicked(menu.console, NULL);
         }
 
         // Prev Slot
-        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyPrevSlot)) || LibretroHotkeyGPReleased(menu.gamepadPrevSlot)) {
+        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.hotkeys[LIBRETRO_HOTKEY_PREV_SLOT].key)) || LibretroHotkeyGPReleased(menu.hotkeys[LIBRETRO_HOTKEY_PREV_SLOT].gamepad)) {
             menu.saveSlotIndex = (menu.saveSlotIndex - 1 + 10) % 10;
             SetLibretroMessage(TextFormat("Save Slot: %d", menu.saveSlotIndex + 1), 2.0);
         }
 
         // Next Slot
-        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyNextSlot)) || LibretroHotkeyGPReleased(menu.gamepadNextSlot)) {
+        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.hotkeys[LIBRETRO_HOTKEY_NEXT_SLOT].key)) || LibretroHotkeyGPReleased(menu.hotkeys[LIBRETRO_HOTKEY_NEXT_SLOT].gamepad)) {
             menu.saveSlotIndex = (menu.saveSlotIndex + 1) % 10;
             SetLibretroMessage(TextFormat("Save Slot: %d", menu.saveSlotIndex + 1), 2.0);
         }
 
         // Reset
-        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyReset)) || LibretroHotkeyGPReleased(menu.gamepadReset)) {
+        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.hotkeys[LIBRETRO_HOTKEY_RESET].key)) || LibretroHotkeyGPReleased(menu.hotkeys[LIBRETRO_HOTKEY_RESET].gamepad)) {
             if (IsLibretroGameReady()) {
                 ResetLibretro();
                 SetLibretroMessage("Reset", 2.0);
@@ -748,38 +750,38 @@ bool Update(void* userData) {
         }
 
         // Volume Up
-        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyVolumeUp)) || LibretroHotkeyGPReleased(menu.gamepadVolumeUp)) {
+        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.hotkeys[LIBRETRO_HOTKEY_VOLUME_UP].key)) || LibretroHotkeyGPReleased(menu.hotkeys[LIBRETRO_HOTKEY_VOLUME_UP].gamepad)) {
             float vol = GetLibretroVolume() + 0.1f;
             SetLibretroVolume(vol);
             vol = GetLibretroVolume();
-            menu.volumeSelected = vol;
             SetLibretroMessage(TextFormat("Volume: %d%%", (int)(vol * 10.0f + 0.5f) * 10), 1.0);
         }
 
         // Volume Down
-        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyVolumeDown)) || LibretroHotkeyGPReleased(menu.gamepadVolumeDown)) {
+        else if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.hotkeys[LIBRETRO_HOTKEY_VOLUME_DOWN].key)) || LibretroHotkeyGPReleased(menu.hotkeys[LIBRETRO_HOTKEY_VOLUME_DOWN].gamepad)) {
             float vol = GetLibretroVolume() - 0.1f;
             SetLibretroVolume(vol);
             vol = GetLibretroVolume();
-            menu.volumeSelected = vol;
             SetLibretroMessage(TextFormat("Volume: %d%%", (int)(vol * 10.0f + 0.5f) * 10), 1.0);
         }
 
         // Mute
-        else if (IsKeyPressed(LibretroHotkeyToKeyboardKey(menu.keyMute)) || LibretroHotkeyGPReleased(menu.gamepadMute)) {
+        else if (IsKeyPressed(LibretroHotkeyToKeyboardKey(menu.hotkeys[LIBRETRO_HOTKEY_MUTE].key)) || LibretroHotkeyGPReleased(menu.hotkeys[LIBRETRO_HOTKEY_MUTE].gamepad)) {
             if (!data->muted) {
+                data->savedVolume = LIBRETRO.volume;
                 SetLibretroVolume(0.0f);
                 data->muted = true;
                 SetLibretroMessage("Mute", 1.0f);
             } else {
-                SetLibretroVolume(data->menu->volumeSelected);
+                float vol = data->savedVolume > 0.0f ? data->savedVolume : 1.0f;
+                SetLibretroVolume(vol);
                 data->muted = false;
-                SetLibretroMessage(TextFormat("Volume: %d%%", (int)(data->menu->volumeSelected * 10.0f + 0.5f) * 10), 1.0);
+                SetLibretroMessage(TextFormat("Volume: %d%%", (int)(vol * 10.0f + 0.5f) * 10), 1.0);
             }
         }
 
         // Quit (keyboard is handled by SetExitKey; this covers the gamepad binding).
-        else if (LibretroHotkeyGPReleased(menu.gamepadQuit)) {
+        else if (LibretroHotkeyGPReleased(menu.hotkeys[LIBRETRO_HOTKEY_QUIT].gamepad)) {
             menu.shouldQuit = true;
         }
     }

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -153,7 +153,6 @@ typedef struct {
     float rewindTimer;  // seconds accumulated toward the next rewind capture/step
     bool muted;
     bool pendingMenuOpen;
-    float savedVolume;  // volume saved before fast-forward halves it
 } AppData;
 
 // Breadcrumb logging through startup. On Android these go to logcat (and the
@@ -592,10 +591,10 @@ bool Update(void* userData) {
                 KeyboardKey slowMotionKey = LibretroHotkeyToKeyboardKey(data->menu->hotkeys[LIBRETRO_HOTKEY_SLOW_MOTION].key);
                 if (IsKeyDown(key) || LibretroHotkeyGPDown(data->menu->hotkeys[LIBRETRO_HOTKEY_FAST_FORWARD].gamepad)) {
                     if (IsKeyPressed(key) || LibretroHotkeyGPPressed(data->menu->hotkeys[LIBRETRO_HOTKEY_FAST_FORWARD].gamepad)) {
-                        // Halve the volume during fast-forward to soften the
-                        // sped-up audio and ring-buffer overrun crackle.
-                        data->savedVolume = LIBRETRO.volume;
-                        SetLibretroVolume(LIBRETRO.volume * 0.5f);
+                        // Halve audio stream volume during fast-forward without touching
+                        // LIBRETRO.volume so restore is just re-applying the stored value.
+                        if (IsAudioStreamValid(LIBRETRO.core.audioStream))
+                            SetAudioStreamVolume(LIBRETRO.core.audioStream, LIBRETRO.volume * 0.5f);
                         SetLibretroSpeed(data->menu->fastForwardSpeed);
                         SetLibretroMessage("Fast Forward", 1.0);
                     }
@@ -603,7 +602,7 @@ bool Update(void* userData) {
                     // so the single UpdateLibretro() call below runs the extra ticks.
                 }
                 else if (IsKeyReleased(key) || LibretroHotkeyGPReleased(data->menu->hotkeys[LIBRETRO_HOTKEY_FAST_FORWARD].gamepad)) {
-                    SetLibretroVolume(data->savedVolume);
+                    SetLibretroVolume(LIBRETRO.volume);
                     SetLibretroSpeed(1.0f);
                     SetLibretroMessage(NULL, 0.0);
                 }
@@ -768,15 +767,14 @@ bool Update(void* userData) {
         // Mute
         else if (IsKeyPressed(LibretroHotkeyToKeyboardKey(menu.hotkeys[LIBRETRO_HOTKEY_MUTE].key)) || LibretroHotkeyGPReleased(menu.hotkeys[LIBRETRO_HOTKEY_MUTE].gamepad)) {
             if (!data->muted) {
-                data->savedVolume = LIBRETRO.volume;
-                SetLibretroVolume(0.0f);
+                if (IsAudioStreamValid(LIBRETRO.core.audioStream))
+                    SetAudioStreamVolume(LIBRETRO.core.audioStream, 0.0f);
                 data->muted = true;
                 SetLibretroMessage("Mute", 1.0f);
             } else {
-                float vol = data->savedVolume > 0.0f ? data->savedVolume : 1.0f;
-                SetLibretroVolume(vol);
+                SetLibretroVolume(LIBRETRO.volume);
                 data->muted = false;
-                SetLibretroMessage(TextFormat("Volume: %d%%", (int)(vol * 10.0f + 0.5f) * 10), 1.0);
+                SetLibretroMessage(TextFormat("Volume: %d%%", (int)(LIBRETRO.volume * 10.0f + 0.5f) * 10), 1.0);
             }
         }
 

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -67,6 +67,8 @@ typedef enum LibretroMenuCombo {
 typedef struct LibretroMenuBinding {
     nk_rune key;
     enum nk_gamepad_button gamepad;
+    const char* name;
+    nk_rune defaultKey;
 } LibretroMenuBinding;
 
 typedef enum LibretroHotkey {
@@ -1318,39 +1320,6 @@ static void LibretroMenuLoadStateClicked(nk_console* widget, void* user_data) {
 static void LibretroMenuUpdateLoadGameFilter(LibretroMenu* m);
 
 /**
- * Maps each hot key in the Keys settings to the menu fields.
- */
-typedef struct LibretroMenuHotkey {
-    const char* name; /** The name of the hot key, as shown in the menu. */
-    enum nk_gamepad_button* gamepad; /** The gamepad button that's currently assigned. */
-    nk_rune* key; /** The keyboard key that's currently assigned. */
-    nk_rune default_key; /** The initial keyboard binding that will be set. Gamepad button defaults are ignored. */
-} LibretroMenuHotkey;
-
-/**
- * Set of menu hot keys that will be built into input widgets in the Hot Keys menu.
- */
-static const LibretroMenuHotkey LibretroMenuHotkeys[] = {
-    { "Screenshot",      &menu.hotkeys[LIBRETRO_HOTKEY_SCREENSHOT].gamepad,   &menu.hotkeys[LIBRETRO_HOTKEY_SCREENSHOT].key,   NK_CONSOLE_KEY_F8 },
-    { "Rewind",          &menu.hotkeys[LIBRETRO_HOTKEY_REWIND].gamepad,       &menu.hotkeys[LIBRETRO_HOTKEY_REWIND].key,       (nk_rune)'R' },
-    { "Menu",            &menu.hotkeys[LIBRETRO_HOTKEY_MENU].gamepad,         &menu.hotkeys[LIBRETRO_HOTKEY_MENU].key,         NK_CONSOLE_KEY_ESCAPE },
-    { "Save State",      &menu.hotkeys[LIBRETRO_HOTKEY_SAVE_STATE].gamepad,   &menu.hotkeys[LIBRETRO_HOTKEY_SAVE_STATE].key,   NK_CONSOLE_KEY_F2 },
-    { "Load State",      &menu.hotkeys[LIBRETRO_HOTKEY_LOAD_STATE].gamepad,   &menu.hotkeys[LIBRETRO_HOTKEY_LOAD_STATE].key,   NK_CONSOLE_KEY_F4 },
-    { "Prev Slot",       &menu.hotkeys[LIBRETRO_HOTKEY_PREV_SLOT].gamepad,    &menu.hotkeys[LIBRETRO_HOTKEY_PREV_SLOT].key,    NK_CONSOLE_KEY_NONE },
-    { "Next Slot",       &menu.hotkeys[LIBRETRO_HOTKEY_NEXT_SLOT].gamepad,    &menu.hotkeys[LIBRETRO_HOTKEY_NEXT_SLOT].key,    NK_CONSOLE_KEY_NONE },
-    { "Fullscreen",      &menu.hotkeys[LIBRETRO_HOTKEY_FULLSCREEN].gamepad,   &menu.hotkeys[LIBRETRO_HOTKEY_FULLSCREEN].key,   NK_CONSOLE_KEY_F11 },
-    { "Previous Shader", &menu.hotkeys[LIBRETRO_HOTKEY_PREV_SHADER].gamepad,  &menu.hotkeys[LIBRETRO_HOTKEY_PREV_SHADER].key,  NK_CONSOLE_KEY_F9 },
-    { "Next Shader",     &menu.hotkeys[LIBRETRO_HOTKEY_NEXT_SHADER].gamepad,  &menu.hotkeys[LIBRETRO_HOTKEY_NEXT_SHADER].key,  NK_CONSOLE_KEY_F10 },
-    { "Reset",           &menu.hotkeys[LIBRETRO_HOTKEY_RESET].gamepad,        &menu.hotkeys[LIBRETRO_HOTKEY_RESET].key,        NK_CONSOLE_KEY_NONE },
-    { "Quit",            &menu.hotkeys[LIBRETRO_HOTKEY_QUIT].gamepad,         &menu.hotkeys[LIBRETRO_HOTKEY_QUIT].key,         NK_CONSOLE_KEY_NONE },
-    { "Volume Up",       &menu.hotkeys[LIBRETRO_HOTKEY_VOLUME_UP].gamepad,    &menu.hotkeys[LIBRETRO_HOTKEY_VOLUME_UP].key,    (nk_rune)'=' },
-    { "Volume Down",     &menu.hotkeys[LIBRETRO_HOTKEY_VOLUME_DOWN].gamepad,  &menu.hotkeys[LIBRETRO_HOTKEY_VOLUME_DOWN].key,  (nk_rune)'-' },
-    { "Mute",            &menu.hotkeys[LIBRETRO_HOTKEY_MUTE].gamepad,         &menu.hotkeys[LIBRETRO_HOTKEY_MUTE].key,         (nk_rune)'M' },
-    { "Fast Forward",    &menu.hotkeys[LIBRETRO_HOTKEY_FAST_FORWARD].gamepad, &menu.hotkeys[LIBRETRO_HOTKEY_FAST_FORWARD].key, (nk_rune)'F' },
-    { "Slow Motion",     &menu.hotkeys[LIBRETRO_HOTKEY_SLOW_MOTION].gamepad,  &menu.hotkeys[LIBRETRO_HOTKEY_SLOW_MOTION].key,  (nk_rune)'G' },
-};
-
-/**
  * Event that's triggered when a menu hot key was changed.
  */
 static void LibretroMenuHotkeyChanged(nk_console* widget, void* user_data) {
@@ -1367,25 +1336,21 @@ static void LibretroMenuHotkeyChanged(nk_console* widget, void* user_data) {
     }
 
     // Check if there were any conflicts with other keys/buttons.
-    for (int i = 0; i < (int)(sizeof(LibretroMenuHotkeys) / sizeof(LibretroMenuHotkeys[0])); i++) {
-        const LibretroMenuHotkey* hk = &LibretroMenuHotkeys[i];
-
+    for (int i = 0; i < LIBRETRO_HOTKEY_COUNT; i++) {
         // Skip the binding that was just changed (matched by output pointer).
-        if (hk->gamepad == data->out_gamepad_button || hk->key == data->out_key) {
+        if (&menu.hotkeys[i].gamepad == data->out_gamepad_button || &menu.hotkeys[i].key == data->out_key) {
             continue;
         }
 
         // Check if the key conflicts.
-        if (isKey && hk->key != NULL && *hk->key == *data->out_key) {
-            *hk->key = NK_CONSOLE_KEY_NONE; // Unbind it.
-            nk_console_show_message(menu.console,
-                TextFormat("%s has been unbound", hk->name));
+        if (isKey && menu.hotkeys[i].key == *data->out_key) {
+            menu.hotkeys[i].key = NK_CONSOLE_KEY_NONE;
+            nk_console_show_message(menu.console, TextFormat("%s has been unbound", menu.hotkeys[i].name));
         }
         // Check if the gamepad button conflicts.
-        else if (isGamepad && hk->gamepad != NULL && *hk->gamepad == *data->out_gamepad_button) {
-            *hk->gamepad = NK_GAMEPAD_BUTTON_INVALID; // Unbind it.
-            nk_console_show_message(menu.console,
-                TextFormat("%s has been unbound", hk->name));
+        else if (isGamepad && menu.hotkeys[i].gamepad == *data->out_gamepad_button) {
+            menu.hotkeys[i].gamepad = NK_GAMEPAD_BUTTON_INVALID;
+            nk_console_show_message(menu.console, TextFormat("%s has been unbound", menu.hotkeys[i].name));
         }
     }
 }
@@ -1413,10 +1378,32 @@ LibretroMenu* InitLibretroMenu(void) {
     menu.menuComboIndex = LIBRETRO_MENU_COMBO_SELECT_START;
     menu.slowMotionSpeed = 0.5f;
 
-    // Default hotkey bindings.
-    for (int i = 0; i < (int)(sizeof(LibretroMenuHotkeys) / sizeof(LibretroMenuHotkeys[0])); i++) {
-        *LibretroMenuHotkeys[i].key = LibretroMenuHotkeys[i].default_key;
-        *LibretroMenuHotkeys[i].gamepad = NK_GAMEPAD_BUTTON_INVALID;
+    // Default hotkey bindings — names and defaults live here so NK_CONSOLE_KEY_*
+    // constants are declared by this point (vendor headers already included above).
+    static const struct { const char* name; nk_rune defaultKey; } hotkeyDefs[LIBRETRO_HOTKEY_COUNT] = {
+        { "Screenshot",      NK_CONSOLE_KEY_F8     },
+        { "Rewind",          (nk_rune)'R'          },
+        { "Menu",            NK_CONSOLE_KEY_ESCAPE },
+        { "Save State",      NK_CONSOLE_KEY_F2     },
+        { "Load State",      NK_CONSOLE_KEY_F4     },
+        { "Prev Slot",       NK_CONSOLE_KEY_NONE   },
+        { "Next Slot",       NK_CONSOLE_KEY_NONE   },
+        { "Fullscreen",      NK_CONSOLE_KEY_F11    },
+        { "Previous Shader", NK_CONSOLE_KEY_F9     },
+        { "Next Shader",     NK_CONSOLE_KEY_F10    },
+        { "Reset",           NK_CONSOLE_KEY_NONE   },
+        { "Quit",            NK_CONSOLE_KEY_NONE   },
+        { "Volume Up",       (nk_rune)'='          },
+        { "Volume Down",     (nk_rune)'-'          },
+        { "Mute",            (nk_rune)'M'          },
+        { "Fast Forward",    (nk_rune)'F'          },
+        { "Slow Motion",     (nk_rune)'G'          },
+    };
+    for (int i = 0; i < LIBRETRO_HOTKEY_COUNT; i++) {
+        menu.hotkeys[i].name       = hotkeyDefs[i].name;
+        menu.hotkeys[i].defaultKey = hotkeyDefs[i].defaultKey;
+        menu.hotkeys[i].key        = hotkeyDefs[i].defaultKey;
+        menu.hotkeys[i].gamepad    = NK_GAMEPAD_BUTTON_INVALID;
     }
 
     // Font
@@ -1636,9 +1623,8 @@ LibretroMenu* InitLibretroMenu(void) {
                 "None|Select + Start|L1 + R1|L2 + R2|L3 + R3|Down + Select",
                 '|', &menu.menuComboIndex);
             menuCombo->tooltip = "Controller button combination to toggle the menu";
-            for (int i = 0; i < (int)(sizeof(LibretroMenuHotkeys) / sizeof(LibretroMenuHotkeys[0])); i++) {
-                const LibretroMenuHotkey* hk = &LibretroMenuHotkeys[i];
-                LibretroMenuAddHotkey(keysMenu, hk->name, hk->gamepad, hk->key);
+            for (int i = 0; i < LIBRETRO_HOTKEY_COUNT; i++) {
+                LibretroMenuAddHotkey(keysMenu, menu.hotkeys[i].name, &menu.hotkeys[i].gamepad, &menu.hotkeys[i].key);
             }
         }
 
@@ -2188,11 +2174,10 @@ static void LibretroMenuUpdateConfig(void) {
     rlconfig_set_float(menu.cfg, "raylib-libretro", "slowMotionSpeed", menu.slowMotionSpeed);
 
     // Hotkey bindings (keyboard + gamepad), keyed by name as "key<Name>"/"gamepad<Name>".
-    for (int i = 0; i < (int)(sizeof(LibretroMenuHotkeys) / sizeof(LibretroMenuHotkeys[0])); i++) {
-        const LibretroMenuHotkey* hk = &LibretroMenuHotkeys[i];
-        const char* shortName = TextReplace(hk->name, " ", "");
-        rlconfig_set_int(menu.cfg, "raylib-libretro", TextFormat("key%s", shortName), (int)*hk->key);
-        rlconfig_set_int(menu.cfg, "raylib-libretro", TextFormat("gamepad%s", shortName), (int)*hk->gamepad);
+    for (int i = 0; i < LIBRETRO_HOTKEY_COUNT; i++) {
+        const char* shortName = TextReplace(menu.hotkeys[i].name, " ", "");
+        rlconfig_set_int(menu.cfg, "raylib-libretro", TextFormat("key%s", shortName), (int)menu.hotkeys[i].key);
+        rlconfig_set_int(menu.cfg, "raylib-libretro", TextFormat("gamepad%s", shortName), (int)menu.hotkeys[i].gamepad);
     }
 
     rlconfig_set(menu.cfg, "raylib-libretro", "coreDirectory", LibretroResolveAbsoluteDirectory(LIBRETRO.coreDirectory));
@@ -2414,11 +2399,10 @@ static bool LoadLibretroMenuSettings(void) {
     if (username) TextCopy(LIBRETRO.username, username);
 
     // Hotkey bindings (keyboard + gamepad), keyed by name as "key<Name>"/"gamepad<Name>".
-    for (int i = 0; i < (int)(sizeof(LibretroMenuHotkeys) / sizeof(LibretroMenuHotkeys[0])); i++) {
-        const LibretroMenuHotkey* hk = &LibretroMenuHotkeys[i];
-        const char* shortName = TextReplace(hk->name, " ", "");
-        *hk->key = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", TextFormat("key%s", shortName), (int)*hk->key);
-        *hk->gamepad = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", TextFormat("gamepad%s", shortName), (int)*hk->gamepad);
+    for (int i = 0; i < LIBRETRO_HOTKEY_COUNT; i++) {
+        const char* shortName = TextReplace(menu.hotkeys[i].name, " ", "");
+        menu.hotkeys[i].key = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", TextFormat("key%s", shortName), (int)menu.hotkeys[i].key);
+        menu.hotkeys[i].gamepad = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", TextFormat("gamepad%s", shortName), (int)menu.hotkeys[i].gamepad);
     }
     SetExitKey(LibretroHotkeyToKeyboardKey(menu.hotkeys[LIBRETRO_HOTKEY_QUIT].key));
 

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -296,7 +296,117 @@ static void LibretroMenuEmscriptenLoadGameClicked(nk_console* widget, void* user
 extern "C" {
 #endif
 
-static LibretroMenu menu = {0};
+static LibretroMenu menu = {
+    .themeSelectedIndex = LIBRETRO_MENU_STYLE_CATPPUCCIN_MOCHA,
+    .vsync              = nk_true,
+    .fastForwardSpeed   = 3.0f,
+    .slowMotionSpeed    = 0.5f,
+    .menuComboIndex     = LIBRETRO_MENU_COMBO_SELECT_START,
+    .hotkeys = {
+        [LIBRETRO_HOTKEY_SCREENSHOT] = {
+            .name = "Screenshot",
+            .defaultKey = NK_CONSOLE_KEY_F8,
+            .key = NK_CONSOLE_KEY_F8,
+            .gamepad = NK_GAMEPAD_BUTTON_INVALID
+        },
+        [LIBRETRO_HOTKEY_REWIND] = {
+            .name = "Rewind",
+            .defaultKey = (nk_rune)'R',
+            .key = (nk_rune)'R',
+            .gamepad = NK_GAMEPAD_BUTTON_INVALID
+        },
+        [LIBRETRO_HOTKEY_MENU] = {
+            .name = "Menu",
+            .defaultKey = NK_CONSOLE_KEY_ESCAPE,
+            .key = NK_CONSOLE_KEY_ESCAPE,
+            .gamepad = NK_GAMEPAD_BUTTON_INVALID
+        },
+        [LIBRETRO_HOTKEY_SAVE_STATE] = {
+            .name = "Save State",
+            .defaultKey = NK_CONSOLE_KEY_F2,
+            .key = NK_CONSOLE_KEY_F2,
+            .gamepad = NK_GAMEPAD_BUTTON_INVALID
+        },
+        [LIBRETRO_HOTKEY_LOAD_STATE] = {
+            .name = "Load State",
+            .defaultKey = NK_CONSOLE_KEY_F4,
+            .key = NK_CONSOLE_KEY_F4,
+            .gamepad = NK_GAMEPAD_BUTTON_INVALID
+        },
+        [LIBRETRO_HOTKEY_PREV_SLOT] = {
+            .name = "Prev Slot",
+            .defaultKey = NK_CONSOLE_KEY_NONE,
+            .key = NK_CONSOLE_KEY_NONE,
+            .gamepad = NK_GAMEPAD_BUTTON_INVALID
+        },
+        [LIBRETRO_HOTKEY_NEXT_SLOT] = {
+            .name = "Next Slot",
+            .defaultKey = NK_CONSOLE_KEY_NONE,
+            .key = NK_CONSOLE_KEY_NONE,
+            .gamepad = NK_GAMEPAD_BUTTON_INVALID
+        },
+        [LIBRETRO_HOTKEY_FULLSCREEN]   = {
+            .name = "Fullscreen",
+            .defaultKey = NK_CONSOLE_KEY_F11,
+            .key = NK_CONSOLE_KEY_F11,
+            .gamepad = NK_GAMEPAD_BUTTON_INVALID
+        },
+        [LIBRETRO_HOTKEY_PREV_SHADER]  = {
+            .name = "Previous Shader",
+            .defaultKey = NK_CONSOLE_KEY_F9,
+            .key = NK_CONSOLE_KEY_F9,
+            .gamepad = NK_GAMEPAD_BUTTON_INVALID
+        },
+        [LIBRETRO_HOTKEY_NEXT_SHADER] = {
+            .name = "Next Shader",
+            .defaultKey = NK_CONSOLE_KEY_F10,
+            .key = NK_CONSOLE_KEY_F10,
+            .gamepad = NK_GAMEPAD_BUTTON_INVALID
+        },
+        [LIBRETRO_HOTKEY_RESET] = {
+            .name = "Reset",
+            .defaultKey = NK_CONSOLE_KEY_NONE,
+            .key = NK_CONSOLE_KEY_NONE,
+            .gamepad = NK_GAMEPAD_BUTTON_INVALID
+        },
+        [LIBRETRO_HOTKEY_QUIT] = {
+            .name = "Quit",
+            .defaultKey = NK_CONSOLE_KEY_NONE,
+            .key = NK_CONSOLE_KEY_NONE,
+            .gamepad = NK_GAMEPAD_BUTTON_INVALID
+        },
+        [LIBRETRO_HOTKEY_VOLUME_UP] = {
+            .name = "Volume Up",
+            .defaultKey = (nk_rune)'=',
+            .key = (nk_rune)'=',
+            .gamepad = NK_GAMEPAD_BUTTON_INVALID
+        },
+        [LIBRETRO_HOTKEY_VOLUME_DOWN]  = {
+            .name = "Volume Down",
+            .defaultKey = (nk_rune)'-',
+            .key = (nk_rune)'-',
+            .gamepad = NK_GAMEPAD_BUTTON_INVALID
+        },
+        [LIBRETRO_HOTKEY_MUTE] = {
+            .name = "Mute",
+            .defaultKey = (nk_rune)'M',
+            .key = (nk_rune)'M',
+            .gamepad = NK_GAMEPAD_BUTTON_INVALID
+        },
+        [LIBRETRO_HOTKEY_FAST_FORWARD] = {
+            .name = "Fast Forward",
+            .defaultKey = (nk_rune)'F',
+            .key = (nk_rune)'F',
+            .gamepad = NK_GAMEPAD_BUTTON_INVALID
+        },
+        [LIBRETRO_HOTKEY_SLOW_MOTION]  = {
+            .name = "Slow Motion",
+            .defaultKey = (nk_rune)'G',
+            .key = (nk_rune)'G',
+            .gamepad = NK_GAMEPAD_BUTTON_INVALID
+        },
+    },
+};
 
 static void SetLibretroMenuStyle(LibretroMenuStyle style);
 static bool IsLibretroMenuReady(void);
@@ -1355,55 +1465,8 @@ static void LibretroMenuHotkeyChanged(nk_console* widget, void* user_data) {
     }
 }
 
-/**
- * Creates a Hot Key widget in the Hot Key menu.
- */
-static nk_console* LibretroMenuAddHotkey(nk_console* parent, const char* label, enum nk_gamepad_button* gamepad, nk_rune* key) {
-    nk_console* widget = nk_console_input(parent, label, -1, NULL, gamepad, key, NULL);
-    nk_console_add_event(widget, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuHotkeyChanged);
-    return widget;
-}
-
 LibretroMenu* InitLibretroMenu(void) {
-    int fontSize = 13;
-    int screenWidth = GetScreenWidth();
-
-    // Create the menu.
-    menu = (LibretroMenu){0};
-    menu.themeSelectedIndex = LIBRETRO_MENU_STYLE_CATPPUCCIN_MOCHA;
-    menu.vsync = nk_true;
-    menu.fpsIndex = 0; // Auto
-    menu.saveSlotIndex  = 0;
-    menu.fastForwardSpeed = 3.0f;
-    menu.menuComboIndex = LIBRETRO_MENU_COMBO_SELECT_START;
-    menu.slowMotionSpeed = 0.5f;
-
-    // Default hotkey bindings — names and defaults live here so NK_CONSOLE_KEY_*
-    // constants are declared by this point (vendor headers already included above).
-    static const LibretroMenuBinding hotkeyDefs[LIBRETRO_HOTKEY_COUNT] = {
-        { .name = "Screenshot",      .defaultKey = NK_CONSOLE_KEY_F8     },
-        { .name = "Rewind",          .defaultKey = (nk_rune)'R'          },
-        { .name = "Menu",            .defaultKey = NK_CONSOLE_KEY_ESCAPE },
-        { .name = "Save State",      .defaultKey = NK_CONSOLE_KEY_F2     },
-        { .name = "Load State",      .defaultKey = NK_CONSOLE_KEY_F4     },
-        { .name = "Prev Slot",       .defaultKey = NK_CONSOLE_KEY_NONE   },
-        { .name = "Next Slot",       .defaultKey = NK_CONSOLE_KEY_NONE   },
-        { .name = "Fullscreen",      .defaultKey = NK_CONSOLE_KEY_F11    },
-        { .name = "Previous Shader", .defaultKey = NK_CONSOLE_KEY_F9     },
-        { .name = "Next Shader",     .defaultKey = NK_CONSOLE_KEY_F10    },
-        { .name = "Reset",           .defaultKey = NK_CONSOLE_KEY_NONE   },
-        { .name = "Quit",            .defaultKey = NK_CONSOLE_KEY_NONE   },
-        { .name = "Volume Up",       .defaultKey = (nk_rune)'='          },
-        { .name = "Volume Down",     .defaultKey = (nk_rune)'-'          },
-        { .name = "Mute",            .defaultKey = (nk_rune)'M'          },
-        { .name = "Fast Forward",    .defaultKey = (nk_rune)'F'          },
-        { .name = "Slow Motion",     .defaultKey = (nk_rune)'G'          },
-    };
-    for (int i = 0; i < LIBRETRO_HOTKEY_COUNT; i++) {
-        menu.hotkeys[i]        = hotkeyDefs[i];
-        menu.hotkeys[i].key    = hotkeyDefs[i].defaultKey;
-        menu.hotkeys[i].gamepad = NK_GAMEPAD_BUTTON_INVALID;
-    }
+    const int fontSize = 13;
 
     // Font
     menu.font = LoadFontFromNuklear(fontSize);
@@ -1610,20 +1673,25 @@ LibretroMenu* InitLibretroMenu(void) {
             nk_console_textedit(gameplayMenu, "Username", LIBRETRO.username, 128);
         }
 
-        // Keys
+        // Hot Keys
         {
-            nk_console* keysMenu = nk_console_button(settings, "Keys");
+            nk_console* keysMenu = nk_console_button(settings, "Hot Keys");
             nk_console_button_set_symbol(keysMenu, NK_SYMBOL_TRIANGLE_RIGHT);
             nk_console_add_event(keysMenu, NK_CONSOLE_EVENT_BACK, &MenuCommitSettings);
             nk_console_button_set_symbol(
-                nk_console_button_onclick(keysMenu, "Keys", &nk_console_button_back),
+                nk_console_button_onclick(keysMenu, "Hot Keys", &nk_console_button_back),
                 NK_SYMBOL_TRIANGLE_UP);
+
+            // Menu Controller Combo
             nk_console* menuCombo = nk_console_combobox(keysMenu, "Menu Controller Combo",
                 "None|Select + Start|L1 + R1|L2 + R2|L3 + R3|Down + Select",
                 '|', &menu.menuComboIndex);
             menuCombo->tooltip = "Controller button combination to toggle the menu";
+
+            // Keys
             for (int i = 0; i < LIBRETRO_HOTKEY_COUNT; i++) {
-                LibretroMenuAddHotkey(keysMenu, menu.hotkeys[i].name, &menu.hotkeys[i].gamepad, &menu.hotkeys[i].key);
+                nk_console* widget = nk_console_input(keysMenu, menu.hotkeys[i].name, -1, NULL, &menu.hotkeys[i].gamepad, &menu.hotkeys[i].key, NULL);
+                nk_console_add_event(widget, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuHotkeyChanged);
             }
         }
 

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -64,6 +64,32 @@ typedef enum LibretroMenuCombo {
     LIBRETRO_MENU_COMBO_COUNT,
 } LibretroMenuCombo;
 
+typedef struct LibretroMenuBinding {
+    nk_rune key;
+    enum nk_gamepad_button gamepad;
+} LibretroMenuBinding;
+
+typedef enum LibretroHotkey {
+    LIBRETRO_HOTKEY_SCREENSHOT,
+    LIBRETRO_HOTKEY_REWIND,
+    LIBRETRO_HOTKEY_MENU,
+    LIBRETRO_HOTKEY_SAVE_STATE,
+    LIBRETRO_HOTKEY_LOAD_STATE,
+    LIBRETRO_HOTKEY_PREV_SLOT,
+    LIBRETRO_HOTKEY_NEXT_SLOT,
+    LIBRETRO_HOTKEY_FULLSCREEN,
+    LIBRETRO_HOTKEY_PREV_SHADER,
+    LIBRETRO_HOTKEY_NEXT_SHADER,
+    LIBRETRO_HOTKEY_RESET,
+    LIBRETRO_HOTKEY_QUIT,
+    LIBRETRO_HOTKEY_VOLUME_UP,
+    LIBRETRO_HOTKEY_VOLUME_DOWN,
+    LIBRETRO_HOTKEY_MUTE,
+    LIBRETRO_HOTKEY_FAST_FORWARD,
+    LIBRETRO_HOTKEY_SLOW_MOTION,
+    LIBRETRO_HOTKEY_COUNT,
+} LibretroHotkey;
+
 typedef struct LibretroMenu {
     struct nk_context* ctx;
     Font font;
@@ -87,56 +113,15 @@ typedef struct LibretroMenu {
     nk_console* cheatsMenuButton;
     //nk_console* closeGameButton;
     int shaderSelectedIndex;
-    int textureFilterIndex;
     int themeSelectedIndex;
-    float volumeSelected;
     bool rewindEnabled;
     int menuComboIndex;
-    nk_rune keyScreenshot;
-    nk_rune keyRewind;
-    nk_rune keyMenu;
-    nk_rune keySaveState;
-    nk_rune keyLoadState;
-    nk_rune keyPrevSlot;
-    nk_rune keyNextSlot;
+    LibretroMenuBinding hotkeys[LIBRETRO_HOTKEY_COUNT];
     int saveSlotIndex;
-    nk_rune keyFullscreen;
-    nk_rune keyPrevShader;
-    nk_rune keyNextShader;
-    nk_rune keyReset;
-    nk_rune keyQuit;
-    nk_rune keyVolumeUp;
-    nk_rune keyVolumeDown;
-    nk_rune keyMute;
-    nk_rune keyFastForward;
     float fastForwardSpeed;
-    nk_rune keySlowMotion;
     float slowMotionSpeed;
-    enum nk_gamepad_button gamepadScreenshot;
-    enum nk_gamepad_button gamepadRewind;
-    enum nk_gamepad_button gamepadMenu;
-    enum nk_gamepad_button gamepadSaveState;
-    enum nk_gamepad_button gamepadLoadState;
-    enum nk_gamepad_button gamepadPrevSlot;
-    enum nk_gamepad_button gamepadNextSlot;
-    enum nk_gamepad_button gamepadFullscreen;
-    enum nk_gamepad_button gamepadPrevShader;
-    enum nk_gamepad_button gamepadNextShader;
-    enum nk_gamepad_button gamepadReset;
-    enum nk_gamepad_button gamepadQuit;
-    enum nk_gamepad_button gamepadVolumeUp;
-    enum nk_gamepad_button gamepadVolumeDown;
-    enum nk_gamepad_button gamepadMute;
-    enum nk_gamepad_button gamepadFastForward;
-    enum nk_gamepad_button gamepadSlowMotion;
     int optionSelectedIndices[LIBRETRO_MAX_CORE_VARIABLES];    // per-option combobox index
     nk_bool optionCheckboxValues[LIBRETRO_MAX_CORE_VARIABLES]; // per-option checkbox state for enabled/disabled options
-    char coreDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
-    char saveDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
-    char coreAssetsDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
-    char systemDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
-    char playlistsDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
-    char fileBrowserStartDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char loadGamePath[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     bool touchControls;
     bool touchHapticsEnabled;
@@ -371,12 +356,14 @@ static void LibretroMenuSettingChanged(nk_console* widget, void* user_data) {
     (void)user_data;
     SetActiveLibretroShader((LibretroShaderType)menu.shaderSelectedIndex);
     SetLibretroMenuStyle((LibretroMenuStyle)menu.themeSelectedIndex);
-    SetLibretroVolume(menu.volumeSelected);
-    if (LIBRETRO.textureFilter != menu.textureFilterIndex) {
-        LIBRETRO.textureFilter = menu.textureFilterIndex;
-        InitLibretroVideo();
-    }
-    SetExitKey(LibretroHotkeyToKeyboardKey(menu.keyQuit));
+    SetLibretroVolume(LIBRETRO.volume);
+    SetExitKey(LibretroHotkeyToKeyboardKey(menu.hotkeys[LIBRETRO_HOTKEY_QUIT].key));
+}
+
+static void LibretroMenuTextureFilterChanged(nk_console* widget, void* user_data) {
+    NK_UNUSED(widget);
+    NK_UNUSED(user_data);
+    InitLibretroVideo();
 }
 
 static LibretroMenu* GetLibretroMenu(void) {
@@ -980,21 +967,15 @@ static void MenuCommitSettings(nk_console* widget, void* user_data) {
 
 static void ScanLibretroCoreDirectory(void);
 
-static void LibretroApplyDirectories(void) {
-    TextCopy(LIBRETRO.coreDirectory,            menu.coreDirectory);
-    TextCopy(LIBRETRO.saveDirectory,            menu.saveDirectory);
-    TextCopy(LIBRETRO.coreAssetsDirectory,      menu.coreAssetsDirectory);
-    TextCopy(LIBRETRO.systemDirectory,          menu.systemDirectory);
-    TextCopy(LIBRETRO.playlistsDirectory,       menu.playlistsDirectory);
-    TextCopy(LIBRETRO.fileBrowserStartDirectory, menu.fileBrowserStartDirectory);
-    if (menu.saveDirectory[0] != '\0' && !DirectoryExists(menu.saveDirectory)) {
-        MakeDirectory(menu.saveDirectory);
+static void LibretroMenuEnsureSaveDir(void) {
+    if (LIBRETRO.saveDirectory[0] != '\0' && !DirectoryExists(LIBRETRO.saveDirectory)) {
+        MakeDirectory(LIBRETRO.saveDirectory);
     }
 }
 
 static void MenuDirChanged(nk_console* widget, void* user_data) {
     LibretroMenuSettingChanged(widget, user_data);
-    LibretroApplyDirectories();
+    LibretroMenuEnsureSaveDir();
 }
 
 static void MenuCoreDirChanged(nk_console* widget, void* user_data) {
@@ -1005,8 +986,8 @@ static void MenuCoreDirChanged(nk_console* widget, void* user_data) {
 static void MenuContentDirChanged(nk_console* widget, void* user_data) {
     MenuDirChanged(widget, user_data);
 #ifndef __EMSCRIPTEN__
-    if (menu.loadGameWidget && menu.fileBrowserStartDirectory[0] != '\0') {
-        nk_console_file_set_directory(menu.loadGameWidget, menu.fileBrowserStartDirectory);
+    if (menu.loadGameWidget && LIBRETRO.fileBrowserStartDirectory[0] != '\0') {
+        nk_console_file_set_directory(menu.loadGameWidget, LIBRETRO.fileBrowserStartDirectory);
     }
 #endif
 }
@@ -1032,7 +1013,7 @@ static int LibretroCoreDirectoryFileCount(const char* dir) {
 static void ScanLibretroCoreDirectory(void) {
 #ifdef RAYLIB_LIBRETRO_CONFIG_H
     if (!menu.cfg) return;
-    const char* dir = menu.coreDirectory;
+    const char* dir = LIBRETRO.coreDirectory;
     if (!dir || !dir[0]) return;
 
     // If a core is already loaded we can't peek at other cores; just invalidate
@@ -1188,10 +1169,9 @@ static const char* FindCoreForGame(const char* gamePath) {
 }
 
 static bool MenuInitCore(const char* corePath) {
-    LibretroApplyDirectories();
     if (!InitLibretro(corePath)) return false;
     LoadLibretroCoreOptions();
-    SetLibretroVolume(menu.volumeSelected);
+    SetLibretroVolume(LIBRETRO.volume);
     menu.cheatIndex = 0;
     menu.cheatBuffer[0] = '\0';
     menu.cheatList[0] = '\0';
@@ -1351,23 +1331,23 @@ typedef struct LibretroMenuHotkey {
  * Set of menu hot keys that will be built into input widgets in the Hot Keys menu.
  */
 static const LibretroMenuHotkey LibretroMenuHotkeys[] = {
-    { "Screenshot",      &menu.gamepadScreenshot,  &menu.keyScreenshot,  NK_CONSOLE_KEY_F8 },
-    { "Rewind",          &menu.gamepadRewind,      &menu.keyRewind,      (nk_rune)'R' },
-    { "Menu",            &menu.gamepadMenu,        &menu.keyMenu,        NK_CONSOLE_KEY_ESCAPE },
-    { "Save State",      &menu.gamepadSaveState,   &menu.keySaveState,   NK_CONSOLE_KEY_F2 },
-    { "Load State",      &menu.gamepadLoadState,   &menu.keyLoadState,   NK_CONSOLE_KEY_F4 },
-    { "Prev Slot",       &menu.gamepadPrevSlot,    &menu.keyPrevSlot,    NK_CONSOLE_KEY_NONE },
-    { "Next Slot",       &menu.gamepadNextSlot,    &menu.keyNextSlot,    NK_CONSOLE_KEY_NONE },
-    { "Fullscreen",      &menu.gamepadFullscreen,  &menu.keyFullscreen,  NK_CONSOLE_KEY_F11 },
-    { "Previous Shader", &menu.gamepadPrevShader,  &menu.keyPrevShader,  NK_CONSOLE_KEY_F9 },
-    { "Next Shader",     &menu.gamepadNextShader,  &menu.keyNextShader,  NK_CONSOLE_KEY_F10 },
-    { "Reset",           &menu.gamepadReset,       &menu.keyReset,       NK_CONSOLE_KEY_NONE },
-    { "Quit",            &menu.gamepadQuit,        &menu.keyQuit,        NK_CONSOLE_KEY_NONE },
-    { "Volume Up",       &menu.gamepadVolumeUp,    &menu.keyVolumeUp,    (nk_rune)'=' },
-    { "Volume Down",     &menu.gamepadVolumeDown,  &menu.keyVolumeDown,  (nk_rune)'-' },
-    { "Mute",            &menu.gamepadMute,        &menu.keyMute,        (nk_rune)'M' },
-    { "Fast Forward",    &menu.gamepadFastForward, &menu.keyFastForward, (nk_rune)'F' },
-    { "Slow Motion",     &menu.gamepadSlowMotion,  &menu.keySlowMotion,  (nk_rune)'G' },
+    { "Screenshot",      &menu.hotkeys[LIBRETRO_HOTKEY_SCREENSHOT].gamepad,   &menu.hotkeys[LIBRETRO_HOTKEY_SCREENSHOT].key,   NK_CONSOLE_KEY_F8 },
+    { "Rewind",          &menu.hotkeys[LIBRETRO_HOTKEY_REWIND].gamepad,       &menu.hotkeys[LIBRETRO_HOTKEY_REWIND].key,       (nk_rune)'R' },
+    { "Menu",            &menu.hotkeys[LIBRETRO_HOTKEY_MENU].gamepad,         &menu.hotkeys[LIBRETRO_HOTKEY_MENU].key,         NK_CONSOLE_KEY_ESCAPE },
+    { "Save State",      &menu.hotkeys[LIBRETRO_HOTKEY_SAVE_STATE].gamepad,   &menu.hotkeys[LIBRETRO_HOTKEY_SAVE_STATE].key,   NK_CONSOLE_KEY_F2 },
+    { "Load State",      &menu.hotkeys[LIBRETRO_HOTKEY_LOAD_STATE].gamepad,   &menu.hotkeys[LIBRETRO_HOTKEY_LOAD_STATE].key,   NK_CONSOLE_KEY_F4 },
+    { "Prev Slot",       &menu.hotkeys[LIBRETRO_HOTKEY_PREV_SLOT].gamepad,    &menu.hotkeys[LIBRETRO_HOTKEY_PREV_SLOT].key,    NK_CONSOLE_KEY_NONE },
+    { "Next Slot",       &menu.hotkeys[LIBRETRO_HOTKEY_NEXT_SLOT].gamepad,    &menu.hotkeys[LIBRETRO_HOTKEY_NEXT_SLOT].key,    NK_CONSOLE_KEY_NONE },
+    { "Fullscreen",      &menu.hotkeys[LIBRETRO_HOTKEY_FULLSCREEN].gamepad,   &menu.hotkeys[LIBRETRO_HOTKEY_FULLSCREEN].key,   NK_CONSOLE_KEY_F11 },
+    { "Previous Shader", &menu.hotkeys[LIBRETRO_HOTKEY_PREV_SHADER].gamepad,  &menu.hotkeys[LIBRETRO_HOTKEY_PREV_SHADER].key,  NK_CONSOLE_KEY_F9 },
+    { "Next Shader",     &menu.hotkeys[LIBRETRO_HOTKEY_NEXT_SHADER].gamepad,  &menu.hotkeys[LIBRETRO_HOTKEY_NEXT_SHADER].key,  NK_CONSOLE_KEY_F10 },
+    { "Reset",           &menu.hotkeys[LIBRETRO_HOTKEY_RESET].gamepad,        &menu.hotkeys[LIBRETRO_HOTKEY_RESET].key,        NK_CONSOLE_KEY_NONE },
+    { "Quit",            &menu.hotkeys[LIBRETRO_HOTKEY_QUIT].gamepad,         &menu.hotkeys[LIBRETRO_HOTKEY_QUIT].key,         NK_CONSOLE_KEY_NONE },
+    { "Volume Up",       &menu.hotkeys[LIBRETRO_HOTKEY_VOLUME_UP].gamepad,    &menu.hotkeys[LIBRETRO_HOTKEY_VOLUME_UP].key,    (nk_rune)'=' },
+    { "Volume Down",     &menu.hotkeys[LIBRETRO_HOTKEY_VOLUME_DOWN].gamepad,  &menu.hotkeys[LIBRETRO_HOTKEY_VOLUME_DOWN].key,  (nk_rune)'-' },
+    { "Mute",            &menu.hotkeys[LIBRETRO_HOTKEY_MUTE].gamepad,         &menu.hotkeys[LIBRETRO_HOTKEY_MUTE].key,         (nk_rune)'M' },
+    { "Fast Forward",    &menu.hotkeys[LIBRETRO_HOTKEY_FAST_FORWARD].gamepad, &menu.hotkeys[LIBRETRO_HOTKEY_FAST_FORWARD].key, (nk_rune)'F' },
+    { "Slow Motion",     &menu.hotkeys[LIBRETRO_HOTKEY_SLOW_MOTION].gamepad,  &menu.hotkeys[LIBRETRO_HOTKEY_SLOW_MOTION].key,  (nk_rune)'G' },
 };
 
 /**
@@ -1426,7 +1406,6 @@ LibretroMenu* InitLibretroMenu(void) {
     // Create the menu.
     menu = (LibretroMenu){0};
     menu.themeSelectedIndex = LIBRETRO_MENU_STYLE_CATPPUCCIN_MOCHA;
-    menu.volumeSelected = 1.0f;
     menu.vsync = nk_true;
     menu.fpsIndex = 0; // Auto
     menu.saveSlotIndex  = 0;
@@ -1477,20 +1456,20 @@ LibretroMenu* InitLibretroMenu(void) {
 #endif
 
     // Directories
-    TextCopy(menu.coreDirectory, "cores");
-    TextCopy(menu.saveDirectory, "saves");
-    TextCopy(menu.systemDirectory, "system");
+    TextCopy(LIBRETRO.coreDirectory, "cores");
+    TextCopy(LIBRETRO.saveDirectory, "saves");
+    TextCopy(LIBRETRO.systemDirectory, "system");
 #ifdef __EMSCRIPTEN__
     // Default save/system directories point at the IDBFS mount so they
     // persist across page reloads. The user can still override via the
     // Settings menu; saved values take precedence on subsequent runs.
-    TextCopy(menu.saveDirectory,   "/userdata/saves");
-    TextCopy(menu.systemDirectory, "/userdata/system");
+    TextCopy(LIBRETRO.saveDirectory,   "/userdata/saves");
+    TextCopy(LIBRETRO.systemDirectory, "/userdata/system");
 #endif
 
     // Menu Settings
     LoadLibretroMenuSettings();
-    LibretroApplyDirectories();
+    LibretroMenuEnsureSaveDir();
     ScanLibretroCoreDirectory();
 
     // Apply VSYNC/FPS even when no config was loaded, so the frame cap is always
@@ -1548,8 +1527,8 @@ LibretroMenu* InitLibretroMenu(void) {
 #else
     menu.loadGameWidget = nk_console_file_action(menu.console, "Load Game", menu.loadGamePath, RAYLIB_LIBRETRO_VFS_MAX_PATH);
     nk_console_add_event_handler(menu.loadGameWidget, NK_CONSOLE_EVENT_CHANGED, &MenuGameFileChanged, menu.loadGamePath, NULL);
-    if (menu.fileBrowserStartDirectory[0] != '\0') {
-        nk_console_file_set_directory(menu.loadGameWidget, menu.fileBrowserStartDirectory);
+    if (LIBRETRO.fileBrowserStartDirectory[0] != '\0') {
+        nk_console_file_set_directory(menu.loadGameWidget, LIBRETRO.fileBrowserStartDirectory);
     }
 #endif
     LibretroMenuUpdateLoadGameFilter(&menu);
@@ -1578,7 +1557,7 @@ LibretroMenu* InitLibretroMenu(void) {
                 NK_SYMBOL_TRIANGLE_UP);
 
             // Volume
-            nk_console* volume = nk_console_slider_float(graphicsMenu, "Volume", 0.0f, &menu.volumeSelected, 1.0f, RAYLIB_LIBRETRO_MENU_SLIDER_STEP(0.0f, 1.0f));
+            nk_console* volume = nk_console_slider_float(graphicsMenu, "Volume", 0.0f, &LIBRETRO.volume, 1.0f, RAYLIB_LIBRETRO_MENU_SLIDER_STEP(0.0f, 1.0f));
             nk_console_add_event_handler(volume, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
 
             nk_console* fullscreenCheckbox = nk_console_checkbox(graphicsMenu, "Fullscreen", &menu.fullscreen);
@@ -1607,8 +1586,8 @@ LibretroMenu* InitLibretroMenu(void) {
             nk_console* shaderCombo = nk_console_combobox(graphicsMenu, "Shader", shaderNames, '|', &menu.shaderSelectedIndex);
             nk_console_add_event_handler(shaderCombo, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
 
-            nk_console* textureFilter = nk_console_combobox(graphicsMenu, "Texture Filter", "None|Bilinear|Trilinear|Anisotropic 4x|Anisotropic 8x|Anisotropic 16x", '|', &menu.textureFilterIndex);
-            nk_console_add_event_handler(textureFilter, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+            nk_console* textureFilter = nk_console_combobox(graphicsMenu, "Texture Filter", "None|Bilinear|Trilinear|Anisotropic 4x|Anisotropic 8x|Anisotropic 16x", '|', &LIBRETRO.textureFilter);
+            nk_console_add_event_handler(textureFilter, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuTextureFilterChanged, NULL, NULL);
 
             nk_console* rotation = nk_console_combobox(graphicsMenu, "Rotation", "0 Degrees|90 Degrees|180 Degrees|270 Degrees", '|', &LIBRETRO.core.rotation);
             rotation->tooltip = "Override the display rotation for the running game.";
@@ -1698,22 +1677,22 @@ LibretroMenu* InitLibretroMenu(void) {
                 nk_console_button_onclick(dirMenu, "Directories", &nk_console_button_back),
                 NK_SYMBOL_TRIANGLE_UP);
 
-            nk_console* coreDirectory = nk_console_dir(dirMenu, "Cores", menu.coreDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+            nk_console* coreDirectory = nk_console_dir(dirMenu, "Cores", LIBRETRO.coreDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
             nk_console_add_event_handler(coreDirectory, NK_CONSOLE_EVENT_CHANGED, &MenuCoreDirChanged, NULL, NULL);
 
-            nk_console* saveDirectory = nk_console_dir(dirMenu, "Saves", menu.saveDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+            nk_console* saveDirectory = nk_console_dir(dirMenu, "Saves", LIBRETRO.saveDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
             nk_console_add_event_handler(saveDirectory, NK_CONSOLE_EVENT_CHANGED, &MenuDirChanged, NULL, NULL);
 
-            nk_console* coreAssetsDirectory = nk_console_dir(dirMenu, "Assets", menu.coreAssetsDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+            nk_console* coreAssetsDirectory = nk_console_dir(dirMenu, "Assets", LIBRETRO.coreAssetsDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
             nk_console_add_event_handler(coreAssetsDirectory, NK_CONSOLE_EVENT_CHANGED, &MenuDirChanged, NULL, NULL);
 
-            nk_console* systemDirectory = nk_console_dir(dirMenu, "System", menu.systemDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+            nk_console* systemDirectory = nk_console_dir(dirMenu, "System", LIBRETRO.systemDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
             nk_console_add_event_handler(systemDirectory, NK_CONSOLE_EVENT_CHANGED, &MenuDirChanged, NULL, NULL);
 
-            nk_console* playlistsDirectory = nk_console_dir(dirMenu, "Playlists", menu.playlistsDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+            nk_console* playlistsDirectory = nk_console_dir(dirMenu, "Playlists", LIBRETRO.playlistsDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
             nk_console_add_event_handler(playlistsDirectory, NK_CONSOLE_EVENT_CHANGED, &MenuDirChanged, NULL, NULL);
 
-            nk_console* fileBrowserStartDirectory = nk_console_dir(dirMenu, "Content", menu.fileBrowserStartDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
+            nk_console* fileBrowserStartDirectory = nk_console_dir(dirMenu, "Content", LIBRETRO.fileBrowserStartDirectory, RAYLIB_LIBRETRO_VFS_MAX_PATH);
             nk_console_add_event_handler(fileBrowserStartDirectory, NK_CONSOLE_EVENT_CHANGED, &MenuContentDirChanged, NULL, NULL);
         }
 
@@ -2192,9 +2171,9 @@ static void LibretroMenuUpdateConfig(void) {
     rlconfig_set_int(menu.cfg, "raylib-libretro", "vsync", (int)menu.vsync);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "fps", menu.fpsIndex);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "shader", menu.shaderSelectedIndex);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "textureFilter", menu.textureFilterIndex);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "textureFilter", LIBRETRO.textureFilter);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "theme", menu.themeSelectedIndex);
-    rlconfig_set_float(menu.cfg, "raylib-libretro", "volume", menu.volumeSelected);
+    rlconfig_set_float(menu.cfg, "raylib-libretro", "volume", LIBRETRO.volume);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "rewind", menu.rewindEnabled ? 1 : 0);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "analogToDpad", LIBRETRO.analogToDpadIndex);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "menuCombo", menu.menuComboIndex);
@@ -2216,12 +2195,12 @@ static void LibretroMenuUpdateConfig(void) {
         rlconfig_set_int(menu.cfg, "raylib-libretro", TextFormat("gamepad%s", shortName), (int)*hk->gamepad);
     }
 
-    rlconfig_set(menu.cfg, "raylib-libretro", "coreDirectory", LibretroResolveAbsoluteDirectory(menu.coreDirectory));
-    rlconfig_set(menu.cfg, "raylib-libretro", "saveDirectory", LibretroResolveAbsoluteDirectory(menu.saveDirectory));
-    rlconfig_set(menu.cfg, "raylib-libretro", "coreAssetsDirectory", LibretroResolveAbsoluteDirectory(menu.coreAssetsDirectory));
-    rlconfig_set(menu.cfg, "raylib-libretro", "systemDirectory", LibretroResolveAbsoluteDirectory(menu.systemDirectory));
-    rlconfig_set(menu.cfg, "raylib-libretro", "playlistsDirectory", LibretroResolveAbsoluteDirectory(menu.playlistsDirectory));
-    rlconfig_set(menu.cfg, "raylib-libretro", "fileBrowserStartDirectory", LibretroResolveAbsoluteDirectory(menu.fileBrowserStartDirectory));
+    rlconfig_set(menu.cfg, "raylib-libretro", "coreDirectory", LibretroResolveAbsoluteDirectory(LIBRETRO.coreDirectory));
+    rlconfig_set(menu.cfg, "raylib-libretro", "saveDirectory", LibretroResolveAbsoluteDirectory(LIBRETRO.saveDirectory));
+    rlconfig_set(menu.cfg, "raylib-libretro", "coreAssetsDirectory", LibretroResolveAbsoluteDirectory(LIBRETRO.coreAssetsDirectory));
+    rlconfig_set(menu.cfg, "raylib-libretro", "systemDirectory", LibretroResolveAbsoluteDirectory(LIBRETRO.systemDirectory));
+    rlconfig_set(menu.cfg, "raylib-libretro", "playlistsDirectory", LibretroResolveAbsoluteDirectory(LIBRETRO.playlistsDirectory));
+    rlconfig_set(menu.cfg, "raylib-libretro", "fileBrowserStartDirectory", LibretroResolveAbsoluteDirectory(LIBRETRO.fileBrowserStartDirectory));
 
     for (int i = 0; i <= RETRO_DEVICE_ID_JOYPAD_R3; i++) {
         rlconfig_set_int(menu.cfg, "raylib-libretro", TextFormat("keyboard%d", i), LIBRETRO.keyboardPlayer1[i]);
@@ -2402,22 +2381,19 @@ static bool LoadLibretroMenuSettings(void) {
     }
     SetActiveLibretroShader((LibretroShaderType)menu.shaderSelectedIndex);
 
-    menu.textureFilterIndex = rlconfig_get_int(menu.cfg, "raylib-libretro", "textureFilter", 0);
-    if (menu.textureFilterIndex < 0 || menu.textureFilterIndex > TEXTURE_FILTER_ANISOTROPIC_16X)
-        menu.textureFilterIndex = 0;
-    LIBRETRO.textureFilter = menu.textureFilterIndex;
+    LIBRETRO.textureFilter = rlconfig_get_int(menu.cfg, "raylib-libretro", "textureFilter", 0);
+    if (LIBRETRO.textureFilter < 0 || LIBRETRO.textureFilter > TEXTURE_FILTER_ANISOTROPIC_16X)
+        LIBRETRO.textureFilter = 0;
 
     menu.themeSelectedIndex = rlconfig_get_int(menu.cfg, "raylib-libretro", "theme", LIBRETRO_MENU_STYLE_DRACULA);
     if (menu.themeSelectedIndex < 0 || menu.themeSelectedIndex >= LIBRETRO_MENU_STYLE_COUNT)
         menu.themeSelectedIndex = LIBRETRO_MENU_STYLE_DRACULA;
     SetLibretroMenuStyle((LibretroMenuStyle)menu.themeSelectedIndex);
 
-    menu.volumeSelected = rlconfig_get_float(menu.cfg, "raylib-libretro", "volume", menu.volumeSelected);
+    float savedVolume = rlconfig_get_float(menu.cfg, "raylib-libretro", "volume", LIBRETRO.volume);
     // Migrate the legacy 0..100 integer storage to the 0.0..1.0 float scale.
-    if (menu.volumeSelected > 1.0f) menu.volumeSelected /= 100.0f;
-    if (menu.volumeSelected < 0.0f) menu.volumeSelected = 0.0f;
-    if (menu.volumeSelected > 1.0f) menu.volumeSelected = 1.0f;
-    SetLibretroVolume(menu.volumeSelected);
+    if (savedVolume > 1.0f) savedVolume /= 100.0f;
+    SetLibretroVolume(savedVolume);
 
     menu.rewindEnabled = rlconfig_get_int(menu.cfg, "raylib-libretro", "rewind", 0) > 0;
     LIBRETRO.analogToDpadIndex = rlconfig_get_int(menu.cfg, "raylib-libretro", "analogToDpad", 0);
@@ -2444,7 +2420,7 @@ static bool LoadLibretroMenuSettings(void) {
         *hk->key = (nk_rune)rlconfig_get_int(menu.cfg, "raylib-libretro", TextFormat("key%s", shortName), (int)*hk->key);
         *hk->gamepad = (enum nk_gamepad_button)rlconfig_get_int(menu.cfg, "raylib-libretro", TextFormat("gamepad%s", shortName), (int)*hk->gamepad);
     }
-    SetExitKey(LibretroHotkeyToKeyboardKey(menu.keyQuit));
+    SetExitKey(LibretroHotkeyToKeyboardKey(menu.hotkeys[LIBRETRO_HOTKEY_QUIT].key));
 
     menu.fastForwardSpeed = rlconfig_get_float(menu.cfg, "raylib-libretro", "fastForwardSpeed", menu.fastForwardSpeed);
     if (menu.fastForwardSpeed < 1.1f) menu.fastForwardSpeed = 1.1f;
@@ -2456,17 +2432,17 @@ static bool LoadLibretroMenuSettings(void) {
     if (menu.slowMotionSpeed > 0.9f) menu.slowMotionSpeed = 0.9f;
 
     const char* coreDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "coreDirectory");
-    if (coreDirectory) TextCopy(menu.coreDirectory, coreDirectory);
+    if (coreDirectory) TextCopy(LIBRETRO.coreDirectory, coreDirectory);
     const char* saveDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "saveDirectory");
-    if (saveDirectory) TextCopy(menu.saveDirectory, saveDirectory);
+    if (saveDirectory) TextCopy(LIBRETRO.saveDirectory, saveDirectory);
     const char* coreAssetsDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "coreAssetsDirectory");
-    if (coreAssetsDirectory) TextCopy(menu.coreAssetsDirectory, coreAssetsDirectory);
+    if (coreAssetsDirectory) TextCopy(LIBRETRO.coreAssetsDirectory, coreAssetsDirectory);
     const char* systemDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "systemDirectory");
-    if (systemDirectory) TextCopy(menu.systemDirectory, systemDirectory);
+    if (systemDirectory) TextCopy(LIBRETRO.systemDirectory, systemDirectory);
     const char* playlistsDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "playlistsDirectory");
-    if (playlistsDirectory) TextCopy(menu.playlistsDirectory, playlistsDirectory);
+    if (playlistsDirectory) TextCopy(LIBRETRO.playlistsDirectory, playlistsDirectory);
     const char* fileBrowserStartDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "fileBrowserStartDirectory");
-    if (fileBrowserStartDirectory) TextCopy(menu.fileBrowserStartDirectory, fileBrowserStartDirectory);
+    if (fileBrowserStartDirectory) TextCopy(LIBRETRO.fileBrowserStartDirectory, fileBrowserStartDirectory);
 
     // Read raylib KeyboardKey values written under "keyboardP1[..]"; missing keys
     // keep the defaults seeded into LIBRETRO.keyboardPlayer1 at init.
@@ -2582,7 +2558,7 @@ void UpdateLibretroMenu(void) {// If there is no menu, skip.
     }
 
     // Menu Key
-    if ((IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.keyMenu)) || LibretroHotkeyGPReleased(menu.gamepadMenu)) && !menu.active) {
+    if ((IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.hotkeys[LIBRETRO_HOTKEY_MENU].key)) || LibretroHotkeyGPReleased(menu.hotkeys[LIBRETRO_HOTKEY_MENU].gamepad)) && !menu.active) {
         ShowLibretroMenu();
     }
 

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -1380,30 +1380,29 @@ LibretroMenu* InitLibretroMenu(void) {
 
     // Default hotkey bindings — names and defaults live here so NK_CONSOLE_KEY_*
     // constants are declared by this point (vendor headers already included above).
-    static const struct { const char* name; nk_rune defaultKey; } hotkeyDefs[LIBRETRO_HOTKEY_COUNT] = {
-        { "Screenshot",      NK_CONSOLE_KEY_F8     },
-        { "Rewind",          (nk_rune)'R'          },
-        { "Menu",            NK_CONSOLE_KEY_ESCAPE },
-        { "Save State",      NK_CONSOLE_KEY_F2     },
-        { "Load State",      NK_CONSOLE_KEY_F4     },
-        { "Prev Slot",       NK_CONSOLE_KEY_NONE   },
-        { "Next Slot",       NK_CONSOLE_KEY_NONE   },
-        { "Fullscreen",      NK_CONSOLE_KEY_F11    },
-        { "Previous Shader", NK_CONSOLE_KEY_F9     },
-        { "Next Shader",     NK_CONSOLE_KEY_F10    },
-        { "Reset",           NK_CONSOLE_KEY_NONE   },
-        { "Quit",            NK_CONSOLE_KEY_NONE   },
-        { "Volume Up",       (nk_rune)'='          },
-        { "Volume Down",     (nk_rune)'-'          },
-        { "Mute",            (nk_rune)'M'          },
-        { "Fast Forward",    (nk_rune)'F'          },
-        { "Slow Motion",     (nk_rune)'G'          },
+    static const LibretroMenuBinding hotkeyDefs[LIBRETRO_HOTKEY_COUNT] = {
+        { .name = "Screenshot",      .defaultKey = NK_CONSOLE_KEY_F8     },
+        { .name = "Rewind",          .defaultKey = (nk_rune)'R'          },
+        { .name = "Menu",            .defaultKey = NK_CONSOLE_KEY_ESCAPE },
+        { .name = "Save State",      .defaultKey = NK_CONSOLE_KEY_F2     },
+        { .name = "Load State",      .defaultKey = NK_CONSOLE_KEY_F4     },
+        { .name = "Prev Slot",       .defaultKey = NK_CONSOLE_KEY_NONE   },
+        { .name = "Next Slot",       .defaultKey = NK_CONSOLE_KEY_NONE   },
+        { .name = "Fullscreen",      .defaultKey = NK_CONSOLE_KEY_F11    },
+        { .name = "Previous Shader", .defaultKey = NK_CONSOLE_KEY_F9     },
+        { .name = "Next Shader",     .defaultKey = NK_CONSOLE_KEY_F10    },
+        { .name = "Reset",           .defaultKey = NK_CONSOLE_KEY_NONE   },
+        { .name = "Quit",            .defaultKey = NK_CONSOLE_KEY_NONE   },
+        { .name = "Volume Up",       .defaultKey = (nk_rune)'='          },
+        { .name = "Volume Down",     .defaultKey = (nk_rune)'-'          },
+        { .name = "Mute",            .defaultKey = (nk_rune)'M'          },
+        { .name = "Fast Forward",    .defaultKey = (nk_rune)'F'          },
+        { .name = "Slow Motion",     .defaultKey = (nk_rune)'G'          },
     };
     for (int i = 0; i < LIBRETRO_HOTKEY_COUNT; i++) {
-        menu.hotkeys[i].name       = hotkeyDefs[i].name;
-        menu.hotkeys[i].defaultKey = hotkeyDefs[i].defaultKey;
-        menu.hotkeys[i].key        = hotkeyDefs[i].defaultKey;
-        menu.hotkeys[i].gamepad    = NK_GAMEPAD_BUTTON_INVALID;
+        menu.hotkeys[i]        = hotkeyDefs[i];
+        menu.hotkeys[i].key    = hotkeyDefs[i].defaultKey;
+        menu.hotkeys[i].gamepad = NK_GAMEPAD_BUTTON_INVALID;
     }
 
     // Font


### PR DESCRIPTION
Replace duplicated fields across `LibretroMenu` and `LibretroData` with shared or direct references.

- Replace 34 individual `nk_rune key*` / `gamepad*` fields with `LibretroMenuBinding hotkeys[LIBRETRO_HOTKEY_COUNT]`
- Remove `menu.textureFilterIndex` shadow — combobox now binds to `LIBRETRO.textureFilter` directly
- Remove `menu.volumeSelected` shadow — slider now binds to `LIBRETRO.volume` directly
- Remove 6 duplicated directory fields from `LibretroMenu` — widgets and config load/save use `LIBRETRO.*` directly, eliminating `LibretroApplyDirectories()` and its 12 `TextCopy` calls