### PR TITLE
Fix broken release architectures

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -104,7 +104,15 @@ jobs:
         with:
           submodules: recursive
       - name: Install Dependencies
-        run: sudo apt-get update && sudo apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
+        run: |
+          sudo dpkg --add-architecture armhf
+          sudo apt-get update
+          sudo apt-get install -y \
+            gcc-arm-linux-gnueabihf \
+            g++-arm-linux-gnueabihf \
+            libgles2-mesa-dev:armhf \
+            libdrm-dev:armhf \
+            libgbm-dev:armhf
       - name: Configure
         run: |
           cmake -B build \
@@ -114,6 +122,9 @@ jobs:
             -DCMAKE_SYSTEM_PROCESSOR=armv7 \
             -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc \
             -DCMAKE_CXX_COMPILER=arm-linux-gnueabihf-g++ \
+            -DCMAKE_FIND_ROOT_PATH=/usr/arm-linux-gnueabihf \
+            -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH \
+            -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY \
             -DPLATFORM=DRM
       - name: Build
         run: cmake --build build --parallel

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -42,6 +42,7 @@ target_compile_definitions(raylib-libretro PRIVATE
 if (NOT DEFINED CORES_DIR)
     set(CORES_DIR "${CMAKE_BINARY_DIR}/cores")
 endif()
+file(MAKE_DIRECTORY "${CORES_DIR}")
 
 # download_cores(<url> [<url> ...])
 # Downloads each zip URL to the build directory and extracts it into CORES_DIR.

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -356,40 +356,39 @@ static void SetupAndroidEnvironment(LibretroMenu* menu) {
 
     // Only override values still at the relative desktop defaults — an absolute
     // path means the user (or a saved config) already chose a directory.
-    if (menu->coreDirectory[0]   != '/') TextCopy(menu->coreDirectory,   TextFormat("%s/cores", dataDir));
-    if (menu->saveDirectory[0]   != '/') TextCopy(menu->saveDirectory,   TextFormat("%s/saves", dataDir));
-    if (menu->systemDirectory[0] != '/') TextCopy(menu->systemDirectory, TextFormat("%s/system", dataDir));
-    if (menu->fileBrowserStartDirectory[0] == '\0' && externalDir != NULL) {
-        TextCopy(menu->fileBrowserStartDirectory, externalDir);
+    if (LIBRETRO.coreDirectory[0]   != '/') TextCopy(LIBRETRO.coreDirectory,   TextFormat("%s/cores", dataDir));
+    if (LIBRETRO.saveDirectory[0]   != '/') TextCopy(LIBRETRO.saveDirectory,   TextFormat("%s/saves", dataDir));
+    if (LIBRETRO.systemDirectory[0] != '/') TextCopy(LIBRETRO.systemDirectory, TextFormat("%s/system", dataDir));
+    if (LIBRETRO.fileBrowserStartDirectory[0] == '\0' && externalDir != NULL) {
+        TextCopy(LIBRETRO.fileBrowserStartDirectory, externalDir);
     }
 
-    MakeDirectory(menu->coreDirectory);
-    MakeDirectory(menu->saveDirectory);
-    MakeDirectory(menu->systemDirectory);
+    MakeDirectory(LIBRETRO.coreDirectory);
+    MakeDirectory(LIBRETRO.saveDirectory);
+    MakeDirectory(LIBRETRO.systemDirectory);
 
     // Install each core listed in the build-generated assets/cores.list.
     char* list = LoadFileText("cores.list");
     if (list != NULL) {
         int count = 0;
-        const char** lines = TextSplit(list, '\n', &count);
+        char** lines = TextSplit(list, '\n', &count);
         for (int i = 0; i < count; i++) {
             char coreName[256];
             TextCopy(coreName, lines[i]);
             int len = TextLength(coreName);
             if (len > 0 && coreName[len - 1] == '\r') coreName[len - 1] = '\0';
             if (coreName[0] == '\0') continue;
-            AndroidCopyCore(coreName, menu->coreDirectory);
+            AndroidCopyCore(coreName, LIBRETRO.coreDirectory);
         }
         UnloadFileText(list);
     } else {
         TraceLog(LOG_WARNING, "ANDROID: cores.list missing; no bundled cores to install");
     }
 
-    // Re-apply the directories and rescan now that the cores are on disk.
-    LibretroApplyDirectories();
+    // Rescan the core directory now that bundled cores are on disk.
     ScanLibretroCoreDirectory();
-    if (menu->loadGameWidget != NULL && menu->fileBrowserStartDirectory[0] != '\0') {
-        nk_console_file_set_directory(menu->loadGameWidget, menu->fileBrowserStartDirectory);
+    if (menu->loadGameWidget != NULL && LIBRETRO.fileBrowserStartDirectory[0] != '\0') {
+        nk_console_file_set_directory(menu->loadGameWidget, LIBRETRO.fileBrowserStartDirectory);
     }
 
     INIT_TRACE("ANDROID/INIT: requesting storage access");


### PR DESCRIPTION
Fixes armv7 (missing GLES/DRM cross-compile headers), Android (LIBRETRO struct member access + removed missing LibretroApplyDirectories call), and Windows ARM64 (CORES_DIR not created before install). Fixes #272