### PR TITLE
remove gambatte core

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Features
 
 - Multi-System Emulator for NES, SNES, GB, GBA, SMS/GG
-- Shipped Cores: fceumm, snes9x, gambatte, mgba, picodrive, prboom
+- Shipped Cores: fceumm, snes9x, mgba, picodrive, prboom
 - Gamepad, Keyboard, On-Screen Controls
 - Audio
 - Fast Forward, Slow Motion, Rewind
@@ -22,7 +22,6 @@
 | System | Core | Extensions |
 | --- | --- | --- |
 | PC Engine / TurboGrafx-16 | `mednafen_pce_fast` | `.pce`, `.cue`, `.ccd`, `.chd`, `.toc`, `.m3u` |
-| Game Boy / Game Boy Color | `gambatte` | `.gb`, `.gbc`, `.dmg` |
 | WonderSwan / WonderSwan Color | `mednafen_wswan` | `.ws`, `.wsc`, `.pc2` |
 | Sega Genesis / Mega Drive / Master System / Game Gear / 32X / Sega CD | `picodrive` | `.bin`, `.gen`, `.smd`, `.md`, `.32x`, `.cue`, `.iso`, `.chd`, `.m3u`, `.sms`, `.gg`, `.sg`, `.sc`, `.68k`, `.sgd`, `.pco`, `.vgm`, `.vgz` |
 | Doom (PrBoom Engine) | `prboom` | `.wad`, `.iwad`, `.pwad`, `.lmp`, `.m3u` |

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@
 
 | System | Core | Extensions |
 | --- | --- | --- |
+| Nintendo Entertainment System (NES)** | `fceumm` | `.fds`, `.nes`, `.unf`, `.unif` |
+| Super Nintendo (SNES) | `snes9x` | `.smc`, `.sfc`, `.swc`, `.fig`, `.bs`, `.st` |
+| Game Boy / Color / Advance | `mgba` | `.gba`, `.gb`, `.gbc`, `.sgb` |
+| Sega Genesis / Mega Drive / Master System / Game Gear / 32X / Sega CD | `picodrive` | `.bin`, `.gen`, `.smd`, `.md`, `.32x`, `.cue`, `.iso`, `.chd`, `.m3u`, `.sms`, `.gg`, `.sg`, `.sc`, `.68k`, `.sgd`, `.pco`, `.vgm`, `.vgz` |
 | PC Engine / TurboGrafx-16 | `mednafen_pce_fast` | `.pce`, `.cue`, `.ccd`, `.chd`, `.toc`, `.m3u` |
 | WonderSwan / WonderSwan Color | `mednafen_wswan` | `.ws`, `.wsc`, `.pc2` |
-| Sega Genesis / Mega Drive / Master System / Game Gear / 32X / Sega CD | `picodrive` | `.bin`, `.gen`, `.smd`, `.md`, `.32x`, `.cue`, `.iso`, `.chd`, `.m3u`, `.sms`, `.gg`, `.sg`, `.sc`, `.68k`, `.sgd`, `.pco`, `.vgm`, `.vgz` |
 | Doom (PrBoom Engine) | `prboom` | `.wad`, `.iwad`, `.pwad`, `.lmp`, `.m3u` |
-| Nintendo Entertainment System (NES) / Famicom Disk System** | `fceumm` | `.fds`, `.nes`, `.unf`, `.unif` |
-| Super Nintendo (SNES) | `snes9x` | `.smc`, `.sfc`, `.swc`, `.fig`, `.bs`, `.st` |
-| Game Boy Advance | `mgba` | `.gba`, `.gb`, `.gbc`, `.sgb` |
 
 ## Usage
 

--- a/android/README.md
+++ b/android/README.md
@@ -105,7 +105,7 @@ when linking `libmain` to force it to be kept and exported. Without it the APK
 crashes instantly with a blank screen.
 
 ### Cores
-The bundled cores — **fceumm, snes9x, gambatte, mgba, picodrive** — are
+The bundled cores — **fceumm, snes9x, mgba, picodrive** — are
 downloaded at configure time into `app/src/main/assets/cores/`, with a generated
 `cores.list` naming them. They are stored uncompressed (`noCompress 'so'`) so
 they can be read and copied out efficiently. `SetupAndroidEnvironment()` in

