### PR TITLE
touch: replace LibretroTouchJoypadGamepad with raylib-libretro.h equivalent

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -4,7 +4,7 @@ A roadmap of some interesting features to consider.
 
 ## Quick Fixes
 - [ ] Within raylib-libretro-touch.h, within LibretroTouchJoypadKeyboard(), if the menu is available, then get the menu setting for the related keyboard controls instead of hardcoding the keys.
-- [ ] Within raylib-libretro-touch.h, there is a LibretroTouchJoypadGamepad() function. Isn't there a function like this directly withing raylib-libretro.h we could use instead? Would save some function definitions.
+- [x] Within raylib-libretro-touch.h, there is a LibretroTouchJoypadGamepad() function. Isn't there a function like this directly withing raylib-libretro.h we could use instead? Would save some function definitions.
 - [ ] Within raylib-libretro-touch.h, there's a LibretroTouchFadeColor() function. Isn't there a raylib function we could use for this instead?
 - [x] Is there a way to have the Emscripten Fullscreen capabilities be handled through the Settings>Graphics>Fullscreen toggle widget?
 - [x] Anything that should be persistent across LibretroCore loading, move to a Libretro structure instead. Split into `LibretroData` (persistent: directories, volume, speed) and `LibretroCoreData` (per-load state, reset with `memset(0)`). Global renamed to `LIBRETRO`.

--- a/include/raylib-libretro-touch.h
+++ b/include/raylib-libretro-touch.h
@@ -178,38 +178,13 @@ static int LibretroTouchJoypadKeyboard(int buttonId) {
 }
 
 /**
- * Returns the raylib GamepadButton mapped to a joypad button for port 0.
- */
-static int LibretroTouchJoypadGamepad(int buttonId) {
-    switch (buttonId) {
-        case RETRO_DEVICE_ID_JOYPAD_UP:     return GAMEPAD_BUTTON_LEFT_FACE_UP;
-        case RETRO_DEVICE_ID_JOYPAD_DOWN:   return GAMEPAD_BUTTON_LEFT_FACE_DOWN;
-        case RETRO_DEVICE_ID_JOYPAD_LEFT:   return GAMEPAD_BUTTON_LEFT_FACE_LEFT;
-        case RETRO_DEVICE_ID_JOYPAD_RIGHT:  return GAMEPAD_BUTTON_LEFT_FACE_RIGHT;
-        case RETRO_DEVICE_ID_JOYPAD_B:      return GAMEPAD_BUTTON_RIGHT_FACE_DOWN;
-        case RETRO_DEVICE_ID_JOYPAD_A:      return GAMEPAD_BUTTON_RIGHT_FACE_RIGHT;
-        case RETRO_DEVICE_ID_JOYPAD_Y:      return GAMEPAD_BUTTON_RIGHT_FACE_LEFT;
-        case RETRO_DEVICE_ID_JOYPAD_X:      return GAMEPAD_BUTTON_RIGHT_FACE_UP;
-        case RETRO_DEVICE_ID_JOYPAD_SELECT: return GAMEPAD_BUTTON_MIDDLE_LEFT;
-        case RETRO_DEVICE_ID_JOYPAD_START:  return GAMEPAD_BUTTON_MIDDLE_RIGHT;
-        case RETRO_DEVICE_ID_JOYPAD_L:      return GAMEPAD_BUTTON_LEFT_TRIGGER_1;
-        case RETRO_DEVICE_ID_JOYPAD_R:      return GAMEPAD_BUTTON_RIGHT_TRIGGER_1;
-        case RETRO_DEVICE_ID_JOYPAD_L2:     return GAMEPAD_BUTTON_LEFT_TRIGGER_2;
-        case RETRO_DEVICE_ID_JOYPAD_R2:     return GAMEPAD_BUTTON_RIGHT_TRIGGER_2;
-        case RETRO_DEVICE_ID_JOYPAD_L3:     return GAMEPAD_BUTTON_LEFT_THUMB;
-        case RETRO_DEVICE_ID_JOYPAD_R3:     return GAMEPAD_BUTTON_RIGHT_THUMB;
-        default: return GAMEPAD_BUTTON_UNKNOWN;
-    }
-}
-
-/**
  * Returns true if the joypad button is currently held via keyboard or gamepad.
  */
 static bool LibretroTouchIsPhysicalButtonDown(int buttonId) {
     int key = LibretroTouchJoypadKeyboard(buttonId);
     if (key != KEY_NULL && IsKeyDown(key)) return true;
     if (IsGamepadAvailable(0)) {
-        int gbtn = LibretroTouchJoypadGamepad(buttonId);
+        int gbtn = LibretroRetroJoypadButtonToGamepadButton(buttonId);
         if (gbtn != GAMEPAD_BUTTON_UNKNOWN && IsGamepadButtonDown(0, gbtn)) return true;
     }
     return false;


### PR DESCRIPTION
Removes the duplicate `LibretroTouchJoypadGamepad()` from `raylib-libretro-touch.h` and replaces its single call site with `LibretroRetroJoypadButtonToGamepadButton()` from `raylib-libretro.h`. Fixes #287