### PR TITLE
Replace config cache with .info files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -49,3 +49,5 @@
 [submodule "vendor/libretro-core-info"]
 	path = vendor/libretro-core-info
 	url = https://github.com/libretro/libretro-core-info
+	ignore = dirty
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -46,3 +46,6 @@
 	url = https://github.com/icculus/physfs.git
     ignore = dirty
     branch = main
+[submodule "vendor/libretro-core-info"]
+	path = vendor/libretro-core-info
+	url = https://github.com/libretro/libretro-core-info

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,60 +1,86 @@
 # CLAUDE.md — raylib-libretro
 
-A [libretro](https://www.libretro.com/) frontend built with [raylib](https://www.raylib.com). Provides a single-header C library (`include/raylib-libretro.h`) and a full frontend executable (`bin/raylib-libretro.c`). License: zlib/libpng.
+A [libretro](https://www.libretro.com/) frontend built with [raylib](https://www.raylib.com). Ships a single-header C library (core API in `include/raylib-libretro.h`) plus a full frontend app (`bin/raylib-libretro.c`). C99, license zlib/libpng.
 
 ## Architecture
 
-### Single-Header Library Pattern
+### Single-header pattern
 
-Headers in `include/` follow the stb-style pattern. Define the implementation macro **once** in exactly one translation unit:
+Headers in `include/` are stb-style. Define the implementation macro **once**, in exactly one translation unit:
 
 ```c
 #define RAYLIB_LIBRETRO_IMPLEMENTATION
 #include "raylib-libretro.h"
 ```
 
-Same for `RAYLIB_LIBRETRO_SHADERS_IMPLEMENTATION` and `RAYLIB_LIBRETRO_MENU_IMPLEMENTATION`.
+Each opt-in layer has its own macro — `RAYLIB_LIBRETRO_MENU_IMPLEMENTATION`, `..._PHYSFS_IMPLEMENTATION`, `..._SHADERS_IMPLEMENTATION`, `..._TOUCH_IMPLEMENTATION`, `..._LOGO_IMPLEMENTATION`, `..._ANDROID_IMPLEMENTATION`. The VFS layer is pulled in automatically by `raylib-libretro.h`. A frontend composes only the layers it needs; the example uses just the core header. Guards: include `RAYLIB_LIBRETRO_*_H`, implementation `RAYLIB_LIBRETRO_*_IMPLEMENTATION` / `..._IMPLEMENTATION_ONCE`.
 
-### Global State
+### Global state
 
-All state lives in a single static global `LibretroData LIBRETRO = {0};`. No context object is passed around — functions operate on the global, matching raylib's design.
+The core library keeps all its state in one file-static global, `static LibretroData LIBRETRO` (`raylib-libretro.h`), with non-zero defaults — no context object is threaded through calls, matching raylib's design. Frontend layers follow the same shape with their own file-static globals (e.g. `menu`, `LibretroPhysFS`).
 
-### Libretro Core Loading
+### Core loading
 
-Cores are shared libraries (`.so`/`.dll`/`.dylib`) loaded at runtime via `dylib.h` from libretro-common, using the `LoadLibretroMethod(S)` macro.
+Cores are shared libraries (`.so`/`.dll`/`.dylib`/`.wasm`) loaded at runtime via `dylib.h` from libretro-common, using the `LoadLibretroMethod(S)` macro. `PeekLibretroCoreInfo()` opens a core just far enough to read `retro_get_system_info()` (no full init); `InitLibretro()` does the full load.
+
+### Core metadata: two sources of truth
+
+The menu builds its core list (`ScanLibretroCoreDirectory`) from sibling `<core>.info` files (bundled from the `vendor/libretro-core-info` submodule) — fast, no dlopen. A core binary with no matching `.info` is probed directly via `PeekLibretroCoreInfo()`.
+
+The `.info` fields (`supported_extensions`, `needs_fullpath`, `supports_no_game`) are **pre-load hints for menu filtering only — never a hard gate**. Authoritative values come from the core's runtime `retro_get_system_info()` / `RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE` once loaded, and the two can diverge: e.g. `genesis_plus_gx` declares `needs_fullpath="true"` globally (for SegaCD) yet loads cartridge ROMs from memory. Filtering a core out on a coarse `.info` flag is how zipped Genesis games got wrongly rejected — let the loader make the final per-content decision.
 
 ## Build
 
 ```sh
-git submodule update --init
+git submodule update --init    # submodules are required
 mkdir build && cd build && cmake .. && cmake --build .
 ```
 
-Linux deps: `xorg-dev`, `libglu1-mesa-dev`. CMake 3.11+. CMake first tries `find_package(raylib QUIET)`, then falls back to `vendor/raylib`.
+Submodules pull raylib, libretro-common, the Nuklear UI stack (nuklear_console, nuklear_gamepad, raylib-nuklear), PhysFS + raylib-physfs, c-vector, raylib-app, and `vendor/libretro-core-info`. A bundled core whose `.info` is missing from that submodule is a **hard CMake error** (`bin/CMakeLists.txt` → `copy_core_info`), since a core with no `.info` would silently never appear in the menu.
+
+Linux deps: `xorg-dev`, `libglu1-mesa-dev`. CMake 3.11+. CMake first tries `find_package(raylib QUIET)`, then falls back to building `vendor/raylib` with a trimmed feature set.
 
 CMake options: `BUILD_RAYLIB_LIBRETRO_EXAMPLE` (ON), `BUILD_RAYLIB_LIBRETRO` (ON).
 
-Targets: `raylib-libretro-interface` (headers), `raylib-libretro-static` (static lib), `raylib-libretro` (exe), `raylib-libretro-basic` (example).
+Targets:
+- `raylib-libretro-h` — INTERFACE target (headers / include path)
+- `raylib-libretro-static` — static lib (bundles the libretro-common `.c` files it needs)
+- `raylib-libretro` — the full frontend app
+- `raylib-libretro-basic` — the minimal example
 
 ## CI
 
-`.github/workflows/Tests.yml` runs CMake Debug builds on Ubuntu (GCC) and Windows (MSVC). **No unit tests** — CI validates compilation only. Ensure changes compile on both platforms.
+- **`Tests.yml`** (push / PR to `master`): Linux only — `ubuntu-latest`, GCC, `cmake -DCMAKE_BUILD_TYPE=Debug`. Windows and Web jobs are present but commented out.
+- **`Release.yml`** (on release): builds and packages Linux x64, Linux ARM (`ubuntu-24.04-arm`), and Windows (`windows-latest`, MSVC).
+- **No unit tests** anywhere — CI only validates that things compile/package. PRs are gated on Linux/GCC, but keep code MSVC-clean since releases build Windows.
 
-## Coding Conventions
+## Coding conventions
 
-- **Language:** C99 (not C++)
-- **Public API:** `PascalCase` verbs — `InitLibretro`, `DrawLibretro`, `GetLibretroTexture`
+- **Language:** C99 (not C++).
+- **Public API:** `PascalCase` verbs — `InitLibretro`, `DrawLibretro`, `GetLibretroTexture`.
 - **Internal helpers:** `Libretro`-prefixed — `LibretroLogger`, etc.
-- **Static functions:** all functions in headers are `static`
-- **Error handling:** return `bool`; log errors with `TraceLog(LOG_ERROR, ...)`
-- **Memory:** use raylib's `MemAlloc` / `MemFree`, never raw `malloc`/`free`
-- **Include guards:** `RAYLIB_LIBRETRO_*_H`
-- **Implementation guards:** `RAYLIB_LIBRETRO_*_IMPLEMENTATION` / `..._IMPLEMENTATION_ONCE`
-- **File headers:** raylib-style `/**** ... ****/` banners
+- **All header functions are `static`.**
+- **Errors:** return `bool`; log with `TraceLog(LOG_ERROR, ...)`.
+- **Memory:** raylib's `MemAlloc` / `MemFree`, never raw `malloc`/`free`. Prefer raylib built-ins (`TextCopy`, `IsFileExtension`, `LoadFileData`, …) over `<string.h>`/stdio.
+- **File headers:** raylib-style `/**** … ****/` banners.
 
-## Key Files
+## Key files
 
-- `include/raylib-libretro.h` — the entire library (callbacks, pixel format mapping, audio ring buffer)
+Core library:
+- `include/raylib-libretro.h` — core loading (`dylib`), environment callbacks, pixel-format mapping, audio ring buffer, VFS wiring
+- `include/raylib-libretro-vfs.h` — libretro VFS interface implementation, backed by raylib file I/O
+- `include/raylib-libretro-config.h` — `rlconfig`: the INI / `.info` parser used for settings and core metadata
+
+Frontend layers (opt-in):
+- `include/raylib-libretro-menu.h` — full in-app UI (Nuklear / nuklear_console): core scanning, core picker, game-load orchestration, settings
+- `include/raylib-libretro-physfs.h` — PhysFS-backed, zip-aware game loader (mounts archives at `/game`)
+- `include/raylib-libretro-shaders.h` — GLSL retro shaders
+- `include/raylib-libretro-touch.h` — on-screen / touch controls
+- `include/raylib-libretro-android.h` — Android JNI glue (file picker, intents); guarded by `__ANDROID__`
+- `include/raylib-libretro-styles.h`, `-logo.h` — menu theme + embedded logo image
+
+Apps & data:
 - `example/raylib-libretro-basic.c` — canonical minimal usage; reference for the expected API flow
 - `bin/raylib-libretro.c` — full app using `raylib-app` lifecycle callbacks
+- `vendor/libretro-core-info/` — submodule of `.info` core metadata; CMake copies the relevant ones next to built cores
 - `TASKS.md` — planned features; check here before implementing new work

--- a/android/app/CMakeLists.txt
+++ b/android/app/CMakeLists.txt
@@ -22,6 +22,12 @@ set(RAYLIB_LIBRETRO_VER "${CMAKE_MATCH_1}")
 set(CORES_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/main/assets/cores/${CMAKE_ANDROID_ARCH_ABI}")
 file(MAKE_DIRECTORY "${CORES_DIR}")
 set(CORE_NAMES "")
+
+# The menu scan is .info-driven: each core needs its sibling <core>.info to show
+# up with proper metadata (display name, system, license, supports_no_game) and
+# to skip the slow dlopen probe. Cores are named *_libretro_android.so but their
+# .info is named *_libretro.info, which ScanLibretroCoreDirectory() matches.
+set(CORE_INFO_DIR "${ROOT}/vendor/libretro-core-info")
 foreach(URL IN ITEMS
     "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/fceumm_libretro_android.so.zip"
     "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/snes9x_libretro_android.so.zip"
@@ -54,6 +60,20 @@ foreach(URL IN ITEMS
         continue()
     endif()
     list(APPEND CORE_NAMES "${CORE_SO}")
+
+    # Bundle the matching .info next to the core. A missing .info means the core
+    # would fall back to the slow dlopen probe with no metadata, so fail loudly
+    # for bundled cores rather than discovering it at runtime (mirrors the
+    # copy_core_info() guard in bin/CMakeLists.txt).
+    string(REGEX REPLACE "_android\\.so$" "" CORE_BASE "${CORE_SO}")
+    if (EXISTS "${CORE_INFO_DIR}/${CORE_BASE}.info")
+        file(COPY_FILE "${CORE_INFO_DIR}/${CORE_BASE}.info"
+                       "${CORES_DIR}/${CORE_BASE}.info" ONLY_IF_DIFFERENT)
+        list(APPEND CORE_NAMES "${CORE_BASE}.info")
+    else()
+        message(FATAL_ERROR "${CORE_BASE}.info not found in ${CORE_INFO_DIR}. "
+            "Run: git submodule update --init -- vendor/libretro-core-info")
+    endif()
 endforeach()
 
 # Write the manifest of bundled cores the app reads on first launch, alongside

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -90,7 +90,11 @@ function(copy_core_info)
         if (EXISTS "${INFO_SRC}")
             file(COPY_FILE "${INFO_SRC}" "${INFO_DST}" ONLY_IF_DIFFERENT)
         else()
-            message(WARNING "${CORE_NAME}.info not found in libretro-core-info submodule")
+            # A missing .info means the core ships but silently never appears in
+            # the menu (ScanLibretroCoreDirectory is .info-driven). Fail loudly
+            # for bundled cores rather than discovering it at runtime.
+            message(FATAL_ERROR "${CORE_NAME}.info not found in ${CORE_INFO_DIR}. "
+                "Run: git submodule update --init -- vendor/libretro-core-info")
         endif()
     endforeach()
 endfunction()

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -79,24 +79,18 @@ function(download_cores)
     endforeach()
 endfunction()
 
-# download_core_info(<name> [<name> ...])
-# Downloads each core's .info metadata file from the libretro-core-info repository.
-function(download_core_info)
+# copy_core_info(<name> [<name> ...])
+# Copies each core's .info metadata file from the libretro-core-info submodule.
+set(CORE_INFO_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../vendor/libretro-core-info")
+function(copy_core_info)
     file(MAKE_DIRECTORY "${CORES_DIR}")
     foreach(CORE_NAME IN LISTS ARGN)
-        set(INFO_URL "https://raw.githubusercontent.com/libretro/libretro-core-info/refs/heads/master/${CORE_NAME}.info")
-        set(INFO_PATH "${CORES_DIR}/${CORE_NAME}.info")
-
-        if (NOT EXISTS "${INFO_PATH}")
-            message(STATUS "Downloading ${CORE_NAME}.info")
-            file(DOWNLOAD "${INFO_URL}" "${INFO_PATH}"
-                STATUS DOWNLOAD_STATUS
-            )
-            list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
-            list(GET DOWNLOAD_STATUS 1 STATUS_MSG)
-            if (NOT STATUS_CODE EQUAL 0)
-                message(WARNING "Failed to download ${CORE_NAME}.info: ${STATUS_MSG}")
-            endif()
+        set(INFO_SRC "${CORE_INFO_DIR}/${CORE_NAME}.info")
+        set(INFO_DST "${CORES_DIR}/${CORE_NAME}.info")
+        if (EXISTS "${INFO_SRC}")
+            file(COPY_FILE "${INFO_SRC}" "${INFO_DST}" ONLY_IF_DIFFERENT)
+        else()
+            message(WARNING "${CORE_NAME}.info not found in libretro-core-info submodule")
         endif()
     endforeach()
 endfunction()
@@ -321,7 +315,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Android")
     )
 endif()
 
-download_core_info(${CORE_INFO_NAMES})
+copy_core_info(${CORE_INFO_NAMES})
 
 install(TARGETS raylib-libretro DESTINATION .)
 install(FILES ../README.md DESTINATION .)

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -79,6 +79,38 @@ function(download_cores)
     endforeach()
 endfunction()
 
+# download_core_info(<name> [<name> ...])
+# Downloads each core's .info metadata file from the libretro-core-info repository.
+function(download_core_info)
+    file(MAKE_DIRECTORY "${CORES_DIR}")
+    foreach(CORE_NAME IN LISTS ARGN)
+        set(INFO_URL "https://raw.githubusercontent.com/libretro/libretro-core-info/refs/heads/master/${CORE_NAME}.info")
+        set(INFO_PATH "${CORES_DIR}/${CORE_NAME}.info")
+
+        if (NOT EXISTS "${INFO_PATH}")
+            message(STATUS "Downloading ${CORE_NAME}.info")
+            file(DOWNLOAD "${INFO_URL}" "${INFO_PATH}"
+                STATUS DOWNLOAD_STATUS
+            )
+            list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
+            list(GET DOWNLOAD_STATUS 1 STATUS_MSG)
+            if (NOT STATUS_CODE EQUAL 0)
+                message(WARNING "Failed to download ${CORE_NAME}.info: ${STATUS_MSG}")
+            endif()
+        endif()
+    endforeach()
+endfunction()
+
+set(CORE_INFO_NAMES
+    fceumm_libretro
+    snes9x_libretro
+    mgba_libretro
+    genesis_plus_gx_libretro
+    prboom_libretro
+    mednafen_pce_fast_libretro
+    mednafen_wswan_libretro
+)
+
 if ("${PLATFORM}" STREQUAL "Web")
     set_target_properties(raylib-libretro PROPERTIES OUTPUT_NAME "index")
     set_target_properties(raylib-libretro PROPERTIES SUFFIX ".html")
@@ -288,6 +320,8 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Android")
         "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/mednafen_wswan_libretro_android.so.zip"
     )
 endif()
+
+download_core_info(${CORE_INFO_NAMES})
 
 install(TARGETS raylib-libretro DESTINATION .)
 install(FILES ../README.md DESTINATION .)

--- a/bin/manifest.webmanifest
+++ b/bin/manifest.webmanifest
@@ -7,8 +7,8 @@
   "scope": ".",
   "display": "standalone",
   "orientation": "landscape",
-  "background_color": "#232634",
-  "theme_color": "#000000",
+  "background_color": "#11111b",
+  "theme_color": "#11111b",
   "icons": [
     {
       "src": "icon-192.png",

--- a/bin/shell.html
+++ b/bin/shell.html
@@ -5,12 +5,16 @@
     <title>raylib-libretro</title>
     <meta name="description" content="A libretro frontend built with raylib — play retro games in your browser.">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover">
+    <!-- Render UA surfaces (scrollbars, the pre-paint frame) dark to match the
+         #11111b backdrop and avoid a white flash on first navigation. -->
+    <meta name="color-scheme" content="dark">
 
-    <!-- Progressive Web App: installable + standalone "Add to Home Screen" -->
+    <!-- Progressive Web App: installable + standalone "Add to Home Screen".
+         theme-color matches the page/canvas backdrop (and the manifest) so the
+         browser chrome and PWA splash are seamless with the app. -->
     <link rel="manifest" href="manifest.webmanifest">
-    <meta name="theme-color" content="#000000">
+    <meta name="theme-color" content="#11111b">
     <link rel="icon" type="image/png" sizes="192x192" href="icon-192.png">
-    <link rel="shortcut icon" href="https://www.raylib.com/favicon.ico">
     <!-- iOS standalone web app -->
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -243,7 +247,7 @@
           if (_overlayFailed || !text) return; // overlay is hidden in postRun
           // Emscripten reports byte progress as "msg (x/y)" — show a percentage.
           var m = text.match(/([^(]+)\((\d+(\.\d+)?)\/(\d+)\)/);
-          if (m) text = m[1].trim() + ' (' + Math.round(100 * m[2] / m[4]) + '%)';
+          if (m && +m[4] > 0) text = m[1].trim() + ' (' + Math.round(100 * m[2] / m[4]) + '%)';
           setOverlay(text);
         },
         monitorRunDependencies: function (left) {
@@ -313,9 +317,17 @@
           // the background and handed to LoadLibretroGameFromJS once main()
           // is running — see postRun below. This lets the UI come up while a
           // large ROM is still downloading.
+
+          // Map a URL to the /downloads path it will be written to. Shared by
+          // fetchToFS and the ?core= block below, which has to build the core's
+          // -L argv synchronously (before the fetch resolves) — deriving the
+          // name in one place keeps the write path and the argv path identical.
+          function fsPathForUrl(url) {
+            return '/downloads/' + (url.split('/').pop().split('?')[0] || 'download');
+          }
+
           function fetchToFS(url) {
-            var filename = url.split('/').pop().split('?')[0] || 'download';
-            var destPath = '/downloads/' + filename;
+            var destPath = fsPathForUrl(url);
             try { FS.mkdir('/downloads'); } catch (e) {}
             return fetch(url)
               .then(function (r) {
@@ -349,8 +361,7 @@
               console.warn('Loading a libretro core (executable code) from a different origin: ' + coreUrl);
             }
             addRunDependency('url-core');
-            var coreFilename = coreUrl.split('/').pop().split('?')[0] || 'url-core';
-            Module.arguments = (Module.arguments || []).concat(['-L', '/downloads/' + coreFilename]);
+            Module.arguments = (Module.arguments || []).concat(['-L', fsPathForUrl(coreUrl)]);
             fetchToFS(coreUrl)
               .catch(function (err) {
                 logFetchError('core', err);
@@ -412,10 +423,17 @@
                 Module._SaveLibretroAllSettings();
               }
             } catch (e) { console.error('flushPersistence: save failed:', e); }
-            FS.syncfs(false, function (err) {
-              if (err) console.error('IDBFS sync failed:', err);
+            try {
+              FS.syncfs(false, function (err) {
+                if (err) console.error('IDBFS sync failed:', err);
+                _flushInFlight = false;
+              });
+            } catch (e) {
+              // A synchronous throw would otherwise leave _flushInFlight pinned
+              // true and silently disable every later flush — reset it.
+              console.error('flushPersistence: syncfs failed:', e);
               _flushInFlight = false;
-            });
+            }
           }
 
           // Periodic safety-net flush. Once a minute is plenty: pagehide /

--- a/include/raylib-libretro-config.h
+++ b/include/raylib-libretro-config.h
@@ -85,6 +85,10 @@ static void rlconfig_clear_section(RLibretroConfig *cfg, const char *section);
 /* Free config and all associated memory. */
 static void rlconfig_free(RLibretroConfig *cfg);
 
+/* Load a sectionless .info file (key = "value") into the given section of cfg.
+   Strips surrounding double quotes from values. */
+static void rlconfig_load_info(RLibretroConfig *cfg, const char *section, const char *filename);
+
 /* --- Implementation --- */
 
 #ifdef RAYLIB_LIBRETRO_CONFIG_IMPLEMENTATION
@@ -280,6 +284,38 @@ static RLibretroConfig* rlconfig_load(const char *filename) {
 
     fclose(f);
     return cfg;
+}
+
+static void rlconfig_load_info(RLibretroConfig *cfg, const char *section, const char *filename) {
+    if (!cfg || !section || !filename) return;
+
+    FILE *f = fopen(filename, "r");
+    if (!f) return;
+
+    char line[RLCONFIG_LINE_MAX];
+    while (fgets(line, sizeof(line), f)) {
+        RLibretroConfigTrim(line);
+        if (line[0] == '\0' || line[0] == '#' || line[0] == ';') continue;
+
+        char *eq = strchr(line, '=');
+        if (!eq) continue;
+
+        *eq = '\0';
+        char *k = line;
+        char *v = eq + 1;
+        RLibretroConfigTrim(k);
+        RLibretroConfigTrim(v);
+
+        size_t vlen = strlen(v);
+        if (vlen >= 2 && v[0] == '"' && v[vlen - 1] == '"') {
+            v[vlen - 1] = '\0';
+            v++;
+        }
+
+        if (k[0] != '\0') rlconfig_set(cfg, section, k, v);
+    }
+
+    fclose(f);
 }
 
 static bool rlconfig_save(RLibretroConfig *cfg, const char *filename) {

--- a/include/raylib-libretro-config.h
+++ b/include/raylib-libretro-config.h
@@ -236,18 +236,20 @@ static void RLibretroConfigTrim(char *s) {
     }
 }
 
-static RLibretroConfig* rlconfig_load(const char *filename) {
-    RLibretroConfig *cfg = (RLibretroConfig*)MemAlloc(sizeof(RLibretroConfig));
-    if (!cfg) return NULL;
-    memset(cfg, 0, sizeof(RLibretroConfig));
-
-    if (!filename) return cfg;
+/* Parse an INI/.info file into cfg. Lines are "key = value"; [section] headers
+   switch the active section. defaultSection (may be NULL) is the section keys
+   land in before any header — pass the target section for sectionless .info
+   files, NULL for .cfg files where keys must follow a header. Surrounding
+   double quotes are stripped from values (.info style; harmless for .cfg). */
+static void RLibretroConfigParse(RLibretroConfig *cfg, const char *defaultSection, const char *filename) {
+    if (!cfg || !filename) return;
 
     FILE *f = fopen(filename, "r");
-    if (!f) return cfg;
+    if (!f) return;
 
     char line[RLCONFIG_LINE_MAX];
     char section[RLCONFIG_SECTION_MAX] = {0};
+    if (defaultSection) snprintf(section, sizeof(section), "%s", defaultSection);
 
     while (fgets(line, sizeof(line), f)) {
         RLibretroConfigTrim(line);
@@ -279,33 +281,7 @@ static RLibretroConfig* rlconfig_load(const char *filename) {
         RLibretroConfigTrim(k);
         RLibretroConfigTrim(v);
 
-        if (k[0] != '\0') rlconfig_set(cfg, section, k, v);
-    }
-
-    fclose(f);
-    return cfg;
-}
-
-static void rlconfig_load_info(RLibretroConfig *cfg, const char *section, const char *filename) {
-    if (!cfg || !section || !filename) return;
-
-    FILE *f = fopen(filename, "r");
-    if (!f) return;
-
-    char line[RLCONFIG_LINE_MAX];
-    while (fgets(line, sizeof(line), f)) {
-        RLibretroConfigTrim(line);
-        if (line[0] == '\0' || line[0] == '#' || line[0] == ';') continue;
-
-        char *eq = strchr(line, '=');
-        if (!eq) continue;
-
-        *eq = '\0';
-        char *k = line;
-        char *v = eq + 1;
-        RLibretroConfigTrim(k);
-        RLibretroConfigTrim(v);
-
+        /* Strip surrounding double quotes from the value */
         size_t vlen = strlen(v);
         if (vlen >= 2 && v[0] == '"' && v[vlen - 1] == '"') {
             v[vlen - 1] = '\0';
@@ -316,6 +292,20 @@ static void rlconfig_load_info(RLibretroConfig *cfg, const char *section, const 
     }
 
     fclose(f);
+}
+
+static RLibretroConfig* rlconfig_load(const char *filename) {
+    RLibretroConfig *cfg = (RLibretroConfig*)MemAlloc(sizeof(RLibretroConfig));
+    if (!cfg) return NULL;
+    memset(cfg, 0, sizeof(RLibretroConfig));
+
+    RLibretroConfigParse(cfg, NULL, filename);
+    return cfg;
+}
+
+static void rlconfig_load_info(RLibretroConfig *cfg, const char *section, const char *filename) {
+    if (!section) return;
+    RLibretroConfigParse(cfg, section, filename);
 }
 
 static bool rlconfig_save(RLibretroConfig *cfg, const char *filename) {

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -94,6 +94,8 @@ typedef struct {
     char path[256];
     char displayName[256];
     char coreName[256];
+    char systemName[256];
+    char license[64];
     char supportedExtensions[RLCONFIG_VALUE_MAX];
     bool supportsNoGame;
     bool needsFullpath;
@@ -860,6 +862,10 @@ static void ScanLibretroCoreDirectory(void) {
         TextCopy(info->coreName, coreName);
         const char* displayName = rlconfig_get(infoCfg, infoBase, "display_name");
         TextCopy(info->displayName, (displayName && displayName[0]) ? displayName : coreName);
+        const char* systemName = rlconfig_get(infoCfg, infoBase, "systemname");
+        TextCopy(info->systemName, (systemName && systemName[0]) ? systemName : "");
+        const char* license = rlconfig_get(infoCfg, infoBase, "license");
+        TextCopy(info->license, (license && license[0]) ? license : "");
         const char* noGame = rlconfig_get(infoCfg, infoBase, "supports_no_game");
         info->supportsNoGame = noGame && TextIsEqual(noGame, "true");
         const char* fullpath = rlconfig_get(infoCfg, infoBase, "needs_fullpath");
@@ -1656,7 +1662,10 @@ LibretroMenu* InitLibretroMenu(void) {
                 nk_console_label(coresTree, "(none found)");
             }
             for (int i = 0; i < (int)cvector_size(menu.coreInfos); i++) {
-                nk_console_label(coresTree, LibretroCoreDisplayName(i));
+                LibretroCoreInfo* ci = menu.coreInfos[i];
+                nk_console* coreTree = nk_console_tree(coresTree, LibretroCoreDisplayName(i), nk_false);
+                if (ci->systemName[0]) nk_console_label(coreTree, TextFormat("System:  %s", ci->systemName));
+                if (ci->license[0]) nk_console_label(coreTree, TextFormat("License: %s", ci->license));
             }
 
             // License

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -880,8 +880,6 @@ static void ScanLibretroCoreDirectory(void) {
     FreeLibretroCoreInfos();
     if (!dir || !dir[0] || !DirectoryExists(dir)) return;
 
-    rlconfig_clear_section(menu.cfg, "core_cache");
-
     FilePathList files = LoadDirectoryFiles(dir);
     for (unsigned int i = 0; i < files.count; i++) {
         if (!TextIsEqual(GetFileExtension(files.paths[i]), ".info")) continue;

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -1175,34 +1175,7 @@ static void MenuShowCorePicker(nk_console* widget, void* user_data) {
     MenuNavigateInto(menu.corePickerMenu);
 }
 
-static void MenuRunCoreClicked(nk_console* widget, void* user_data) {
-    NK_UNUSED(widget);
-    NK_UNUSED(user_data);
-    if (IsLibretroGameReady()) {
-        UnloadLibretroGame();
-    }
 
-    menu.pendingGamePath[0] = '\0';
-    int coreCount = FindCoresForGame(NULL, menu.pendingCorePaths, menu.pendingCoreNames, LIBRETRO_MAX_GAME_CORES);
-    if (coreCount == 0) {
-        nk_console_show_message(menu.console, "No standalone cores available");
-        return;
-    }
-
-    if (coreCount == 1) {
-        SaveLibretroAllSettings();
-        CloseLibretro();
-        if (MenuLoadCoreAndGame(menu.pendingCorePaths[0], NULL)) {
-            HideLibretroMenu();
-        } else {
-            ShowLibretroMenu();
-        }
-        return;
-    }
-
-    menu.pendingCoreCount = coreCount;
-    nk_console_add_event(menu.console, NK_CONSOLE_EVENT_POST_RENDER_ONCE, &MenuShowCorePicker);
-}
 
 static bool MenuLoadGame(const char* gamePath) {
     // Unload the current game if it's a thing.
@@ -1416,9 +1389,6 @@ LibretroMenu* InitLibretroMenu(void) {
     }
 #endif
     LibretroMenuUpdateLoadGameFilter(&menu);
-
-    // Run Core (standalone cores that don't require a game file)
-    nk_console_button_onclick(menu.console, "Run Core", &MenuRunCoreClicked);
 
     // Close Game
     //menu.closeGameButton = nk_console_button_onclick(menu.console, "Close Game", &MenuCloseGameClicked);

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -861,9 +861,9 @@ static void ScanLibretroCoreDirectory(void) {
         const char* displayName = rlconfig_get(infoCfg, infoBase, "display_name");
         TextCopy(info->displayName, (displayName && displayName[0]) ? displayName : coreName);
         const char* noGame = rlconfig_get(infoCfg, infoBase, "supports_no_game");
-        info->supportsNoGame = noGame && strcmp(noGame, "true") == 0;
+        info->supportsNoGame = noGame && TextIsEqual(noGame, "true");
         const char* fullpath = rlconfig_get(infoCfg, infoBase, "needs_fullpath");
-        info->needsFullpath = fullpath && strcmp(fullpath, "true") == 0;
+        info->needsFullpath = fullpath && TextIsEqual(fullpath, "true");
 
         TraceLog(LOG_INFO, "LIBRETRO: Found %s (%s)", info->displayName, exts);
         cvector_push_back(menu.coreInfos, info);

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -149,6 +149,10 @@ typedef struct LibretroMenu {
     char aboutExtensions[256];
     char aboutCoreNames[LIBRETRO_MENU_MAX_LISTED_CORES][128]; // "Available Cores" labels (nk_console keeps the pointers)
     nk_rune keyboardControls[RETRO_DEVICE_ID_JOYPAD_R3 + 1];
+    int coreInfoCount;
+    char coreInfoPaths[LIBRETRO_MENU_MAX_LISTED_CORES][512];
+    char coreInfoExtensions[LIBRETRO_MENU_MAX_LISTED_CORES][200];
+    char coreInfoNames[LIBRETRO_MENU_MAX_LISTED_CORES][200];
     nk_console* corePickerMenu;
     char pendingGamePath[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char pendingCorePaths[LIBRETRO_MAX_GAME_CORES][512];
@@ -804,99 +808,100 @@ static void MenuContentDirChanged(nk_console* widget, void* user_data) {
 #endif
 }
 
-#define LIBRETRO_CORE_CACHE_SECTION "core_cache"
-
 static bool IsLibretroCoreFile(const char* path) {
     const char* ext = GetFileExtension(path);
     return TextIsEqual(ext, ".so") || TextIsEqual(ext, ".dll") || TextIsEqual(ext, ".dylib") || TextIsEqual(ext, ".wasm");
 }
 
-static int LibretroCoreDirectoryFileCount(const char* dir) {
-    if (!dir || !dir[0] || !DirectoryExists(dir)) return 0;
-    FilePathList files = LoadDirectoryFiles(dir);
-    int count = 0;
-    for (unsigned int i = 0; i < files.count; i++) {
-        if (IsLibretroCoreFile(files.paths[i])) count++;
-    }
-    UnloadDirectoryFiles(files);
-    return count;
-}
+static bool LibretroParseInfoFile(const char* infoPath, char* coreName, int coreNameSize,
+                                   char* extensions, int extensionsSize) {
+    char* text = LoadFileText(infoPath);
+    if (!text) return false;
 
-// True when every cached core file (rebuilt as <dir>/<file>) still exists on
-// disk. A missing entry means a core was moved/removed or the cache predates a
-// path-format change, so the cache should be rebuilt.
-static bool LibretroCoreCacheFilesPresent(const char* dir, int count) {
-    for (int i = 0; i < count; i++) {
-        const char* file = rlconfig_get(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, TextFormat("core_%d_path", i));
-        if (!file || !FileExists(TextFormat("%s/%s", dir, file))) return false;
+    coreName[0] = '\0';
+    extensions[0] = '\0';
+    char* pos = text;
+    while (*pos) {
+        char* eol = pos;
+        while (*eol && *eol != '\n' && *eol != '\r') eol++;
+        char saved = *eol;
+        *eol = '\0';
+
+        char* p = pos;
+        while (*p == ' ' || *p == '\t') p++;
+        if (*p && *p != '#') {
+            char* eq = strchr(p, '=');
+            if (eq) {
+                *eq = '\0';
+                char* k = p;
+                char* v = eq + 1;
+                char* kEnd = k + strlen(k);
+                while (kEnd > k && (kEnd[-1] == ' ' || kEnd[-1] == '\t')) kEnd--;
+                *kEnd = '\0';
+                while (*v == ' ' || *v == '\t') v++;
+                char* vEnd = v + strlen(v);
+                while (vEnd > v && (vEnd[-1] == ' ' || vEnd[-1] == '\t')) vEnd--;
+                *vEnd = '\0';
+                size_t vlen = (size_t)(vEnd - v);
+                if (vlen >= 2 && v[0] == '"' && v[vlen - 1] == '"') {
+                    v++;
+                    v[vlen - 2] = '\0';
+                }
+                if (strcmp(k, "corename") == 0) {
+                    snprintf(coreName, coreNameSize, "%s", v);
+                } else if (strcmp(k, "supported_extensions") == 0) {
+                    snprintf(extensions, extensionsSize, "%s", v);
+                }
+            }
+        }
+
+        *eol = saved;
+        while (*eol == '\r' || *eol == '\n') eol++;
+        pos = eol;
     }
-    return true;
+
+    UnloadFileText(text);
+    return coreName[0] != '\0';
 }
 
 static void ScanLibretroCoreDirectory(void) {
-    if (!menu.cfg) return;
     const char* dir = LIBRETRO.coreDirectory;
-    if (!dir || !dir[0]) return;
+    menu.coreInfoCount = 0;
+    if (!dir || !dir[0] || !DirectoryExists(dir)) return;
 
-    // If a core is already loaded we can't peek at other cores; just invalidate
-    // so the next launch performs a full rescan.
-    if (IsLibretroReady()) {
-        rlconfig_set_int(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, "file_count", -1);
-        rlconfig_save(menu.cfg, RAYLIB_LIBRETRO_CFG_FILE);
-        return;
-    }
-
-    // The cache stays valid while it describes the same directory (dir_path)
-    // with the same number of core files (file_count) AND every cached core
-    // file is still present. The existence check catches a core moved/removed
-    // even when the file count is unchanged (a same-count swap), and rebuilds a
-    // cache left by an older path format — all without re-peeking every core.
-    int currentCount = LibretroCoreDirectoryFileCount(dir);
-    int cachedCount = rlconfig_get_int(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, "file_count", -1);
-    const char* cachedDir = rlconfig_get(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, "dir_path");
-    if (cachedCount == currentCount && cachedDir && TextIsEqual(cachedDir, dir)) {
-        int cached = rlconfig_get_int(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, "count", 0);
-        if (LibretroCoreCacheFilesPresent(dir, cached)) {
-            TraceLog(LOG_INFO, "LIBRETRO: Core cache valid (%d cores)", cached);
-            return;
-        }
-    }
-
-    TraceLog(LOG_INFO, "LIBRETRO: Rescanning cores in %s", dir);
-    rlconfig_clear_section(menu.cfg, LIBRETRO_CORE_CACHE_SECTION);
-    rlconfig_set_int(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, "file_count", currentCount);
-    rlconfig_set(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, "dir_path", dir);
-
-    if (!DirectoryExists(dir)) {
-        rlconfig_save(menu.cfg, RAYLIB_LIBRETRO_CFG_FILE);
-        return;
-    }
+    rlconfig_clear_section(menu.cfg, "core_cache");
 
     FilePathList files = LoadDirectoryFiles(dir);
-    int coreIndex = 0;
-    for (unsigned int i = 0; i < files.count; i++) {
-        if (!IsLibretroCoreFile(files.paths[i])) continue;
-        if (!PeekLibretroCoreInfo(files.paths[i])) continue;
-        if (TextLength(LIBRETRO.core.validExtensions) == 0) {
-            CloseLibretro();
-            continue;
-        }
+    for (unsigned int i = 0; i < files.count && menu.coreInfoCount < LIBRETRO_MENU_MAX_LISTED_CORES; i++) {
+        if (!TextIsEqual(GetFileExtension(files.paths[i]), ".info")) continue;
 
-        // Store only the file name (the directory is dir_path) so the cache is
-        // portable; the full path is rebuilt as <coreDirectory>/<file> on load.
-        // rlconfig_set copies the key immediately, so chained TextFormat keys are safe.
-        rlconfig_set(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, TextFormat("core_%d_path", coreIndex), GetFileName(files.paths[i]));
-        rlconfig_set(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, TextFormat("core_%d_extensions", coreIndex), LIBRETRO.core.validExtensions);
-        rlconfig_set(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, TextFormat("core_%d_name", coreIndex), LIBRETRO.core.libraryName);
-        TraceLog(LOG_INFO, "LIBRETRO: Cached %s (%s)", LIBRETRO.core.libraryName, LIBRETRO.core.validExtensions);
-        CloseLibretro();
-        coreIndex++;
+        char infoBase[256];
+        TextCopy(infoBase, GetFileNameWithoutExt(files.paths[i]));
+        const char* coreFile = NULL;
+        for (unsigned int j = 0; j < files.count; j++) {
+            if (!IsLibretroCoreFile(files.paths[j])) continue;
+            char coreBase[256];
+            TextCopy(coreBase, GetFileNameWithoutExt(files.paths[j]));
+            if (TextIsEqual(coreBase, infoBase) ||
+                TextIsEqual(coreBase, TextFormat("%s_android", infoBase))) {
+                coreFile = GetFileName(files.paths[j]);
+                break;
+            }
+        }
+        if (!coreFile) continue;
+
+        int idx = menu.coreInfoCount;
+        if (!LibretroParseInfoFile(files.paths[i],
+                menu.coreInfoNames[idx], (int)sizeof(menu.coreInfoNames[idx]),
+                menu.coreInfoExtensions[idx], (int)sizeof(menu.coreInfoExtensions[idx]))) continue;
+        if (menu.coreInfoExtensions[idx][0] == '\0') continue;
+
+        TextCopy(menu.coreInfoPaths[idx], coreFile);
+        TraceLog(LOG_INFO, "LIBRETRO: Found %s (%s)", menu.coreInfoNames[idx], menu.coreInfoExtensions[idx]);
+        menu.coreInfoCount++;
     }
     UnloadDirectoryFiles(files);
-
-    rlconfig_set_int(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, "count", coreIndex);
-    rlconfig_save(menu.cfg, RAYLIB_LIBRETRO_CFG_FILE);
-    TraceLog(LOG_INFO, "LIBRETRO: Cached %d cores in %s", coreIndex, dir);
+    TraceLog(LOG_INFO, "LIBRETRO: Found %d cores in %s", menu.coreInfoCount, dir);
 }
 
 /**
@@ -916,9 +921,9 @@ static bool LibretroExtLower(const char* path, char* out) {
  *         (lower-case, no dot) in its valid_extensions.
  */
 static bool LibretroCoreSupportsExt(int index, const char* extLower) {
-    const char* exts = rlconfig_get(menu.cfg, LIBRETRO_CORE_CACHE_SECTION,
-                                    TextFormat("core_%d_extensions", index));
-    if (!exts) return false;
+    if (index < 0 || index >= menu.coreInfoCount) return false;
+    const char* exts = menu.coreInfoExtensions[index];
+    if (!exts[0]) return false;
     int extCount = 0;
     char** extList = TextSplit(exts, '|', &extCount);
     for (int j = 0; j < extCount; j++) {
@@ -933,10 +938,9 @@ static bool LibretroCoreSupportsExt(int index, const char* extLower) {
  * the next raylib text-buffer call, so callers must copy it immediately.
  */
 static const char* LibretroCoreDisplayName(int index) {
-    const char* name = rlconfig_get(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, TextFormat("core_%d_name", index));
-    if (name && name[0]) return name;
-    const char* file = rlconfig_get(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, TextFormat("core_%d_path", index));
-    return file ? TextReplace(GetFileNameWithoutExt(file), "_libretro", "") : "";
+    if (index < 0 || index >= menu.coreInfoCount) return "";
+    if (menu.coreInfoNames[index][0]) return menu.coreInfoNames[index];
+    return TextReplace(GetFileNameWithoutExt(menu.coreInfoPaths[index]), "_libretro", "");
 }
 
 /**
@@ -959,13 +963,12 @@ static bool FindZipInnerExtensionForCore(const char* zipPath, char* outExt) {
     if (!MountPhysFS(zipPath, "/peek")) return false;
 
     FilePathList entries = LoadDirectoryFilesFromPhysFSEx("/peek", NULL, true);
-    int coreCount = rlconfig_get_int(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, "count", 0);
     bool found = false;
 
     for (unsigned int e = 0; e < entries.count && !found; e++) {
         char innerLower[32];
         if (!LibretroExtLower(entries.paths[e], innerLower)) continue;
-        for (int i = 0; i < coreCount; i++) {
+        for (int i = 0; i < menu.coreInfoCount; i++) {
             if (LibretroCoreSupportsExt(i, innerLower)) {
                 TextCopy(outExt, innerLower);
                 found = true;
@@ -980,7 +983,7 @@ static bool FindZipInnerExtensionForCore(const char* zipPath, char* outExt) {
 }
 
 static int FindCoresForGame(const char* gamePath, char paths[][512], char names[][128], int maxCount) {
-    if (!menu.cfg || !gamePath || !gamePath[0] || !paths || !names || maxCount <= 0) return 0;
+    if (!gamePath || !gamePath[0] || !paths || !names || maxCount <= 0) return 0;
 
     char gameExtLower[32];
     if (!LibretroExtLower(gamePath, gameExtLower)) return 0;
@@ -993,15 +996,10 @@ static int FindCoresForGame(const char* gamePath, char paths[][512], char names[
     }
 
     int found = 0;
-    int count = rlconfig_get_int(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, "count", 0);
-    for (int i = 0; i < count && found < maxCount; i++) {
+    for (int i = 0; i < menu.coreInfoCount && found < maxCount; i++) {
         if (!LibretroCoreSupportsExt(i, gameExtLower)) continue;
-        const char* coreFile = rlconfig_get(menu.cfg, LIBRETRO_CORE_CACHE_SECTION,
-                                            TextFormat("core_%d_path", i));
-        if (!coreFile) continue;
         TextCopy(names[found], LibretroCoreDisplayName(i));
-        // The cache stores the file name; rebuild the full path under the core dir.
-        TextCopy(paths[found], TextFormat("%s/%s", LIBRETRO.coreDirectory, coreFile));
+        TextCopy(paths[found], TextFormat("%s/%s", LIBRETRO.coreDirectory, menu.coreInfoPaths[i]));
         found++;
     }
     return found;
@@ -1667,11 +1665,10 @@ LibretroMenu* InitLibretroMenu(void) {
 
             // Available Cores
             nk_console* coresTree = nk_console_tree(aboutMenu, "Available Cores", nk_false);
-            int cachedCores = rlconfig_get_int(menu.cfg, LIBRETRO_CORE_CACHE_SECTION, "count", 0);
-            if (cachedCores <= 0) {
+            if (menu.coreInfoCount <= 0) {
                 nk_console_label(coresTree, "(none found)");
             }
-            for (int i = 0; i < cachedCores && i < LIBRETRO_MENU_MAX_LISTED_CORES; i++) {
+            for (int i = 0; i < menu.coreInfoCount && i < LIBRETRO_MENU_MAX_LISTED_CORES; i++) {
                 TextCopy(menu.aboutCoreNames[i], LibretroCoreDisplayName(i));
                 nk_console_label(coresTree, menu.aboutCoreNames[i]);
             }
@@ -1925,10 +1922,9 @@ static void LibretroMenuUpdateLoadGameFilter(LibretroMenu* m) {
     // later cores get dropped once it fills.
     char allExts[1024] = {0};
     unsigned int allLen = 0;
-    int coreCount = rlconfig_get_int(m->cfg, LIBRETRO_CORE_CACHE_SECTION, "count", 0);
-    for (int i = 0; i < coreCount; i++) {
-        const char* exts = rlconfig_get(m->cfg, LIBRETRO_CORE_CACHE_SECTION, TextFormat("core_%d_extensions", i));
-        if (!exts || exts[0] == '\0') continue;
+    for (int i = 0; i < m->coreInfoCount; i++) {
+        const char* exts = m->coreInfoExtensions[i];
+        if (exts[0] == '\0') continue;
         // Split this core's "ext1|ext2|..." list and add each token once.
         for (const char* tok = exts; *tok != '\0'; ) {
             const char* end = tok;

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -647,34 +647,34 @@ static const char* LibretroMenuPixelFormatName(enum retro_pixel_format fmt) {
 
 static void LibretroMenuUpdateAbout(void) {
     // Frontend / runtime.
-    snprintf(menu.aboutVersion,     sizeof(menu.aboutVersion),     "raylib-libretro: %s", RAYLIB_LIBRETRO_VERSION);
-    snprintf(menu.aboutRenderer,    sizeof(menu.aboutRenderer),    "Renderer:        %s", LibretroMenuRendererName());
-    snprintf(menu.aboutResolution,  sizeof(menu.aboutResolution),  "Window:          %dx%d",
-        GetScreenWidth(), GetScreenHeight());
+    TextCopy(menu.aboutVersion,  TextFormat("raylib-libretro: %s", RAYLIB_LIBRETRO_VERSION));
+    TextCopy(menu.aboutRenderer, TextFormat("Renderer:        %s", LibretroMenuRendererName()));
+    TextCopy(menu.aboutResolution, TextFormat("Window:          %dx%d",
+        GetScreenWidth(), GetScreenHeight()));
 
     // Core.
     const char* coreName = GetLibretroName();
     const char* coreVer  = GetLibretroVersion();
     if (coreName && coreName[0]) {
-        snprintf(menu.aboutCoreName,    sizeof(menu.aboutCoreName),    "Core:            %s", coreName);
-        snprintf(menu.aboutCoreVersion, sizeof(menu.aboutCoreVersion), "Core Version:    %s", coreVer ? coreVer : "");
-        snprintf(menu.aboutCoreResolution, sizeof(menu.aboutCoreResolution), "Core Size:       %ux%u",
-            GetLibretroWidth(), GetLibretroHeight());
-        snprintf(menu.aboutCorePixelFormat, sizeof(menu.aboutCorePixelFormat), "Pixel Format:    %s",
-            LibretroMenuPixelFormatName(LIBRETRO.core.pixelFormat));
-        snprintf(menu.aboutCoreSampleRate, sizeof(menu.aboutCoreSampleRate), "Sample Rate:     %g Hz",
-            LIBRETRO.core.sampleRate);
+        TextCopy(menu.aboutCoreName,    TextFormat("Core:            %s", coreName));
+        TextCopy(menu.aboutCoreVersion, TextFormat("Core Version:    %s", coreVer ? coreVer : ""));
+        TextCopy(menu.aboutCoreResolution, TextFormat("Core Size:       %ux%u",
+            GetLibretroWidth(), GetLibretroHeight()));
+        TextCopy(menu.aboutCorePixelFormat, TextFormat("Pixel Format:    %s",
+            LibretroMenuPixelFormatName(LIBRETRO.core.pixelFormat)));
+        TextCopy(menu.aboutCoreSampleRate, TextFormat("Sample Rate:     %g Hz",
+            LIBRETRO.core.sampleRate));
         float aspect = GetLibretroAspectRatio();
         if (aspect > 0.0f) {
-            snprintf(menu.aboutCoreAspectRatio, sizeof(menu.aboutCoreAspectRatio), "Aspect Ratio:    %.3f", aspect);
+            TextCopy(menu.aboutCoreAspectRatio, TextFormat("Aspect Ratio:    %.3f", aspect));
         } else {
-            snprintf(menu.aboutCoreAspectRatio, sizeof(menu.aboutCoreAspectRatio), "Aspect Ratio:    (auto)");
+            TextCopy(menu.aboutCoreAspectRatio, "Aspect Ratio:    (auto)");
         }
         const char* exts = GetLibretroValidExtensions();
-        snprintf(menu.aboutExtensions, sizeof(menu.aboutExtensions), "Extensions:      %s",
-            (exts && exts[0]) ? exts : "(any)");
+        TextCopy(menu.aboutExtensions, TextFormat("Extensions:      %s",
+            (exts && exts[0]) ? exts : "(any)"));
     } else {
-        snprintf(menu.aboutCoreName, sizeof(menu.aboutCoreName), "Core:            (none)");
+        TextCopy(menu.aboutCoreName, "Core:            (none)");
         menu.aboutCoreVersion[0] = '\0';
         menu.aboutCoreResolution[0] = '\0';
         menu.aboutCorePixelFormat[0] = '\0';
@@ -685,8 +685,8 @@ static void LibretroMenuUpdateAbout(void) {
 
     // Content.
     if (LIBRETRO.core.contentPath[0] != '\0') {
-        snprintf(menu.aboutContent, sizeof(menu.aboutContent), "Content:         %s",
-            GetFileName(LIBRETRO.core.contentPath));
+        TextCopy(menu.aboutContent, TextFormat("Content:         %s",
+            GetFileName(LIBRETRO.core.contentPath)));
     } else {
         menu.aboutContent[0] = '\0';
     }
@@ -1448,7 +1448,7 @@ LibretroMenu* InitLibretroMenu(void) {
                 int offset = 0;
                 for (int i = 0; i < LIBRETRO_SHADER_TYPE_COUNT; ++i) {
                     const char* name = GetLibretroShaderName((LibretroShaderType)i);
-                    int len = (int)strlen(name);
+                    int len = (int)TextLength(name);
                     if (offset + len + 1 < (int)sizeof(shaderNames)) {
                         if (i > 0) shaderNames[offset++] = '|';
                         TextCopy(shaderNames + offset, name);
@@ -1692,8 +1692,7 @@ static void LibretroMenuGetNthToken(const char* str, int n, char* out, int outSi
             int len = (int)(pipe - p);
             if (len < 0) len = 0;
             if (len >= outSize) len = outSize - 1;
-            if (len > 0) memcpy(out, p, (size_t)len);
-            out[len] = '\0';
+            TextCopy(out, TextSubtext(p, 0, len));
             return;
         }
         if (!*pipe) break;
@@ -1762,7 +1761,7 @@ static int LibretroMenuFindTokenIndex(const char* str, const char* value) {
         while (*pipe && *pipe != '|') pipe++;
         int len = (int)(pipe - p);
         char tok[LIBRETRO_CORE_VARIABLE_VALUE_LEN] = {0};
-        if (len < LIBRETRO_CORE_VARIABLE_VALUE_LEN) memcpy(tok, p, (size_t)len);
+        if (len < LIBRETRO_CORE_VARIABLE_VALUE_LEN) TextCopy(tok, TextSubtext(p, 0, len));
         if (TextIsEqual(tok, value)) return idx;
         if (!*pipe) break;
         p = pipe + 1;
@@ -1783,7 +1782,7 @@ static bool LibretroMenuValueInList(const char* valuesList, const char* value) {
         while (*pipe && *pipe != '|') pipe++;
         int len = (int)(pipe - p);
         char tok[LIBRETRO_CORE_VARIABLE_VALUE_LEN] = {0};
-        if (len < LIBRETRO_CORE_VARIABLE_VALUE_LEN) memcpy(tok, p, (size_t)len);
+        if (len < LIBRETRO_CORE_VARIABLE_VALUE_LEN) TextCopy(tok, TextSubtext(p, 0, len));
         if (TextIsEqual(tok, value)) return true;
         if (!*pipe) break;
         p = pipe + 1;
@@ -1889,9 +1888,8 @@ static unsigned int LibretroMenuAddExtension(char* list, unsigned int len, size_
     // +2 reserves the '|' separator and the null terminator.
     if (len + tokLen + 2 >= cap) return len;
     if (len > 0) list[len++] = '|';
-    memcpy(list + len, tok, tokLen);
+    TextCopy(list + len, TextSubtext(tok, 0, (int)tokLen));
     len += tokLen;
-    list[len] = '\0';
     return len;
 }
 
@@ -2049,9 +2047,10 @@ void BuildLibretroMenuControllers(LibretroMenu* m) {
         // copying them, so they must persist for the lifetime of the widget.
         char* options = m->portDeviceOptions[port];
         options[0] = '\0';
+        int optLen = 0;
         for (unsigned i = 0; i < info[port].num_types; i++) {
-            if (i > 0) strncat(options, "|", sizeof(m->portDeviceOptions[port]) - strlen(options) - 1);
-            strncat(options, info[port].types[i].desc, sizeof(m->portDeviceOptions[port]) - strlen(options) - 1);
+            if (i > 0) TextAppend(options, "|", &optLen);
+            TextAppend(options, info[port].types[i].desc, &optLen);
         }
 
         unsigned currentDevice = GetLibretroPortDevice(port);

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -52,15 +52,6 @@
 #define LIBRETRO_MAX_GAME_CORES 16
 #endif
 
-typedef struct LibretroCoreInfo {
-    char path[512];
-    char extensions[200];
-    char coreName[200];
-    char displayName[200];
-    bool supportsNoGame;
-    bool needsFullpath;
-} LibretroCoreInfo;
-
 typedef enum LibretroMenuCombo {
     LIBRETRO_MENU_COMBO_NONE = 0,
     LIBRETRO_MENU_COMBO_SELECT_START,
@@ -152,7 +143,8 @@ typedef struct LibretroMenu {
     char aboutContent[160];
     char aboutExtensions[256];
     nk_rune keyboardControls[RETRO_DEVICE_ID_JOYPAD_R3 + 1];
-    cvector(LibretroCoreInfo*) coreInfos;
+    RLibretroConfig* coreInfoCfg;
+    cvector(char*) coreInfoSections;
     nk_console* corePickerMenu;
     char pendingGamePath[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char pendingCorePaths[LIBRETRO_MAX_GAME_CORES][512];
@@ -813,71 +805,30 @@ static bool IsLibretroCoreFile(const char* path) {
     return TextIsEqual(ext, ".so") || TextIsEqual(ext, ".dll") || TextIsEqual(ext, ".dylib") || TextIsEqual(ext, ".wasm");
 }
 
-static bool LibretroParseInfoFile(const char* infoPath, LibretroCoreInfo* info) {
-    char* text = LoadFileText(infoPath);
-    if (!text) return false;
+static const char* LibretroCoreInfoGet(int index, const char* key) {
+    if (index < 0 || index >= (int)cvector_size(menu.coreInfoSections)) return NULL;
+    return rlconfig_get(menu.coreInfoCfg, menu.coreInfoSections[index], key);
+}
 
-    char* pos = text;
-    while (*pos) {
-        char* eol = pos;
-        while (*eol && *eol != '\n' && *eol != '\r') eol++;
-        char saved = *eol;
-        *eol = '\0';
-
-        char* p = pos;
-        while (*p == ' ' || *p == '\t') p++;
-        if (*p && *p != '#') {
-            char* eq = strchr(p, '=');
-            if (eq) {
-                *eq = '\0';
-                char* k = p;
-                char* v = eq + 1;
-                char* kEnd = k + strlen(k);
-                while (kEnd > k && (kEnd[-1] == ' ' || kEnd[-1] == '\t')) kEnd--;
-                *kEnd = '\0';
-                while (*v == ' ' || *v == '\t') v++;
-                char* vEnd = v + strlen(v);
-                while (vEnd > v && (vEnd[-1] == ' ' || vEnd[-1] == '\t')) vEnd--;
-                *vEnd = '\0';
-                size_t vlen = (size_t)(vEnd - v);
-                if (vlen >= 2 && v[0] == '"' && v[vlen - 1] == '"') {
-                    v++;
-                    v[vlen - 2] = '\0';
-                }
-                if (strcmp(k, "corename") == 0) {
-                    snprintf(info->coreName, sizeof(info->coreName), "%s", v);
-                } else if (strcmp(k, "display_name") == 0) {
-                    snprintf(info->displayName, sizeof(info->displayName), "%s", v);
-                } else if (strcmp(k, "supported_extensions") == 0) {
-                    snprintf(info->extensions, sizeof(info->extensions), "%s", v);
-                } else if (strcmp(k, "supports_no_game") == 0) {
-                    info->supportsNoGame = strcmp(v, "true") == 0;
-                } else if (strcmp(k, "needs_fullpath") == 0) {
-                    info->needsFullpath = strcmp(v, "true") == 0;
-                }
-            }
-        }
-
-        *eol = saved;
-        while (*eol == '\r' || *eol == '\n') eol++;
-        pos = eol;
-    }
-
-    UnloadFileText(text);
-    return info->coreName[0] != '\0';
+static bool LibretroCoreInfoBool(int index, const char* key) {
+    const char* v = LibretroCoreInfoGet(index, key);
+    return v && strcmp(v, "true") == 0;
 }
 
 static void FreeLibretroCoreInfos(void) {
-    for (size_t i = 0; i < cvector_size(menu.coreInfos); i++) {
-        MemFree(menu.coreInfos[i]);
+    for (size_t i = 0; i < cvector_size(menu.coreInfoSections); i++) {
+        MemFree(menu.coreInfoSections[i]);
     }
-    cvector_free(menu.coreInfos);
-    menu.coreInfos = NULL;
+    cvector_free(menu.coreInfoSections);
+    menu.coreInfoSections = NULL;
+    rlconfig_free(menu.coreInfoCfg);
+    menu.coreInfoCfg = NULL;
 }
 
 static void ScanLibretroCoreDirectory(void) {
     const char* dir = LIBRETRO.coreDirectory;
     FreeLibretroCoreInfos();
+    menu.coreInfoCfg = rlconfig_load(NULL);
     if (!dir || !dir[0] || !DirectoryExists(dir)) return;
 
     FilePathList files = LoadDirectoryFiles(dir);
@@ -899,19 +850,24 @@ static void ScanLibretroCoreDirectory(void) {
         }
         if (!coreFile) continue;
 
-        LibretroCoreInfo* info = (LibretroCoreInfo*)MemAlloc(sizeof(LibretroCoreInfo));
-        memset(info, 0, sizeof(*info));
-        if (!LibretroParseInfoFile(files.paths[i], info) || info->extensions[0] == '\0') {
-            MemFree(info);
+        rlconfig_load_info(menu.coreInfoCfg, infoBase, files.paths[i]);
+        const char* coreName = rlconfig_get(menu.coreInfoCfg, infoBase, "corename");
+        const char* exts = rlconfig_get(menu.coreInfoCfg, infoBase, "supported_extensions");
+        if (!coreName || !coreName[0] || !exts || !exts[0]) {
+            rlconfig_clear_section(menu.coreInfoCfg, infoBase);
             continue;
         }
 
-        TextCopy(info->path, coreFile);
-        TraceLog(LOG_INFO, "LIBRETRO: Found %s (%s)", info->displayName[0] ? info->displayName : info->coreName, info->extensions);
-        cvector_push_back(menu.coreInfos, info);
+        rlconfig_set(menu.coreInfoCfg, infoBase, "path", coreFile);
+        const char* displayName = rlconfig_get(menu.coreInfoCfg, infoBase, "display_name");
+        TraceLog(LOG_INFO, "LIBRETRO: Found %s (%s)", displayName && displayName[0] ? displayName : coreName, exts);
+
+        char* section = (char*)MemAlloc(256);
+        snprintf(section, 256, "%s", infoBase);
+        cvector_push_back(menu.coreInfoSections, section);
     }
     UnloadDirectoryFiles(files);
-    TraceLog(LOG_INFO, "LIBRETRO: Found %d cores in %s", (int)cvector_size(menu.coreInfos), dir);
+    TraceLog(LOG_INFO, "LIBRETRO: Found %d cores in %s", (int)cvector_size(menu.coreInfoSections), dir);
 }
 
 /**
@@ -931,9 +887,8 @@ static bool LibretroExtLower(const char* path, char* out) {
  *         (lower-case, no dot) in its valid_extensions.
  */
 static bool LibretroCoreSupportsExt(int index, const char* extLower) {
-    if (index < 0 || index >= (int)cvector_size(menu.coreInfos)) return false;
-    const char* exts = menu.coreInfos[index]->extensions;
-    if (!exts[0]) return false;
+    const char* exts = LibretroCoreInfoGet(index, "supported_extensions");
+    if (!exts || !exts[0]) return false;
     int extCount = 0;
     char** extList = TextSplit(exts, '|', &extCount);
     for (int j = 0; j < extCount; j++) {
@@ -948,11 +903,12 @@ static bool LibretroCoreSupportsExt(int index, const char* extLower) {
  * the next raylib text-buffer call, so callers must copy it immediately.
  */
 static const char* LibretroCoreDisplayName(int index) {
-    if (index < 0 || index >= (int)cvector_size(menu.coreInfos)) return "";
-    LibretroCoreInfo* info = menu.coreInfos[index];
-    if (info->displayName[0]) return info->displayName;
-    if (info->coreName[0]) return info->coreName;
-    return TextReplace(GetFileNameWithoutExt(info->path), "_libretro", "");
+    const char* v = LibretroCoreInfoGet(index, "display_name");
+    if (v && v[0]) return v;
+    v = LibretroCoreInfoGet(index, "corename");
+    if (v && v[0]) return v;
+    v = LibretroCoreInfoGet(index, "path");
+    return v ? TextReplace(GetFileNameWithoutExt(v), "_libretro", "") : "";
 }
 
 /**
@@ -980,7 +936,7 @@ static bool FindZipInnerExtensionForCore(const char* zipPath, char* outExt) {
     for (unsigned int e = 0; e < entries.count && !found; e++) {
         char innerLower[32];
         if (!LibretroExtLower(entries.paths[e], innerLower)) continue;
-        for (int i = 0; i < (int)cvector_size(menu.coreInfos); i++) {
+        for (int i = 0; i < (int)cvector_size(menu.coreInfoSections); i++) {
             if (LibretroCoreSupportsExt(i, innerLower)) {
                 TextCopy(outExt, innerLower);
                 found = true;
@@ -1013,15 +969,17 @@ static int FindCoresForGame(const char* gamePath, char paths[][512], char names[
     }
 
     int found = 0;
-    for (int i = 0; i < (int)cvector_size(menu.coreInfos) && found < maxCount; i++) {
+    for (int i = 0; i < (int)cvector_size(menu.coreInfoSections) && found < maxCount; i++) {
         if (noGame) {
-            if (!menu.coreInfos[i]->supportsNoGame) continue;
+            if (!LibretroCoreInfoBool(i, "supports_no_game")) continue;
         } else {
             if (!LibretroCoreSupportsExt(i, gameExtLower)) continue;
-            if (isZip && menu.coreInfos[i]->needsFullpath) continue;
+            if (isZip && LibretroCoreInfoBool(i, "needs_fullpath")) continue;
         }
         TextCopy(names[found], LibretroCoreDisplayName(i));
-        TextCopy(paths[found], TextFormat("%s/%s", LIBRETRO.coreDirectory, menu.coreInfos[i]->path));
+        const char* corePath = LibretroCoreInfoGet(i, "path");
+        if (!corePath) continue;
+        TextCopy(paths[found], TextFormat("%s/%s", LIBRETRO.coreDirectory, corePath));
         found++;
     }
     return found;
@@ -1720,12 +1678,11 @@ LibretroMenu* InitLibretroMenu(void) {
 
             // Available Cores
             nk_console* coresTree = nk_console_tree(aboutMenu, "Available Cores", nk_false);
-            if (cvector_size(menu.coreInfos) == 0) {
+            if (cvector_size(menu.coreInfoSections) == 0) {
                 nk_console_label(coresTree, "(none found)");
             }
-            for (int i = 0; i < (int)cvector_size(menu.coreInfos); i++) {
-                LibretroCoreInfo* ci = menu.coreInfos[i];
-                nk_console_label(coresTree, ci->displayName[0] ? ci->displayName : ci->coreName);
+            for (int i = 0; i < (int)cvector_size(menu.coreInfoSections); i++) {
+                nk_console_label(coresTree, LibretroCoreDisplayName(i));
             }
 
             // License
@@ -1977,9 +1934,9 @@ static void LibretroMenuUpdateLoadGameFilter(LibretroMenu* m) {
     // later cores get dropped once it fills.
     char allExts[1024] = {0};
     unsigned int allLen = 0;
-    for (int i = 0; i < (int)cvector_size(m->coreInfos); i++) {
-        const char* exts = m->coreInfos[i]->extensions;
-        if (exts[0] == '\0') continue;
+    for (int i = 0; i < (int)cvector_size(m->coreInfoSections); i++) {
+        const char* exts = rlconfig_get(m->coreInfoCfg, m->coreInfoSections[i], "supported_extensions");
+        if (!exts || exts[0] == '\0') continue;
         // Split this core's "ext1|ext2|..." list and add each token once.
         for (const char* tok = exts; *tok != '\0'; ) {
             const char* end = tok;

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -52,10 +52,14 @@
 #define LIBRETRO_MAX_GAME_CORES 16
 #endif
 
-// Maximum number of cores listed in the About screen's "Available Cores" tree.
-#ifndef LIBRETRO_MENU_MAX_LISTED_CORES
-#define LIBRETRO_MENU_MAX_LISTED_CORES 64
-#endif
+typedef struct LibretroCoreInfo {
+    char path[512];
+    char extensions[200];
+    char coreName[200];
+    char displayName[200];
+    bool supportsNoGame;
+    bool needsFullpath;
+} LibretroCoreInfo;
 
 typedef enum LibretroMenuCombo {
     LIBRETRO_MENU_COMBO_NONE = 0,
@@ -147,12 +151,8 @@ typedef struct LibretroMenu {
     char aboutCoreAspectRatio[48];
     char aboutContent[160];
     char aboutExtensions[256];
-    char aboutCoreNames[LIBRETRO_MENU_MAX_LISTED_CORES][128]; // "Available Cores" labels (nk_console keeps the pointers)
     nk_rune keyboardControls[RETRO_DEVICE_ID_JOYPAD_R3 + 1];
-    int coreInfoCount;
-    char coreInfoPaths[LIBRETRO_MENU_MAX_LISTED_CORES][512];
-    char coreInfoExtensions[LIBRETRO_MENU_MAX_LISTED_CORES][200];
-    char coreInfoNames[LIBRETRO_MENU_MAX_LISTED_CORES][200];
+    cvector(LibretroCoreInfo*) coreInfos;
     nk_console* corePickerMenu;
     char pendingGamePath[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char pendingCorePaths[LIBRETRO_MAX_GAME_CORES][512];
@@ -813,13 +813,10 @@ static bool IsLibretroCoreFile(const char* path) {
     return TextIsEqual(ext, ".so") || TextIsEqual(ext, ".dll") || TextIsEqual(ext, ".dylib") || TextIsEqual(ext, ".wasm");
 }
 
-static bool LibretroParseInfoFile(const char* infoPath, char* coreName, int coreNameSize,
-                                   char* extensions, int extensionsSize) {
+static bool LibretroParseInfoFile(const char* infoPath, LibretroCoreInfo* info) {
     char* text = LoadFileText(infoPath);
     if (!text) return false;
 
-    coreName[0] = '\0';
-    extensions[0] = '\0';
     char* pos = text;
     while (*pos) {
         char* eol = pos;
@@ -848,9 +845,15 @@ static bool LibretroParseInfoFile(const char* infoPath, char* coreName, int core
                     v[vlen - 2] = '\0';
                 }
                 if (strcmp(k, "corename") == 0) {
-                    snprintf(coreName, coreNameSize, "%s", v);
+                    snprintf(info->coreName, sizeof(info->coreName), "%s", v);
+                } else if (strcmp(k, "display_name") == 0) {
+                    snprintf(info->displayName, sizeof(info->displayName), "%s", v);
                 } else if (strcmp(k, "supported_extensions") == 0) {
-                    snprintf(extensions, extensionsSize, "%s", v);
+                    snprintf(info->extensions, sizeof(info->extensions), "%s", v);
+                } else if (strcmp(k, "supports_no_game") == 0) {
+                    info->supportsNoGame = strcmp(v, "true") == 0;
+                } else if (strcmp(k, "needs_fullpath") == 0) {
+                    info->needsFullpath = strcmp(v, "true") == 0;
                 }
             }
         }
@@ -861,18 +864,26 @@ static bool LibretroParseInfoFile(const char* infoPath, char* coreName, int core
     }
 
     UnloadFileText(text);
-    return coreName[0] != '\0';
+    return info->coreName[0] != '\0';
+}
+
+static void FreeLibretroCoreInfos(void) {
+    for (size_t i = 0; i < cvector_size(menu.coreInfos); i++) {
+        MemFree(menu.coreInfos[i]);
+    }
+    cvector_free(menu.coreInfos);
+    menu.coreInfos = NULL;
 }
 
 static void ScanLibretroCoreDirectory(void) {
     const char* dir = LIBRETRO.coreDirectory;
-    menu.coreInfoCount = 0;
+    FreeLibretroCoreInfos();
     if (!dir || !dir[0] || !DirectoryExists(dir)) return;
 
     rlconfig_clear_section(menu.cfg, "core_cache");
 
     FilePathList files = LoadDirectoryFiles(dir);
-    for (unsigned int i = 0; i < files.count && menu.coreInfoCount < LIBRETRO_MENU_MAX_LISTED_CORES; i++) {
+    for (unsigned int i = 0; i < files.count; i++) {
         if (!TextIsEqual(GetFileExtension(files.paths[i]), ".info")) continue;
 
         char infoBase[256];
@@ -890,18 +901,19 @@ static void ScanLibretroCoreDirectory(void) {
         }
         if (!coreFile) continue;
 
-        int idx = menu.coreInfoCount;
-        if (!LibretroParseInfoFile(files.paths[i],
-                menu.coreInfoNames[idx], (int)sizeof(menu.coreInfoNames[idx]),
-                menu.coreInfoExtensions[idx], (int)sizeof(menu.coreInfoExtensions[idx]))) continue;
-        if (menu.coreInfoExtensions[idx][0] == '\0') continue;
+        LibretroCoreInfo* info = (LibretroCoreInfo*)MemAlloc(sizeof(LibretroCoreInfo));
+        memset(info, 0, sizeof(*info));
+        if (!LibretroParseInfoFile(files.paths[i], info) || info->extensions[0] == '\0') {
+            MemFree(info);
+            continue;
+        }
 
-        TextCopy(menu.coreInfoPaths[idx], coreFile);
-        TraceLog(LOG_INFO, "LIBRETRO: Found %s (%s)", menu.coreInfoNames[idx], menu.coreInfoExtensions[idx]);
-        menu.coreInfoCount++;
+        TextCopy(info->path, coreFile);
+        TraceLog(LOG_INFO, "LIBRETRO: Found %s (%s)", info->displayName[0] ? info->displayName : info->coreName, info->extensions);
+        cvector_push_back(menu.coreInfos, info);
     }
     UnloadDirectoryFiles(files);
-    TraceLog(LOG_INFO, "LIBRETRO: Found %d cores in %s", menu.coreInfoCount, dir);
+    TraceLog(LOG_INFO, "LIBRETRO: Found %d cores in %s", (int)cvector_size(menu.coreInfos), dir);
 }
 
 /**
@@ -921,8 +933,8 @@ static bool LibretroExtLower(const char* path, char* out) {
  *         (lower-case, no dot) in its valid_extensions.
  */
 static bool LibretroCoreSupportsExt(int index, const char* extLower) {
-    if (index < 0 || index >= menu.coreInfoCount) return false;
-    const char* exts = menu.coreInfoExtensions[index];
+    if (index < 0 || index >= (int)cvector_size(menu.coreInfos)) return false;
+    const char* exts = menu.coreInfos[index]->extensions;
     if (!exts[0]) return false;
     int extCount = 0;
     char** extList = TextSplit(exts, '|', &extCount);
@@ -938,9 +950,11 @@ static bool LibretroCoreSupportsExt(int index, const char* extLower) {
  * the next raylib text-buffer call, so callers must copy it immediately.
  */
 static const char* LibretroCoreDisplayName(int index) {
-    if (index < 0 || index >= menu.coreInfoCount) return "";
-    if (menu.coreInfoNames[index][0]) return menu.coreInfoNames[index];
-    return TextReplace(GetFileNameWithoutExt(menu.coreInfoPaths[index]), "_libretro", "");
+    if (index < 0 || index >= (int)cvector_size(menu.coreInfos)) return "";
+    LibretroCoreInfo* info = menu.coreInfos[index];
+    if (info->displayName[0]) return info->displayName;
+    if (info->coreName[0]) return info->coreName;
+    return TextReplace(GetFileNameWithoutExt(info->path), "_libretro", "");
 }
 
 /**
@@ -968,7 +982,7 @@ static bool FindZipInnerExtensionForCore(const char* zipPath, char* outExt) {
     for (unsigned int e = 0; e < entries.count && !found; e++) {
         char innerLower[32];
         if (!LibretroExtLower(entries.paths[e], innerLower)) continue;
-        for (int i = 0; i < menu.coreInfoCount; i++) {
+        for (int i = 0; i < (int)cvector_size(menu.coreInfos); i++) {
             if (LibretroCoreSupportsExt(i, innerLower)) {
                 TextCopy(outExt, innerLower);
                 found = true;
@@ -996,10 +1010,10 @@ static int FindCoresForGame(const char* gamePath, char paths[][512], char names[
     }
 
     int found = 0;
-    for (int i = 0; i < menu.coreInfoCount && found < maxCount; i++) {
+    for (int i = 0; i < (int)cvector_size(menu.coreInfos) && found < maxCount; i++) {
         if (!LibretroCoreSupportsExt(i, gameExtLower)) continue;
         TextCopy(names[found], LibretroCoreDisplayName(i));
-        TextCopy(paths[found], TextFormat("%s/%s", LIBRETRO.coreDirectory, menu.coreInfoPaths[i]));
+        TextCopy(paths[found], TextFormat("%s/%s", LIBRETRO.coreDirectory, menu.coreInfos[i]->path));
         found++;
     }
     return found;
@@ -1665,12 +1679,12 @@ LibretroMenu* InitLibretroMenu(void) {
 
             // Available Cores
             nk_console* coresTree = nk_console_tree(aboutMenu, "Available Cores", nk_false);
-            if (menu.coreInfoCount <= 0) {
+            if (cvector_size(menu.coreInfos) == 0) {
                 nk_console_label(coresTree, "(none found)");
             }
-            for (int i = 0; i < menu.coreInfoCount && i < LIBRETRO_MENU_MAX_LISTED_CORES; i++) {
-                TextCopy(menu.aboutCoreNames[i], LibretroCoreDisplayName(i));
-                nk_console_label(coresTree, menu.aboutCoreNames[i]);
+            for (int i = 0; i < (int)cvector_size(menu.coreInfos); i++) {
+                LibretroCoreInfo* ci = menu.coreInfos[i];
+                nk_console_label(coresTree, ci->displayName[0] ? ci->displayName : ci->coreName);
             }
 
             // License
@@ -1922,8 +1936,8 @@ static void LibretroMenuUpdateLoadGameFilter(LibretroMenu* m) {
     // later cores get dropped once it fills.
     char allExts[1024] = {0};
     unsigned int allLen = 0;
-    for (int i = 0; i < m->coreInfoCount; i++) {
-        const char* exts = m->coreInfoExtensions[i];
+    for (int i = 0; i < (int)cvector_size(m->coreInfos); i++) {
+        const char* exts = m->coreInfos[i]->extensions;
         if (exts[0] == '\0') continue;
         // Split this core's "ext1|ext2|..." list and add each token once.
         for (const char* tok = exts; *tok != '\0'; ) {
@@ -2405,6 +2419,8 @@ void CloseLibretroMenu(void) {
         UnloadFont(menu.font);
         menu.font.recs = NULL;
     }
+
+    FreeLibretroCoreInfos();
 
     rlconfig_free(menu.cfg);
     menu.cfg = NULL;

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -90,6 +90,15 @@ typedef enum LibretroHotkey {
     LIBRETRO_HOTKEY_COUNT,
 } LibretroHotkey;
 
+typedef struct {
+    char path[256];
+    char displayName[256];
+    char coreName[256];
+    char supportedExtensions[RLCONFIG_VALUE_MAX];
+    bool supportsNoGame;
+    bool needsFullpath;
+} LibretroCoreInfo;
+
 typedef struct LibretroMenu {
     struct nk_context* ctx;
     Font font;
@@ -143,8 +152,7 @@ typedef struct LibretroMenu {
     char aboutContent[160];
     char aboutExtensions[256];
     nk_rune keyboardControls[RETRO_DEVICE_ID_JOYPAD_R3 + 1];
-    RLibretroConfig* coreInfoCfg;
-    cvector(char*) coreInfoSections;
+    cvector(LibretroCoreInfo*) coreInfos;
     nk_console* corePickerMenu;
     char pendingGamePath[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char pendingCorePaths[LIBRETRO_MAX_GAME_CORES][512];
@@ -805,32 +813,20 @@ static bool IsLibretroCoreFile(const char* path) {
     return TextIsEqual(ext, ".so") || TextIsEqual(ext, ".dll") || TextIsEqual(ext, ".dylib") || TextIsEqual(ext, ".wasm");
 }
 
-static const char* LibretroCoreInfoGet(int index, const char* key) {
-    if (index < 0 || index >= (int)cvector_size(menu.coreInfoSections)) return NULL;
-    return rlconfig_get(menu.coreInfoCfg, menu.coreInfoSections[index], key);
-}
-
-static bool LibretroCoreInfoBool(int index, const char* key) {
-    const char* v = LibretroCoreInfoGet(index, key);
-    return v && strcmp(v, "true") == 0;
-}
-
 static void FreeLibretroCoreInfos(void) {
-    for (size_t i = 0; i < cvector_size(menu.coreInfoSections); i++) {
-        MemFree(menu.coreInfoSections[i]);
+    for (size_t i = 0; i < cvector_size(menu.coreInfos); i++) {
+        MemFree(menu.coreInfos[i]);
     }
-    cvector_free(menu.coreInfoSections);
-    menu.coreInfoSections = NULL;
-    rlconfig_free(menu.coreInfoCfg);
-    menu.coreInfoCfg = NULL;
+    cvector_free(menu.coreInfos);
+    menu.coreInfos = NULL;
 }
 
 static void ScanLibretroCoreDirectory(void) {
     const char* dir = LIBRETRO.coreDirectory;
     FreeLibretroCoreInfos();
-    menu.coreInfoCfg = rlconfig_load(NULL);
     if (!dir || !dir[0] || !DirectoryExists(dir)) return;
 
+    RLibretroConfig* infoCfg = rlconfig_load(NULL);
     FilePathList files = LoadDirectoryFiles(dir);
     for (unsigned int i = 0; i < files.count; i++) {
         if (!TextIsEqual(GetFileExtension(files.paths[i]), ".info")) continue;
@@ -850,24 +846,32 @@ static void ScanLibretroCoreDirectory(void) {
         }
         if (!coreFile) continue;
 
-        rlconfig_load_info(menu.coreInfoCfg, infoBase, files.paths[i]);
-        const char* coreName = rlconfig_get(menu.coreInfoCfg, infoBase, "corename");
-        const char* exts = rlconfig_get(menu.coreInfoCfg, infoBase, "supported_extensions");
+        rlconfig_load_info(infoCfg, infoBase, files.paths[i]);
+        const char* coreName = rlconfig_get(infoCfg, infoBase, "corename");
+        const char* exts = rlconfig_get(infoCfg, infoBase, "supported_extensions");
         if (!coreName || !coreName[0] || !exts || !exts[0]) {
-            rlconfig_clear_section(menu.coreInfoCfg, infoBase);
+            rlconfig_clear_section(infoCfg, infoBase);
             continue;
         }
 
-        rlconfig_set(menu.coreInfoCfg, infoBase, "path", coreFile);
-        const char* displayName = rlconfig_get(menu.coreInfoCfg, infoBase, "display_name");
-        TraceLog(LOG_INFO, "LIBRETRO: Found %s (%s)", displayName && displayName[0] ? displayName : coreName, exts);
+        LibretroCoreInfo* info = (LibretroCoreInfo*)MemAlloc(sizeof(LibretroCoreInfo));
+        TextCopy(info->path, coreFile);
+        TextCopy(info->supportedExtensions, exts);
+        TextCopy(info->coreName, coreName);
+        const char* displayName = rlconfig_get(infoCfg, infoBase, "display_name");
+        TextCopy(info->displayName, (displayName && displayName[0]) ? displayName : coreName);
+        const char* noGame = rlconfig_get(infoCfg, infoBase, "supports_no_game");
+        info->supportsNoGame = noGame && strcmp(noGame, "true") == 0;
+        const char* fullpath = rlconfig_get(infoCfg, infoBase, "needs_fullpath");
+        info->needsFullpath = fullpath && strcmp(fullpath, "true") == 0;
 
-        char* section = (char*)MemAlloc(256);
-        snprintf(section, 256, "%s", infoBase);
-        cvector_push_back(menu.coreInfoSections, section);
+        TraceLog(LOG_INFO, "LIBRETRO: Found %s (%s)", info->displayName, exts);
+        cvector_push_back(menu.coreInfos, info);
+        rlconfig_clear_section(infoCfg, infoBase);
     }
     UnloadDirectoryFiles(files);
-    TraceLog(LOG_INFO, "LIBRETRO: Found %d cores in %s", (int)cvector_size(menu.coreInfoSections), dir);
+    rlconfig_free(infoCfg);
+    TraceLog(LOG_INFO, "LIBRETRO: Found %d cores in %s", (int)cvector_size(menu.coreInfos), dir);
 }
 
 /**
@@ -887,8 +891,9 @@ static bool LibretroExtLower(const char* path, char* out) {
  *         (lower-case, no dot) in its valid_extensions.
  */
 static bool LibretroCoreSupportsExt(int index, const char* extLower) {
-    const char* exts = LibretroCoreInfoGet(index, "supported_extensions");
-    if (!exts || !exts[0]) return false;
+    if (index < 0 || index >= (int)cvector_size(menu.coreInfos)) return false;
+    const char* exts = menu.coreInfos[index]->supportedExtensions;
+    if (!exts[0]) return false;
     int extCount = 0;
     char** extList = TextSplit(exts, '|', &extCount);
     for (int j = 0; j < extCount; j++) {
@@ -903,12 +908,11 @@ static bool LibretroCoreSupportsExt(int index, const char* extLower) {
  * the next raylib text-buffer call, so callers must copy it immediately.
  */
 static const char* LibretroCoreDisplayName(int index) {
-    const char* v = LibretroCoreInfoGet(index, "display_name");
-    if (v && v[0]) return v;
-    v = LibretroCoreInfoGet(index, "corename");
-    if (v && v[0]) return v;
-    v = LibretroCoreInfoGet(index, "path");
-    return v ? TextReplace(GetFileNameWithoutExt(v), "_libretro", "") : "";
+    if (index < 0 || index >= (int)cvector_size(menu.coreInfos)) return "";
+    LibretroCoreInfo* info = menu.coreInfos[index];
+    if (info->displayName[0]) return info->displayName;
+    if (info->coreName[0]) return info->coreName;
+    return info->path[0] ? TextReplace(GetFileNameWithoutExt(info->path), "_libretro", "") : "";
 }
 
 /**
@@ -936,7 +940,7 @@ static bool FindZipInnerExtensionForCore(const char* zipPath, char* outExt) {
     for (unsigned int e = 0; e < entries.count && !found; e++) {
         char innerLower[32];
         if (!LibretroExtLower(entries.paths[e], innerLower)) continue;
-        for (int i = 0; i < (int)cvector_size(menu.coreInfoSections); i++) {
+        for (int i = 0; i < (int)cvector_size(menu.coreInfos); i++) {
             if (LibretroCoreSupportsExt(i, innerLower)) {
                 TextCopy(outExt, innerLower);
                 found = true;
@@ -969,17 +973,17 @@ static int FindCoresForGame(const char* gamePath, char paths[][512], char names[
     }
 
     int found = 0;
-    for (int i = 0; i < (int)cvector_size(menu.coreInfoSections) && found < maxCount; i++) {
+    for (int i = 0; i < (int)cvector_size(menu.coreInfos) && found < maxCount; i++) {
+        LibretroCoreInfo* ci = menu.coreInfos[i];
         if (noGame) {
-            if (!LibretroCoreInfoBool(i, "supports_no_game")) continue;
+            if (!ci->supportsNoGame) continue;
         } else {
             if (!LibretroCoreSupportsExt(i, gameExtLower)) continue;
-            if (isZip && LibretroCoreInfoBool(i, "needs_fullpath")) continue;
+            if (isZip && ci->needsFullpath) continue;
         }
         TextCopy(names[found], LibretroCoreDisplayName(i));
-        const char* corePath = LibretroCoreInfoGet(i, "path");
-        if (!corePath) continue;
-        TextCopy(paths[found], TextFormat("%s/%s", LIBRETRO.coreDirectory, corePath));
+        if (!ci->path[0]) continue;
+        TextCopy(paths[found], TextFormat("%s/%s", LIBRETRO.coreDirectory, ci->path));
         found++;
     }
     return found;
@@ -1648,10 +1652,10 @@ LibretroMenu* InitLibretroMenu(void) {
 
             // Available Cores
             nk_console* coresTree = nk_console_tree(aboutMenu, "Available Cores", nk_false);
-            if (cvector_size(menu.coreInfoSections) == 0) {
+            if (cvector_size(menu.coreInfos) == 0) {
                 nk_console_label(coresTree, "(none found)");
             }
-            for (int i = 0; i < (int)cvector_size(menu.coreInfoSections); i++) {
+            for (int i = 0; i < (int)cvector_size(menu.coreInfos); i++) {
                 nk_console_label(coresTree, LibretroCoreDisplayName(i));
             }
 
@@ -1904,9 +1908,9 @@ static void LibretroMenuUpdateLoadGameFilter(LibretroMenu* m) {
     // later cores get dropped once it fills.
     char allExts[1024] = {0};
     unsigned int allLen = 0;
-    for (int i = 0; i < (int)cvector_size(m->coreInfoSections); i++) {
-        const char* exts = rlconfig_get(m->coreInfoCfg, m->coreInfoSections[i], "supported_extensions");
-        if (!exts || exts[0] == '\0') continue;
+    for (int i = 0; i < (int)cvector_size(m->coreInfos); i++) {
+        const char* exts = m->coreInfos[i]->supportedExtensions;
+        if (exts[0] == '\0') continue;
         // Split this core's "ext1|ext2|..." list and add each token once.
         for (const char* tok = exts; *tok != '\0'; ) {
             const char* end = tok;

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -995,21 +995,31 @@ static bool FindZipInnerExtensionForCore(const char* zipPath, char* outExt) {
 }
 
 static int FindCoresForGame(const char* gamePath, char paths[][512], char names[][128], int maxCount) {
-    if (!gamePath || !gamePath[0] || !paths || !names || maxCount <= 0) return 0;
+    if (!paths || !names || maxCount <= 0) return 0;
 
-    char gameExtLower[32];
-    if (!LibretroExtLower(gamePath, gameExtLower)) return 0;
+    bool noGame = !gamePath || !gamePath[0];
+    char gameExtLower[32] = {0};
+    bool isZip = false;
 
-    if (TextIsEqual(gameExtLower, "zip")) {
-        char zipInner[32];
-        if (FindZipInnerExtensionForCore(gamePath, zipInner)) {
-            TextCopy(gameExtLower, zipInner);
+    if (!noGame) {
+        if (!LibretroExtLower(gamePath, gameExtLower)) return 0;
+        isZip = TextIsEqual(gameExtLower, "zip");
+        if (isZip) {
+            char zipInner[32];
+            if (FindZipInnerExtensionForCore(gamePath, zipInner)) {
+                TextCopy(gameExtLower, zipInner);
+            }
         }
     }
 
     int found = 0;
     for (int i = 0; i < (int)cvector_size(menu.coreInfos) && found < maxCount; i++) {
-        if (!LibretroCoreSupportsExt(i, gameExtLower)) continue;
+        if (noGame) {
+            if (!menu.coreInfos[i]->supportsNoGame) continue;
+        } else {
+            if (!LibretroCoreSupportsExt(i, gameExtLower)) continue;
+            if (isZip && menu.coreInfos[i]->needsFullpath) continue;
+        }
         TextCopy(names[found], LibretroCoreDisplayName(i));
         TextCopy(paths[found], TextFormat("%s/%s", LIBRETRO.coreDirectory, menu.coreInfos[i]->path));
         found++;
@@ -1154,7 +1164,8 @@ static void MenuNavigateInto(nk_console* parent) {
 
 static void MenuCorePickerLoad(nk_console* widget, void* user_data) {
     (void)widget;
-    if (!MenuLoadCoreAndGame((const char*)user_data, menu.pendingGamePath)) {
+    const char* gamePath = menu.pendingGamePath[0] ? menu.pendingGamePath : NULL;
+    if (!MenuLoadCoreAndGame((const char*)user_data, gamePath)) {
         ShowLibretroMenu();
         return;
     }
@@ -1204,6 +1215,35 @@ static void MenuShowCorePicker(nk_console* widget, void* user_data) {
     }
     ShowLibretroMenu();
     MenuNavigateInto(menu.corePickerMenu);
+}
+
+static void MenuRunCoreClicked(nk_console* widget, void* user_data) {
+    NK_UNUSED(widget);
+    NK_UNUSED(user_data);
+    if (IsLibretroGameReady()) {
+        UnloadLibretroGame();
+    }
+
+    menu.pendingGamePath[0] = '\0';
+    int coreCount = FindCoresForGame(NULL, menu.pendingCorePaths, menu.pendingCoreNames, LIBRETRO_MAX_GAME_CORES);
+    if (coreCount == 0) {
+        nk_console_show_message(menu.console, "No standalone cores available");
+        return;
+    }
+
+    if (coreCount == 1) {
+        SaveLibretroAllSettings();
+        CloseLibretro();
+        if (MenuLoadCoreAndGame(menu.pendingCorePaths[0], NULL)) {
+            HideLibretroMenu();
+        } else {
+            ShowLibretroMenu();
+        }
+        return;
+    }
+
+    menu.pendingCoreCount = coreCount;
+    nk_console_add_event(menu.console, NK_CONSOLE_EVENT_POST_RENDER_ONCE, &MenuShowCorePicker);
 }
 
 static bool MenuLoadGame(const char* gamePath) {
@@ -1418,6 +1458,9 @@ LibretroMenu* InitLibretroMenu(void) {
     }
 #endif
     LibretroMenuUpdateLoadGameFilter(&menu);
+
+    // Run Core (standalone cores that don't require a game file)
+    nk_console_button_onclick(menu.console, "Run Core", &MenuRunCoreClicked);
 
     // Close Game
     //menu.closeGameButton = nk_console_button_onclick(menu.console, "Close Game", &MenuCloseGameClicked);

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -1644,9 +1644,11 @@ LibretroMenu* InitLibretroMenu(void) {
             nk_console_label(systemTree, menu.aboutRenderer);
             nk_console_label(systemTree, "Platform:        " RAYLIB_LIBRETRO_PLATFORM);
             nk_console_label(systemTree, menu.aboutResolution);
+            nk_console_label(systemTree, "License:         zlib/libpng");
+            nk_console_label(systemTree, "https://github.com/RobLoach/raylib-libretro");
 
             // Core
-            nk_console* coreTree = nk_console_tree(aboutMenu, "Core", nk_false);
+            nk_console* coreTree = nk_console_tree(aboutMenu, "Core", nk_true);
             nk_console_label(coreTree, menu.aboutCoreName);
             nk_console_label(coreTree, menu.aboutCoreVersion);
             nk_console_label(coreTree, menu.aboutCoreResolution);
@@ -1657,21 +1659,19 @@ LibretroMenu* InitLibretroMenu(void) {
             nk_console_label(coreTree, menu.aboutExtensions);
 
             // Available Cores
-            nk_console* coresTree = nk_console_tree(aboutMenu, "Available Cores", nk_false);
+            nk_console* coresTree = nk_console_tree(aboutMenu, "Available Cores", nk_true);
             if (cvector_size(menu.coreInfos) == 0) {
                 nk_console_label(coresTree, "(none found)");
             }
             for (int i = 0; i < (int)cvector_size(menu.coreInfos); i++) {
                 LibretroCoreInfo* ci = menu.coreInfos[i];
-                nk_console* coreTree = nk_console_tree(coresTree, LibretroCoreDisplayName(i), nk_false);
-                if (ci->systemName[0]) nk_console_label(coreTree, TextFormat("System:  %s", ci->systemName));
-                if (ci->license[0]) nk_console_label(coreTree, TextFormat("License: %s", ci->license));
+                nk_console_label(coresTree, LibretroCoreDisplayName(i));
             }
 
-            // License
-            nk_console* licenseTree = nk_console_tree(aboutMenu, "License", nk_false);
-            nk_console_label(licenseTree, "License:         zlib/libpng");
-            nk_console_label(licenseTree, "https://github.com/RobLoach/raylib-libretro");
+            nk_console_rule_horizontal(aboutMenu, nk_rgba(0,0,0,0), nk_false);
+            nk_console_button_set_symbol(
+                nk_console_button_onclick(aboutMenu, "Back", &nk_console_button_back),
+                NK_SYMBOL_TRIANGLE_LEFT);
         }
     }
 

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -2138,6 +2138,24 @@ void BuildLibretroMenuControllers(LibretroMenu* m) {
     m->controllersMenu->visible = (nk_bool)anyWidget;
 }
 
+// Copy a "raylib-libretro" string setting into dest when present; dest is left
+// unchanged if the key is absent, so its existing default stays in place.
+static void LibretroMenuLoadString(const char* key, char* dest) {
+    const char* value = rlconfig_get(menu.cfg, "raylib-libretro", key);
+    if (value) TextCopy(dest, value);
+}
+
+// Write the loaded core's options into its [libraryName] section (no disk flush).
+// No-op when no core is loaded or it exposed no variables.
+static void LibretroMenuWriteCoreOptions(void) {
+    const char* coreName = LIBRETRO.core.libraryName;
+    if (!menu.cfg || !coreName || !coreName[0] || LIBRETRO.core.variableCount == 0) return;
+    rlconfig_clear_section(menu.cfg, coreName);
+    for (unsigned i = 0; i < LIBRETRO.core.variableCount; i++) {
+        rlconfig_set(menu.cfg, coreName, LIBRETRO.core.variableKeys[i], LIBRETRO.core.variableValues[i]);
+    }
+}
+
 static void LibretroMenuUpdateConfig(void) {
     if (!menu.cfg) return;
     if (!IsWindowFullscreen()) {
@@ -2194,13 +2212,9 @@ static bool SaveLibretroMenuSettings(void) {
 }
 
 static bool SaveLibretroCoreOptions(void) {
-    if (!menu.cfg || LIBRETRO.core.variableCount == 0) return false;
     const char *coreName = LIBRETRO.core.libraryName;
-    if (!coreName || !coreName[0]) return false;
-    rlconfig_clear_section(menu.cfg, coreName);
-    for (unsigned i = 0; i < LIBRETRO.core.variableCount; i++) {
-        rlconfig_set(menu.cfg, coreName, LIBRETRO.core.variableKeys[i], LIBRETRO.core.variableValues[i]);
-    }
+    if (!menu.cfg || LIBRETRO.core.variableCount == 0 || !coreName || !coreName[0]) return false;
+    LibretroMenuWriteCoreOptions();
     bool ok = rlconfig_save(menu.cfg, RAYLIB_LIBRETRO_CFG_FILE);
     TraceLog(LOG_INFO, "LIBRETRO: Saved core options to %s", RAYLIB_LIBRETRO_CFG_FILE);
     return ok;
@@ -2286,13 +2300,7 @@ EMSCRIPTEN_KEEPALIVE // expose to JS as Module._SaveLibretroAllSettings
 bool SaveLibretroAllSettings(void) {
     if (!menu.cfg) return false;
     LibretroMenuUpdateConfig();
-    const char *coreName = LIBRETRO.core.libraryName;
-    if (coreName && coreName[0] && LIBRETRO.core.variableCount > 0) {
-        rlconfig_clear_section(menu.cfg, coreName);
-        for (unsigned i = 0; i < LIBRETRO.core.variableCount; i++) {
-            rlconfig_set(menu.cfg, coreName, LIBRETRO.core.variableKeys[i], LIBRETRO.core.variableValues[i]);
-        }
-    }
+    LibretroMenuWriteCoreOptions();
     SaveLibretroPortDevices();
     bool ok = rlconfig_save(menu.cfg, RAYLIB_LIBRETRO_CFG_FILE);
     TraceLog(LOG_INFO, "MENU: Saved all settings to %s", RAYLIB_LIBRETRO_CFG_FILE);
@@ -2388,8 +2396,7 @@ static bool LoadLibretroMenuSettings(void) {
     if (menu.saveSlotIndex < 0 || menu.saveSlotIndex > 9) menu.saveSlotIndex = 0;
 
     // Username
-    const char* username = rlconfig_get(menu.cfg, "raylib-libretro", "username");
-    if (username) TextCopy(LIBRETRO.username, username);
+    LibretroMenuLoadString("username", LIBRETRO.username);
 
     // Hotkey bindings (keyboard + gamepad), keyed by name as "key<Name>"/"gamepad<Name>".
     for (int i = 0; i < LIBRETRO_HOTKEY_COUNT; i++) {
@@ -2412,18 +2419,12 @@ static bool LoadLibretroMenuSettings(void) {
     if (menu.slowMotionSpeed > 0.9f) menu.slowMotionSpeed = 0.9f;
 
     // Directories
-    const char* coreDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "coreDirectory");
-    if (coreDirectory) TextCopy(LIBRETRO.coreDirectory, coreDirectory);
-    const char* saveDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "saveDirectory");
-    if (saveDirectory) TextCopy(LIBRETRO.saveDirectory, saveDirectory);
-    const char* coreAssetsDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "coreAssetsDirectory");
-    if (coreAssetsDirectory) TextCopy(LIBRETRO.coreAssetsDirectory, coreAssetsDirectory);
-    const char* systemDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "systemDirectory");
-    if (systemDirectory) TextCopy(LIBRETRO.systemDirectory, systemDirectory);
-    const char* playlistsDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "playlistsDirectory");
-    if (playlistsDirectory) TextCopy(LIBRETRO.playlistsDirectory, playlistsDirectory);
-    const char* fileBrowserStartDirectory = rlconfig_get(menu.cfg, "raylib-libretro", "fileBrowserStartDirectory");
-    if (fileBrowserStartDirectory) TextCopy(LIBRETRO.fileBrowserStartDirectory, fileBrowserStartDirectory);
+    LibretroMenuLoadString("coreDirectory", LIBRETRO.coreDirectory);
+    LibretroMenuLoadString("saveDirectory", LIBRETRO.saveDirectory);
+    LibretroMenuLoadString("coreAssetsDirectory", LIBRETRO.coreAssetsDirectory);
+    LibretroMenuLoadString("systemDirectory", LIBRETRO.systemDirectory);
+    LibretroMenuLoadString("playlistsDirectory", LIBRETRO.playlistsDirectory);
+    LibretroMenuLoadString("fileBrowserStartDirectory", LIBRETRO.fileBrowserStartDirectory);
 
     // Keyboard Controls
     for (int i = 0; i <= RETRO_DEVICE_ID_JOYPAD_R3; i++) {

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -823,6 +823,22 @@ static void FreeLibretroCoreInfos(void) {
     menu.coreInfos = NULL;
 }
 
+/**
+ * Scan the core directory and build the menu's core list.
+ *
+ * Each core's metadata (name, supported extensions, needs_fullpath,
+ * supports_no_game) is read from its sibling `<core>.info` file — fast, no
+ * dlopen. A core binary with no matching `.info` is probed directly via
+ * PeekLibretroCoreInfo() so it still appears rather than vanishing silently.
+ *
+ * IMPORTANT: the `.info` values are PRE-LOAD HINTS for menu filtering only,
+ * never a hard gate. The authoritative values come from the core's runtime
+ * retro_get_system_info() / CONTENT_INFO_OVERRIDE once it is loaded, and the
+ * two can diverge — e.g. genesis_plus_gx declares needs_fullpath="true"
+ * globally (for SegaCD) yet loads cartridge ROMs from memory. Filtering a core
+ * out on a coarse `.info` flag is exactly how zipped Genesis games got wrongly
+ * rejected; let the loader make the final per-content decision.
+ */
 static void ScanLibretroCoreDirectory(void) {
     const char* dir = LIBRETRO.coreDirectory;
     FreeLibretroCoreInfos();
@@ -833,12 +849,12 @@ static void ScanLibretroCoreDirectory(void) {
     for (unsigned int i = 0; i < files.count; i++) {
         if (!TextIsEqual(GetFileExtension(files.paths[i]), ".info")) continue;
 
-        char infoBase[256];
+        char infoBase[RAYLIB_LIBRETRO_VFS_MAX_PATH];
         TextCopy(infoBase, GetFileNameWithoutExt(files.paths[i]));
         const char* coreFile = NULL;
         for (unsigned int j = 0; j < files.count; j++) {
             if (!IsLibretroCoreFile(files.paths[j])) continue;
-            char coreBase[256];
+            char coreBase[RAYLIB_LIBRETRO_VFS_MAX_PATH];
             TextCopy(coreBase, GetFileNameWithoutExt(files.paths[j]));
             if (TextIsEqual(coreBase, infoBase) ||
                 TextIsEqual(coreBase, TextFormat("%s_android", infoBase))) {
@@ -875,6 +891,47 @@ static void ScanLibretroCoreDirectory(void) {
         cvector_push_back(menu.coreInfos, info);
         rlconfig_clear_section(infoCfg, infoBase);
     }
+
+    // Fallback: a core binary with no sibling .info would otherwise be invisible
+    // (the loop above is .info-driven). Probe such cores directly so they still
+    // appear. Guarded on IsLibretroReady(): the probe's CloseLibretro() wipes
+    // LIBRETRO.core, which would tear down a game in progress — and this scan
+    // also runs from MenuCoreDirChanged while in-game. supports_no_game can't be
+    // known without a full init, so it defaults to false for probed cores.
+    if (!IsLibretroReady()) {
+        for (unsigned int i = 0; i < files.count; i++) {
+            if (!IsLibretroCoreFile(files.paths[i])) continue;
+            const char* coreFile = GetFileName(files.paths[i]);
+
+            bool hasInfo = false;
+            for (int k = 0; k < (int)cvector_size(menu.coreInfos); k++) {
+                if (TextIsEqual(menu.coreInfos[k]->path, coreFile)) { hasInfo = true; break; }
+            }
+            if (hasInfo) continue;
+
+            if (PeekLibretroCoreInfo(files.paths[i])) {
+                const char* name = GetLibretroName();
+                const char* exts = GetLibretroValidExtensions();
+                if (name[0] && exts[0]) {
+                    LibretroCoreInfo* info = (LibretroCoreInfo*)MemAlloc(sizeof(LibretroCoreInfo));
+                    TextCopy(info->path, coreFile);
+                    TextCopy(info->supportedExtensions, exts);
+                    TextCopy(info->coreName, name);
+                    TextCopy(info->displayName, name);
+                    info->systemName[0] = '\0';
+                    info->license[0] = '\0';
+                    info->needsFullpath = GetLibretroNeedFullpath(NULL, NULL);
+                    info->supportsNoGame = false;
+                    TraceLog(LOG_INFO, "LIBRETRO: Probed %s (%s) [no .info]", name, exts);
+                    cvector_push_back(menu.coreInfos, info);
+                }
+            }
+            // Always tear down: PeekLibretroCoreInfo leaves the dylib open on
+            // success, and may leave it open on a mid-way symbol-load failure.
+            CloseLibretro();
+        }
+    }
+
     UnloadDirectoryFiles(files);
     rlconfig_free(infoCfg);
     TraceLog(LOG_INFO, "LIBRETRO: Found %d cores in %s", (int)cvector_size(menu.coreInfos), dir);
@@ -985,8 +1042,9 @@ static int FindCoresForGame(const char* gamePath, char paths[][512], char names[
             if (!ci->supportsNoGame) continue;
         } else {
             if (!LibretroCoreSupportsExt(i, gameExtLower)) continue;
-            if (isZip && ci->needsFullpath) continue;
+            // Some cores require "needs_fullpath", like for CD. We allow attempting to load directly from the .zip for now.
         }
+
         TextCopy(names[found], LibretroCoreDisplayName(i));
         if (!ci->path[0]) continue;
         TextCopy(paths[found], TextFormat("%s/%s", LIBRETRO.coreDirectory, ci->path));
@@ -1184,8 +1242,6 @@ static void MenuShowCorePicker(nk_console* widget, void* user_data) {
     ShowLibretroMenu();
     MenuNavigateInto(menu.corePickerMenu);
 }
-
-
 
 static bool MenuLoadGame(const char* gamePath) {
     // Unload the current game if it's a thing.


### PR DESCRIPTION
Replace the config cache system with .info files from libretro-core-info. Core metadata is now read from .info files at startup instead of dynamically loading each core library to peek at its system info.

Fixes #302