--- a/android/app/CMakeLists.txt
+++ b/android/app/CMakeLists.txt
@@ -14,7 +14,6 @@ set(CORE_NAMES "")
 foreach(URL IN ITEMS
     "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/fceumm_libretro_android.so.zip"
     "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/snes9x_libretro_android.so.zip"
-    "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/gambatte_libretro_android.so.zip"
     "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/mgba_libretro_android.so.zip"
     "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/picodrive_libretro_android.so.zip"
 )

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -195,7 +195,6 @@ if ("${PLATFORM}" STREQUAL "Web")
 
     build_libretro_side_module(fceumm    "https://github.com/libretro/libretro-fceumm"   "Makefile.libretro" "")
     build_libretro_side_module(snes9x    "https://github.com/libretro/snes9x"            "Makefile"          "libretro")
-    build_libretro_side_module(gambatte  "https://github.com/libretro/gambatte-libretro" "Makefile.libretro" "")
     build_libretro_side_module(mgba      "https://github.com/libretro/mgba"              "Makefile.libretro" "")
     # picodrive's Makefile skips libretro-common (including filestream_vfs_init)
     # when STATIC_LINKING=1, on the assumption that the frontend provides them.
@@ -227,7 +226,6 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
         download_cores(
             "https://buildbot.libretro.com/nightly/linux/aarch64/latest/fceumm_libretro.so.zip"
             "https://buildbot.libretro.com/nightly/linux/aarch64/latest/snes9x_libretro.so.zip"
-            "https://buildbot.libretro.com/nightly/linux/aarch64/latest/gambatte_libretro.so.zip"
             "https://buildbot.libretro.com/nightly/linux/aarch64/latest/mgba_libretro.so.zip"
             "https://buildbot.libretro.com/nightly/linux/aarch64/latest/picodrive_libretro.so.zip"
             "https://buildbot.libretro.com/nightly/linux/aarch64/latest/prboom_libretro.so.zip"
@@ -238,7 +236,6 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
         download_cores(
             "https://buildbot.libretro.com/nightly/linux/x86_64/latest/fceumm_libretro.so.zip"
             "https://buildbot.libretro.com/nightly/linux/x86_64/latest/snes9x_libretro.so.zip"
-            "https://buildbot.libretro.com/nightly/linux/x86_64/latest/gambatte_libretro.so.zip"
             "https://buildbot.libretro.com/nightly/linux/x86_64/latest/mgba_libretro.so.zip"
             "https://buildbot.libretro.com/nightly/linux/x86_64/latest/picodrive_libretro.so.zip"
             "https://buildbot.libretro.com/nightly/linux/x86_64/latest/prboom_libretro.so.zip"
@@ -251,7 +248,6 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
         download_cores(
             "https://buildbot.libretro.com/nightly/windows/x86_64/latest/fceumm_libretro.dll.zip"
             "https://buildbot.libretro.com/nightly/windows/x86_64/latest/snes9x_libretro.dll.zip"
-            "https://buildbot.libretro.com/nightly/windows/x86_64/latest/gambatte_libretro.dll.zip"
             "https://buildbot.libretro.com/nightly/windows/x86_64/latest/mgba_libretro.dll.zip"
             "https://buildbot.libretro.com/nightly/windows/x86_64/latest/picodrive_libretro.dll.zip"
             "https://buildbot.libretro.com/nightly/windows/x86_64/latest/prboom_libretro.dll.zip"
@@ -269,7 +265,6 @@ elseif (APPLE)
         download_cores(
             "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/fceumm_libretro.dylib.zip"
             "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/snes9x_libretro.dylib.zip"
-            "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/gambatte_libretro.dylib.zip"
             "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/mgba_libretro.dylib.zip"
             "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/picodrive_libretro.dylib.zip"
             "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/prboom_libretro.dylib.zip"
@@ -280,7 +275,6 @@ elseif (APPLE)
         download_cores(
             "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/fceumm_libretro.dylib.zip"
             "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/snes9x_libretro.dylib.zip"
-            "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/gambatte_libretro.dylib.zip"
             "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/mgba_libretro.dylib.zip"
             "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/picodrive_libretro.dylib.zip"
             "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/prboom_libretro.dylib.zip"
@@ -292,7 +286,6 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Android")
     download_cores(
         "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/fceumm_libretro_android.so.zip"
         "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/snes9x_libretro_android.so.zip"
-        "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/gambatte_libretro_android.so.zip"
         "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/mgba_libretro_android.so.zip"
         "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/picodrive_libretro_android.so.zip"
         "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/prboom_libretro_android.so.zip"


### PR DESCRIPTION
Removes gambatte from all platform build configs and docs since mgba already covers Game Boy and Game Boy Color. Fixes #278