### PR TITLE
video: add integer scaling mode

### DIFF
--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -133,7 +133,6 @@ typedef struct LibretroMenu {
     int orientationIndex;                 // Android screen orientation: 0 = Landscape, 1 = Portrait, 2 = Auto
     nk_bool hideCursor;
     nk_bool lockCursor;
-    nk_bool integerScaling;
     char cheatBuffer[256];
     char cheatList[1024];
     unsigned cheatIndex;
@@ -469,12 +468,6 @@ static nk_console* LibretroMenuKeyConsole(nk_console* parent, const char* label,
     nk_console_add_event_handler(widget, NK_CONSOLE_EVENT_CHANGED,
         &LibretroMenuKeyBindingChanged, (void*)(intptr_t)btn, NULL);
     return widget;
-}
-
-static void LibretroMenuIntegerScalingChanged(nk_console* widget, void* user_data) {
-    (void)widget;
-    (void)user_data;
-    LIBRETRO.integerScaling = (bool)menu.integerScaling;
 }
 
 static void LibretroMenuSettingChanged(nk_console* widget, void* user_data) {
@@ -1437,6 +1430,11 @@ LibretroMenu* InitLibretroMenu(void) {
             nk_console* volume = nk_console_slider_float(graphicsMenu, "Volume", 0.0f, &LIBRETRO.volume, 1.0f, RAYLIB_LIBRETRO_MENU_SLIDER_STEP(0.0f, 1.0f));
             nk_console_add_event_handler(volume, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
 
+            // Theme
+            nk_console* themeCombo = nk_console_combobox(graphicsMenu, "Theme", RAYLIB_LIBRETRO_STYLES_NAMES, '|', &menu.themeSelectedIndex);
+            nk_console_add_event_handler(themeCombo, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
+            SetLibretroMenuStyle((LibretroMenuStyle)menu.themeSelectedIndex);
+
             // Full Screen
             nk_console* fullscreenCheckbox = nk_console_checkbox(graphicsMenu, "Fullscreen", &menu.fullscreen);
             nk_console_add_event(fullscreenCheckbox, NK_CONSOLE_EVENT_CHANGED, LibretroMenuFullscreenChanged);
@@ -1448,6 +1446,10 @@ LibretroMenu* InitLibretroMenu(void) {
             // FPS
             nk_console* fpsCombo = nk_console_combobox(graphicsMenu, "FPS", "Auto|30|60|120|144|240|Unlimited", '|', &menu.fpsIndex);
             nk_console_add_event_handler(fpsCombo, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuVideoChanged, NULL, NULL);
+
+            // Integer Scaling
+            nk_console_checkbox(graphicsMenu, "Integer Scaling", &LIBRETRO.integerScaling)
+                ->tooltip = "Keep pixel graphics looking sharp and crisp.";
 
             // Shader
             static char shaderNames[256] = {0};
@@ -1472,18 +1474,8 @@ LibretroMenu* InitLibretroMenu(void) {
             nk_console_add_event_handler(textureFilter, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuTextureFilterChanged, NULL, NULL);
 
             // Rotation
-            nk_console* rotation = nk_console_combobox(graphicsMenu, "Rotation", "0 Degrees|90 Degrees|180 Degrees|270 Degrees", '|', &LIBRETRO.core.rotation);
-            rotation->tooltip = "Override the display rotation for the running game.";
-
-            // Integer Scaling
-            nk_console* integerScalingCheckbox = nk_console_checkbox(graphicsMenu, "Integer Scaling", &menu.integerScaling);
-            nk_console_add_event_handler(integerScalingCheckbox, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuIntegerScalingChanged, NULL, NULL);
-            integerScalingCheckbox->tooltip = "Scale to exact multiples of the native resolution. Eliminates sub-pixel blurriness on pixel-art content.";
-
-            // Theme
-            nk_console* themeCombo = nk_console_combobox(graphicsMenu, "Theme", RAYLIB_LIBRETRO_STYLES_NAMES, '|', &menu.themeSelectedIndex);
-            nk_console_add_event_handler(themeCombo, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
-            SetLibretroMenuStyle((LibretroMenuStyle)menu.themeSelectedIndex);
+            nk_console_combobox(graphicsMenu, "Rotation", "0 Degrees|90 Degrees|180 Degrees|270 Degrees", '|', &LIBRETRO.core.rotation)
+                ->tooltip = "Override the display rotation for the running game.";
         }
 
         // Gameplay
@@ -2105,7 +2097,7 @@ static void LibretroMenuUpdateConfig(void) {
     rlconfig_set_int(menu.cfg, "raylib-libretro", "fps", menu.fpsIndex);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "shader", menu.shaderSelectedIndex);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "textureFilter", LIBRETRO.textureFilter);
-    rlconfig_set_int(menu.cfg, "raylib-libretro", "integerScaling", (int)menu.integerScaling);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "integerScaling", LIBRETRO.integerScaling ? 1 : 0);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "theme", menu.themeSelectedIndex);
     rlconfig_set_float(menu.cfg, "raylib-libretro", "volume", LIBRETRO.volume);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "rewind", menu.rewindEnabled ? 1 : 0);
@@ -2299,8 +2291,7 @@ static bool LoadLibretroMenuSettings(void) {
         LIBRETRO.textureFilter = 0;
 
     // Integer Scaling
-    menu.integerScaling = (nk_bool)rlconfig_get_int(menu.cfg, "raylib-libretro", "integerScaling", 0);
-    LIBRETRO.integerScaling = (bool)menu.integerScaling;
+    LIBRETRO.integerScaling = (bool)rlconfig_get_int(menu.cfg, "raylib-libretro", "integerScaling", 0);
 
     // Theme
     menu.themeSelectedIndex = rlconfig_get_int(menu.cfg, "raylib-libretro", "theme", 0);

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -133,6 +133,7 @@ typedef struct LibretroMenu {
     int orientationIndex;                 // Android screen orientation: 0 = Landscape, 1 = Portrait, 2 = Auto
     nk_bool hideCursor;
     nk_bool lockCursor;
+    nk_bool integerScaling;
     char cheatBuffer[256];
     char cheatList[1024];
     unsigned cheatIndex;
@@ -468,6 +469,12 @@ static nk_console* LibretroMenuKeyConsole(nk_console* parent, const char* label,
     nk_console_add_event_handler(widget, NK_CONSOLE_EVENT_CHANGED,
         &LibretroMenuKeyBindingChanged, (void*)(intptr_t)btn, NULL);
     return widget;
+}
+
+static void LibretroMenuIntegerScalingChanged(nk_console* widget, void* user_data) {
+    (void)widget;
+    (void)user_data;
+    LIBRETRO.integerScaling = (bool)menu.integerScaling;
 }
 
 static void LibretroMenuSettingChanged(nk_console* widget, void* user_data) {
@@ -1468,6 +1475,11 @@ LibretroMenu* InitLibretroMenu(void) {
             nk_console* rotation = nk_console_combobox(graphicsMenu, "Rotation", "0 Degrees|90 Degrees|180 Degrees|270 Degrees", '|', &LIBRETRO.core.rotation);
             rotation->tooltip = "Override the display rotation for the running game.";
 
+            // Integer Scaling
+            nk_console* integerScalingCheckbox = nk_console_checkbox(graphicsMenu, "Integer Scaling", &menu.integerScaling);
+            nk_console_add_event_handler(integerScalingCheckbox, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuIntegerScalingChanged, NULL, NULL);
+            integerScalingCheckbox->tooltip = "Scale to exact multiples of the native resolution. Eliminates sub-pixel blurriness on pixel-art content.";
+
             // Theme
             nk_console* themeCombo = nk_console_combobox(graphicsMenu, "Theme", RAYLIB_LIBRETRO_STYLES_NAMES, '|', &menu.themeSelectedIndex);
             nk_console_add_event_handler(themeCombo, NK_CONSOLE_EVENT_CHANGED, &LibretroMenuSettingChanged, NULL, NULL);
@@ -2093,6 +2105,7 @@ static void LibretroMenuUpdateConfig(void) {
     rlconfig_set_int(menu.cfg, "raylib-libretro", "fps", menu.fpsIndex);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "shader", menu.shaderSelectedIndex);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "textureFilter", LIBRETRO.textureFilter);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "integerScaling", (int)menu.integerScaling);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "theme", menu.themeSelectedIndex);
     rlconfig_set_float(menu.cfg, "raylib-libretro", "volume", LIBRETRO.volume);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "rewind", menu.rewindEnabled ? 1 : 0);
@@ -2284,6 +2297,10 @@ static bool LoadLibretroMenuSettings(void) {
     LIBRETRO.textureFilter = rlconfig_get_int(menu.cfg, "raylib-libretro", "textureFilter", 0);
     if (LIBRETRO.textureFilter < 0 || LIBRETRO.textureFilter > TEXTURE_FILTER_ANISOTROPIC_16X)
         LIBRETRO.textureFilter = 0;
+
+    // Integer Scaling
+    menu.integerScaling = (nk_bool)rlconfig_get_int(menu.cfg, "raylib-libretro", "integerScaling", 0);
+    LIBRETRO.integerScaling = (bool)menu.integerScaling;
 
     // Theme
     menu.themeSelectedIndex = rlconfig_get_int(menu.cfg, "raylib-libretro", "theme", 0);

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -3118,17 +3118,16 @@ static void DrawLibretroTint(Color tint) {
 
     // Calculate the optimal visual width/height to fit the screen.
     int visH, visW;
-    if (LIBRETRO.integerScaling && LIBRETRO.core.height > 0) {
-        int scaleFactor = GetScreenHeight() / LIBRETRO.core.height;
+    if (LIBRETRO.integerScaling && GetLibretroHeight() > 0 && visAspect > 0) {
+        // Calculate the best integer scaling size.
+        int maxScaleH = GetScreenHeight() / GetLibretroHeight();
+        int maxScaleW = (int)(GetScreenWidth() / (GetLibretroHeight() * visAspect));
+        int scaleFactor = (maxScaleH < maxScaleW) ? maxScaleH : maxScaleW;
         if (scaleFactor < 1) scaleFactor = 1;
-        visH = LIBRETRO.core.height * scaleFactor;
+        visH = GetLibretroHeight() * scaleFactor;
         visW = (int)(visH * visAspect);
-        while (visW > GetScreenWidth() && scaleFactor > 1) {
-            scaleFactor--;
-            visH = LIBRETRO.core.height * scaleFactor;
-            visW = (int)(visH * visAspect);
-        }
-    } else {
+    }
+    else {
         visH = GetScreenHeight();
         visW = (int)(visH * visAspect);
         if (visW > GetScreenWidth()) {

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -374,6 +374,7 @@ typedef struct LibretroData {
     float speed;
     double speedAccumulator;
     int textureFilter; // TextureFilter
+    bool integerScaling;
     int analogToDpadIndex; // 0=None, 1=Left Analog, 2=Right Analog
     int keyboardPlayer1[RETRO_DEVICE_ID_JOYPAD_R3 + 1];
     char coreDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
@@ -3116,11 +3117,24 @@ static void DrawLibretroTint(Color tint) {
     float visAspect = swapDims ? (1.0f / aspect) : aspect;
 
     // Calculate the optimal visual width/height to fit the screen.
-    int visH = GetScreenHeight();
-    int visW = (int)(visH * visAspect);
-    if (visW > GetScreenWidth()) {
-        visW = GetScreenWidth();
-        visH = (int)(visW / visAspect);
+    int visH, visW;
+    if (LIBRETRO.integerScaling && LIBRETRO.core.height > 0) {
+        int scaleFactor = GetScreenHeight() / LIBRETRO.core.height;
+        if (scaleFactor < 1) scaleFactor = 1;
+        visH = LIBRETRO.core.height * scaleFactor;
+        visW = (int)(visH * visAspect);
+        while (visW > GetScreenWidth() && scaleFactor > 1) {
+            scaleFactor--;
+            visH = LIBRETRO.core.height * scaleFactor;
+            visW = (int)(visH * visAspect);
+        }
+    } else {
+        visH = GetScreenHeight();
+        visW = (int)(visH * visAspect);
+        if (visW > GetScreenWidth()) {
+            visW = GetScreenWidth();
+            visH = (int)(visW / visAspect);
+        }
     }
 
     // For 90/270 rotations the dest rect dimensions are swapped relative to visual size


### PR DESCRIPTION
Adds an Integer Scaling toggle to Settings > Graphics. When enabled, computes the largest integer scale factor that fits the window and centers the result with black bars, eliminating sub-pixel blurriness on pixel-art content. Fixes #293