### PR TITLE
Add Beetle Cygne (WonderSwan/Color) core

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -200,7 +200,8 @@ if ("${PLATFORM}" STREQUAL "Web")
     # when STATIC_LINKING=1, on the assumption that the frontend provides them.
     # As a self-contained side module the core must include them itself.
     build_libretro_side_module(picodrive "https://github.com/libretro/picodrive"         "Makefile.libretro" "" STATIC_LINKING=0)
-    build_libretro_side_module(prboom    "https://github.com/libretro/libretro-prboom"   "Makefile"          "")
+    build_libretro_side_module(prboom        "https://github.com/libretro/libretro-prboom"       "Makefile"          "")
+    build_libretro_side_module(mednafen_wswan "https://github.com/libretro/beetle-wswan-libretro" "Makefile"          "")
 
     if (LIBRETRO_SIDE_MODULES)
         add_custom_target(libretro-side-modules ALL DEPENDS ${LIBRETRO_SIDE_MODULES})
@@ -228,6 +229,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
             "https://buildbot.libretro.com/nightly/linux/aarch64/latest/mgba_libretro.so.zip"
             "https://buildbot.libretro.com/nightly/linux/aarch64/latest/picodrive_libretro.so.zip"
             "https://buildbot.libretro.com/nightly/linux/aarch64/latest/prboom_libretro.so.zip"
+            "https://buildbot.libretro.com/nightly/linux/aarch64/latest/mednafen_wswan_libretro.so.zip"
         )
     elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
         download_cores(
@@ -237,6 +239,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
             "https://buildbot.libretro.com/nightly/linux/x86_64/latest/mgba_libretro.so.zip"
             "https://buildbot.libretro.com/nightly/linux/x86_64/latest/picodrive_libretro.so.zip"
             "https://buildbot.libretro.com/nightly/linux/x86_64/latest/prboom_libretro.so.zip"
+            "https://buildbot.libretro.com/nightly/linux/x86_64/latest/mednafen_wswan_libretro.so.zip"
         )
     endif()
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
@@ -248,6 +251,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
             "https://buildbot.libretro.com/nightly/windows/x86_64/latest/mgba_libretro.dll.zip"
             "https://buildbot.libretro.com/nightly/windows/x86_64/latest/picodrive_libretro.dll.zip"
             "https://buildbot.libretro.com/nightly/windows/x86_64/latest/prboom_libretro.dll.zip"
+            "https://buildbot.libretro.com/nightly/windows/x86_64/latest/mednafen_wswan_libretro.dll.zip"
         )
     endif()
 elseif (APPLE)
@@ -264,6 +268,7 @@ elseif (APPLE)
             "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/mgba_libretro.dylib.zip"
             "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/picodrive_libretro.dylib.zip"
             "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/prboom_libretro.dylib.zip"
+            "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/mednafen_wswan_libretro.dylib.zip"
         )
     else()
         download_cores(
@@ -273,6 +278,7 @@ elseif (APPLE)
             "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/mgba_libretro.dylib.zip"
             "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/picodrive_libretro.dylib.zip"
             "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/prboom_libretro.dylib.zip"
+            "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/mednafen_wswan_libretro.dylib.zip"
         )
     endif()
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Android")
@@ -283,6 +289,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Android")
         "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/mgba_libretro_android.so.zip"
         "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/picodrive_libretro_android.so.zip"
         "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/prboom_libretro_android.so.zip"
+        "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/mednafen_wswan_libretro_android.so.zip"
     )
 endif()
 


### PR DESCRIPTION
Adds `mednafen_wswan_libretro` (Beetle Cygne) to all platform core download lists in `bin/CMakeLists.txt`, including Linux, Windows, macOS, Android, and the Emscripten web build. Fixes #265