### PR TITLE
Support zip archives for need_fullpath cores

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,10 @@ The menu builds its core list (`ScanLibretroCoreDirectory`) from sibling `<core>
 
 The `.info` fields (`supported_extensions`, `needs_fullpath`, `supports_no_game`) are **pre-load hints for menu filtering only — never a hard gate**. Authoritative values come from the core's runtime `retro_get_system_info()` / `RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE` once loaded, and the two can diverge: e.g. `genesis_plus_gx` declares `needs_fullpath="true"` globally (for SegaCD) yet loads cartridge ROMs from memory. Filtering a core out on a coarse `.info` flag is how zipped Genesis games got wrongly rejected — let the loader make the final per-content decision.
 
+### VFS alt-filesystem bridge
+
+The core VFS layer (`raylib-libretro-vfs.h`) exposes three nullable global function-pointer hooks — `raylib_libretro_vfs_alt_load_file_data` / `_stat` / `_load_dir_files`. When set, VFS read/stat/listdir operations consult them *before* the real filesystem and fall back if they return not-found. This is the bridge that lets a `needs_fullpath` core read content that lives **inside a mounted archive**: the PhysFS layer (`raylib-libretro-physfs.h`) installs PhysFS-backed implementations in `InitLibretroPhysFS()` (and clears them in `CloseLibretroPhysFS()`), so when such a core `fopen`s a `/game/...` virtual path, the VFS serves it from the zip. The core layer stays PhysFS-free; the dependency points one way (frontend → core globals).
+
 ## Build
 
 ```sh

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -63,6 +63,12 @@
                 <data android:mimeType="*/*" android:pathPattern=".*\\.wad"/>
                 <data android:mimeType="*/*" android:pathPattern=".*\\.iwad"/>
                 <data android:mimeType="*/*" android:pathPattern=".*\\.pwad"/>
+                <!-- Self-contained disc images (genesis_plus_gx, mednafen_pce_fast).
+                     Multi-file descriptors (.cue/.ccd/.toc/.m3u) are intentionally
+                     omitted: a single content-URI copy can't bring sibling tracks
+                     along, so those should be delivered zipped. -->
+                <data android:mimeType="*/*" android:pathPattern=".*\\.chd"/>
+                <data android:mimeType="*/*" android:pathPattern=".*\\.iso"/>
                 <!-- Archives -->
                 <data android:mimeType="*/*" android:pathPattern=".*\\.zip"/>
             </intent-filter>

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -1000,6 +1000,21 @@ static bool FindZipInnerExtensionForCore(const char* zipPath, char* outExt) {
     FilePathList entries = LoadDirectoryFilesFromPhysFSEx("/peek", NULL, true);
     bool found = false;
 
+    // Prefer disc metadata (.m3u, .cue) so the core list matches what the
+    // loader will actually hand to the core.
+    for (unsigned int e = 0; e < entries.count && !found; e++) {
+        if (!IsFileExtension(entries.paths[e], ".m3u;.cue")) continue;
+        char innerLower[32];
+        if (!LibretroExtLower(entries.paths[e], innerLower)) continue;
+        for (int i = 0; i < (int)cvector_size(menu.coreInfos); i++) {
+            if (LibretroCoreSupportsExt(i, innerLower)) {
+                TextCopy(outExt, innerLower);
+                found = true;
+                break;
+            }
+        }
+    }
+
     for (unsigned int e = 0; e < entries.count && !found; e++) {
         char innerLower[32];
         if (!LibretroExtLower(entries.paths[e], innerLower)) continue;

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -979,8 +979,12 @@ static const char* LibretroCoreDisplayName(int index) {
 }
 
 /**
- * Peek inside a .zip and return the first inner-file extension that any
- * cached core advertises in its valid_extensions.
+ * Peek inside a .zip and return an inner-file extension that any cached core
+ * advertises in its valid_extensions.
+ *
+ * Disc metadata (.m3u, .cue) is preferred over other entries so the core list
+ * matches what LibretroPhysFSPickFileInZip will actually hand to the core;
+ * otherwise the first matching entry wins.
  *
  * Mounts the archive at a scratch PhysFS namespace ("/peek") so an active
  * /game mount used by an in-flight load is not disturbed, enumerates the

--- a/include/raylib-libretro-physfs.h
+++ b/include/raylib-libretro-physfs.h
@@ -59,6 +59,49 @@ typedef struct rLibretroPhysFS {
 static rLibretroPhysFS LibretroPhysFS = {0};
 
 /**
+ * PhysFS-backed VFS hook: load file data from the PhysFS search path.
+ * Returns NULL silently when the file is not found in any mount.
+ */
+static unsigned char* LibretroPhysFSVfsLoadFileData(const char* fileName, int* bytesRead) {
+    if (!IsPhysFSReady() || !FileExistsInPhysFS(fileName)) {
+        *bytesRead = 0;
+        return NULL;
+    }
+    return LoadFileDataFromPhysFS(fileName, bytesRead);
+}
+
+/**
+ * PhysFS-backed VFS hook: stat a path in the PhysFS search path.
+ * Returns RETRO_VFS_STAT flags, or 0 if not found.
+ */
+static int LibretroPhysFSVfsStat(const char* path, int32_t* size) {
+    if (!IsPhysFSReady()) return 0;
+    PHYSFS_Stat stat;
+    if (PHYSFS_stat(path, &stat) == 0) return 0;
+
+    if (stat.filetype == PHYSFS_FILETYPE_DIRECTORY) {
+        return RETRO_VFS_STAT_IS_DIRECTORY | RETRO_VFS_STAT_IS_VALID;
+    }
+    if (stat.filetype == PHYSFS_FILETYPE_REGULAR) {
+        if (size != NULL) *size = (int32_t)stat.filesize;
+        return RETRO_VFS_STAT_IS_VALID;
+    }
+    return 0;
+}
+
+/**
+ * PhysFS-backed VFS hook: list directory contents from the PhysFS search path.
+ * Returns an empty list when the directory is not found.
+ */
+static FilePathList LibretroPhysFSVfsLoadDirFiles(const char* dirPath) {
+    if (IsPhysFSReady() && DirectoryExistsInPhysFS(dirPath)) {
+        return LoadDirectoryFilesFromPhysFS(dirPath);
+    }
+    FilePathList empty = {0};
+    return empty;
+}
+
+/**
  * Unmounts the game mount.
  */
 static void LibretroPhysFSClearMount(void) {
@@ -79,6 +122,9 @@ static bool InitLibretroPhysFS(void) {
         TraceLog(LOG_WARNING, "LIBRETRO: Failed to initialize PhysFS");
         return false;
     }
+    raylib_libretro_vfs_alt_load_file_data = LibretroPhysFSVfsLoadFileData;
+    raylib_libretro_vfs_alt_stat = LibretroPhysFSVfsStat;
+    raylib_libretro_vfs_alt_load_dir_files = LibretroPhysFSVfsLoadDirFiles;
     LibretroPhysFS.ready = true;
     return true;
 }
@@ -89,6 +135,9 @@ static bool InitLibretroPhysFS(void) {
 static void CloseLibretroPhysFS(void) {
     LibretroPhysFSClearMount();
     if (LibretroPhysFS.ready) {
+        raylib_libretro_vfs_alt_load_file_data = NULL;
+        raylib_libretro_vfs_alt_stat = NULL;
+        raylib_libretro_vfs_alt_load_dir_files = NULL;
         ClosePhysFS();
         LibretroPhysFS.ready = false;
     }
@@ -118,17 +167,30 @@ static bool LibretroPhysFSPickFileInZip(const char* zipFile, char* outPath) {
     const char* zipBase = GetFileNameWithoutExt(zipFile);
     bool found = false;
 
-    // Pass 1: basename match (any depth).
-    for (unsigned int i = 0; i < entries.count; i++) {
+    // Pass 1: disc metadata — .m3u playlists, then .cue sheets.
+    for (unsigned int i = 0; !found && i < entries.count; i++) {
+        if (IsFileExtension(entries.paths[i], ".m3u")) {
+            TextCopy(outPath, entries.paths[i]);
+            found = true;
+        }
+    }
+    for (unsigned int i = 0; !found && i < entries.count; i++) {
+        if (IsFileExtension(entries.paths[i], ".cue")) {
+            TextCopy(outPath, entries.paths[i]);
+            found = true;
+        }
+    }
+
+    // Pass 2: basename match (any depth).
+    for (unsigned int i = 0; !found && i < entries.count; i++) {
         const char* name = GetFileName(entries.paths[i]);
         if (TextIsEqual(GetFileNameWithoutExt(name), zipBase)) {
             TextCopy(outPath, entries.paths[i]);
             found = true;
-            break;
         }
     }
 
-    // Pass 2: first entry whose extension is in validExtensions (any depth).
+    // Pass 3: first entry whose extension is in validExtensions (any depth).
     const char* exts = GetLibretroValidExtensions();
     if (!found && exts != NULL && exts[0] != '\0') {
         char pattern[256];
@@ -203,9 +265,12 @@ static bool LoadLibretroGameFromPhysFS(const char* gameFile) {
         // rejected (unless block_extract pushed them through the regular
         // file path above).
         if (treatAsArchive) {
-            TraceLog(LOG_ERROR, "LIBRETRO: Core requires a real file path; .zip not supported");
-            LibretroPhysFSClearMount();
-            return false;
+            // Hand the core the PhysFS virtual path. The VFS hooks
+            // installed by InitLibretroPhysFS() let the core read
+            // /game/* transparently from the mounted archive.
+            bool ok = LoadLibretroGame(virtualPath);
+            if (!ok) LibretroPhysFSClearMount();
+            return ok;
         }
         bool ok = LoadLibretroGame(gameFile);
         if (!ok) LibretroPhysFSClearMount();

--- a/include/raylib-libretro-physfs.h
+++ b/include/raylib-libretro-physfs.h
@@ -146,9 +146,12 @@ static void CloseLibretroPhysFS(void) {
 /**
  * Pick the ROM file inside /game after the caller has already mounted a zip file.
  *
- * Will find the first entry that matches...
- *   1. The same basename without the extension. For example: mario.zip > mario.nes
- *   2. The first entry whose extension appears in the core's retro_system_info::valid_extensions
+ * Tries each strategy in turn, stopping at the first match:
+ *   1. Disc metadata — the first .m3u playlist, then the first .cue sheet, so
+ *      CD-based cores receive the descriptor rather than a raw track/bin. Only
+ *      considered when the loaded core advertises that extension.
+ *   2. The same basename without the extension. For example: mario.zip > mario.nes
+ *   3. The first entry whose extension appears in the core's retro_system_info::valid_extensions
  *
  * Subdirectories are searched recursively.
  *
@@ -167,15 +170,27 @@ static bool LibretroPhysFSPickFileInZip(const char* zipFile, char* outPath) {
     const char* zipBase = GetFileNameWithoutExt(zipFile);
     bool found = false;
 
-    // Pass 1: disc metadata — .m3u playlists, then .cue sheets.
+    // The loaded core's valid extensions, as an IsFileExtension pattern.
+    const char* exts = GetLibretroValidExtensions();
+    bool hasExts = exts != NULL && exts[0] != '\0';
+    char pattern[256] = {0};
+    if (hasExts) {
+        GetLibretroFileExtensionPattern(exts, pattern, sizeof(pattern));
+    }
+
+    // Pass 1: disc metadata — .m3u playlists, then .cue sheets — but only when
+    // the loaded core advertises support for them, so a core that takes raw
+    // tracks (e.g. .bin) isn't handed a descriptor it can't parse.
     for (unsigned int i = 0; !found && i < entries.count; i++) {
-        if (IsFileExtension(entries.paths[i], ".m3u")) {
+        if (IsFileExtension(entries.paths[i], ".m3u") &&
+            (!hasExts || IsFileExtension(entries.paths[i], pattern))) {
             TextCopy(outPath, entries.paths[i]);
             found = true;
         }
     }
     for (unsigned int i = 0; !found && i < entries.count; i++) {
-        if (IsFileExtension(entries.paths[i], ".cue")) {
+        if (IsFileExtension(entries.paths[i], ".cue") &&
+            (!hasExts || IsFileExtension(entries.paths[i], pattern))) {
             TextCopy(outPath, entries.paths[i]);
             found = true;
         }
@@ -191,10 +206,7 @@ static bool LibretroPhysFSPickFileInZip(const char* zipFile, char* outPath) {
     }
 
     // Pass 3: first entry whose extension is in validExtensions (any depth).
-    const char* exts = GetLibretroValidExtensions();
-    if (!found && exts != NULL && exts[0] != '\0') {
-        char pattern[256];
-        GetLibretroFileExtensionPattern(exts, pattern, sizeof(pattern));
+    if (!found && hasExts) {
         for (unsigned int i = 0; i < entries.count; i++) {
             const char* name = GetFileName(entries.paths[i]);
             if (IsFileExtension(name, pattern)) {

--- a/include/raylib-libretro-physfs.h
+++ b/include/raylib-libretro-physfs.h
@@ -261,34 +261,9 @@ static bool LoadLibretroGameFromPhysFS(const char* gameFile) {
     bool persistent = false;
     if (GetLibretroNeedFullpath(virtualPath, &persistent)) {
         if (treatAsArchive) {
-            // Hand the core the PhysFS virtual path directly via
-            // retro_load_game. The VFS hooks installed by
-            // InitLibretroPhysFS() let the core read /game/*
-            // transparently from the mounted archive. We bypass
-            // LoadLibretroGame() because its FileExists() check
-            // only sees the real filesystem.
-            if (IsLibretroGameReady()) UnloadLibretroGame();
-            struct retro_game_info info;
-            info.data = NULL;
-            info.size = 0;
-            info.path = virtualPath;
-            info.meta = "";
-            TextCopy(LIBRETRO.core.contentPath, virtualPath);
-            SetLibretroGameInfoExt(NULL, 0);
-            if (!LIBRETRO.core.symbols.retro_load_game(&info)) {
-                TraceLog(LOG_ERROR, "LIBRETRO: Failed to load from archive: %s", virtualPath);
-                LIBRETRO.core.loaded = false;
-                LIBRETRO.core.contentPath[0] = '\0';
-                LIBRETRO.core.gameInfoExtValid = false;
-                LibretroPhysFSClearMount();
-                return false;
-            }
-            LIBRETRO.core.loaded = InitLibretroAudioVideo();
-            if (!LIBRETRO.core.loaded) {
-                LibretroPhysFSClearMount();
-                return false;
-            }
-            return true;
+            bool ok = LoadLibretroGame(virtualPath);
+            if (!ok) LibretroPhysFSClearMount();
+            return ok;
         }
         bool ok = LoadLibretroGame(gameFile);
         if (!ok) LibretroPhysFSClearMount();

--- a/include/raylib-libretro-physfs.h
+++ b/include/raylib-libretro-physfs.h
@@ -260,17 +260,35 @@ static bool LoadLibretroGameFromPhysFS(const char* gameFile) {
     // picked ROM (e.g. fceumm declares need_fullpath=false for .nes).
     bool persistent = false;
     if (GetLibretroNeedFullpath(virtualPath, &persistent)) {
-        // Fullpath cores that don't honor the libretro VFS would fopen()
-        // /game/* and fail. Hand them the original OS path; archives are
-        // rejected (unless block_extract pushed them through the regular
-        // file path above).
         if (treatAsArchive) {
-            // Hand the core the PhysFS virtual path. The VFS hooks
-            // installed by InitLibretroPhysFS() let the core read
-            // /game/* transparently from the mounted archive.
-            bool ok = LoadLibretroGame(virtualPath);
-            if (!ok) LibretroPhysFSClearMount();
-            return ok;
+            // Hand the core the PhysFS virtual path directly via
+            // retro_load_game. The VFS hooks installed by
+            // InitLibretroPhysFS() let the core read /game/*
+            // transparently from the mounted archive. We bypass
+            // LoadLibretroGame() because its FileExists() check
+            // only sees the real filesystem.
+            if (IsLibretroGameReady()) UnloadLibretroGame();
+            struct retro_game_info info;
+            info.data = NULL;
+            info.size = 0;
+            info.path = virtualPath;
+            info.meta = "";
+            TextCopy(LIBRETRO.core.contentPath, virtualPath);
+            SetLibretroGameInfoExt(NULL, 0);
+            if (!LIBRETRO.core.symbols.retro_load_game(&info)) {
+                TraceLog(LOG_ERROR, "LIBRETRO: Failed to load from archive: %s", virtualPath);
+                LIBRETRO.core.loaded = false;
+                LIBRETRO.core.contentPath[0] = '\0';
+                LIBRETRO.core.gameInfoExtValid = false;
+                LibretroPhysFSClearMount();
+                return false;
+            }
+            LIBRETRO.core.loaded = InitLibretroAudioVideo();
+            if (!LIBRETRO.core.loaded) {
+                LibretroPhysFSClearMount();
+                return false;
+            }
+            return true;
         }
         bool ok = LoadLibretroGame(gameFile);
         if (!ok) LibretroPhysFSClearMount();

--- a/include/raylib-libretro-vfs.h
+++ b/include/raylib-libretro-vfs.h
@@ -73,15 +73,44 @@ static int raylib_libretro_vfs_closedir(struct retro_vfs_dir_handle* dirstream);
 extern "C" {
 #endif
 
-// Optional hooks for an alternate read-only filesystem (e.g. PhysFS).
-// When non-NULL, VFS read operations try these before the real filesystem.
-// Signature matches the corresponding raylib / libretro-VFS contracts:
-//   load: returns malloc'd buffer + size, or NULL if not found
-//   stat: returns RETRO_VFS_STAT flags (0 = not found), optionally sets *size
-//   list: returns a FilePathList (may be empty)
-static unsigned char* (*raylib_libretro_vfs_alt_load_file_data)(const char*, int*) = NULL;
-static int (*raylib_libretro_vfs_alt_stat)(const char*, int32_t*) = NULL;
-static FilePathList (*raylib_libretro_vfs_alt_load_dir_files)(const char*) = NULL;
+/**
+ * Optional hook to read a file from an alternate read-only filesystem (e.g. PhysFS).
+ *
+ * When non-NULL, VFS read operations try this before the real filesystem. The
+ * signature matches raylib's \c LoadFileData contract.
+ *
+ * @param fileName The path to load.
+ * @param dataSize Out parameter set to the number of bytes read.
+ * @return A \c MemAlloc'd buffer holding the file contents, or \c NULL if the
+ * file was not found in the alternate filesystem.
+ * @see raylib_libretro_vfs_alt_stat
+ * @see raylib_libretro_vfs_alt_load_dir_files
+ */
+static unsigned char* (*raylib_libretro_vfs_alt_load_file_data)(const char* fileName, int* dataSize) = NULL;
+
+/**
+ * Optional hook to stat a path on an alternate read-only filesystem (e.g. PhysFS).
+ *
+ * When non-NULL, VFS stat operations try this before the real filesystem.
+ *
+ * @param path The path to stat.
+ * @param size Optional out parameter set to the file size in bytes when non-NULL.
+ * @return A bitmask of \c RETRO_VFS_STAT_* flags, or 0 if the path was not found
+ * in the alternate filesystem.
+ * @see raylib_libretro_vfs_alt_load_file_data
+ */
+static int (*raylib_libretro_vfs_alt_stat)(const char* path, int32_t* size) = NULL;
+
+/**
+ * Optional hook to list a directory on an alternate read-only filesystem (e.g. PhysFS).
+ *
+ * When non-NULL, VFS directory listings try this before the real filesystem.
+ *
+ * @param dirPath The directory to enumerate.
+ * @return A \c FilePathList of the directory's entries, which may be empty.
+ * @see raylib_libretro_vfs_alt_load_file_data
+ */
+static FilePathList (*raylib_libretro_vfs_alt_load_dir_files)(const char* dirPath) = NULL;
 
 /**
  * Gets the path associated with the given file handle.

--- a/include/raylib-libretro-vfs.h
+++ b/include/raylib-libretro-vfs.h
@@ -73,6 +73,16 @@ static int raylib_libretro_vfs_closedir(struct retro_vfs_dir_handle* dirstream);
 extern "C" {
 #endif
 
+// Optional hooks for an alternate read-only filesystem (e.g. PhysFS).
+// When non-NULL, VFS read operations try these before the real filesystem.
+// Signature matches the corresponding raylib / libretro-VFS contracts:
+//   load: returns malloc'd buffer + size, or NULL if not found
+//   stat: returns RETRO_VFS_STAT flags (0 = not found), optionally sets *size
+//   list: returns a FilePathList (may be empty)
+static unsigned char* (*raylib_libretro_vfs_alt_load_file_data)(const char*, int*) = NULL;
+static int (*raylib_libretro_vfs_alt_stat)(const char*, int32_t*) = NULL;
+static FilePathList (*raylib_libretro_vfs_alt_load_dir_files)(const char*) = NULL;
+
 /**
  * Gets the path associated with the given file handle.
  *
@@ -123,7 +133,12 @@ static struct retro_vfs_file_handle* raylib_libretro_vfs_open(const char* path, 
     handle->data = NULL;
 
     if (mode & RETRO_VFS_FILE_ACCESS_READ) {
-        handle->data = LoadFileData(path, &handle->dataSize);
+        if (raylib_libretro_vfs_alt_load_file_data != NULL) {
+            handle->data = raylib_libretro_vfs_alt_load_file_data(path, &handle->dataSize);
+        }
+        if (handle->data == NULL) {
+            handle->data = LoadFileData(path, &handle->dataSize);
+        }
         if (handle->data == NULL) {
             MemFree(handle);
             TraceLog(LOG_ERROR, "LIBRETRO: File not found: %s", path);
@@ -418,6 +433,11 @@ static int raylib_libretro_vfs_rename(const char* old_path, const char* new_path
  * @since VFS API v3
  */
 static int raylib_libretro_vfs_stat(const char* path, int32_t *size) {
+    if (raylib_libretro_vfs_alt_stat != NULL) {
+        int result = raylib_libretro_vfs_alt_stat(path, size);
+        if (result != 0) return result;
+    }
+
     // DirectoryExists must be checked first, because FileExists uses
     // access() which returns true for directories.
     if (DirectoryExists(path)) {
@@ -503,7 +523,12 @@ static struct retro_vfs_dir_handle* raylib_libretro_vfs_opendir(const char* dir,
         return NULL;
     }
 
-    if (!DirectoryExists(dir)) {
+    bool dirFound = false;
+    if (raylib_libretro_vfs_alt_stat != NULL) {
+        int result = raylib_libretro_vfs_alt_stat(dir, NULL);
+        if (result & RETRO_VFS_STAT_IS_DIRECTORY) dirFound = true;
+    }
+    if (!dirFound && !DirectoryExists(dir)) {
         return NULL;
     }
 
@@ -515,7 +540,13 @@ static struct retro_vfs_dir_handle* raylib_libretro_vfs_opendir(const char* dir,
     TextCopy(handle->path, dir);
     handle->include_hidden = include_hidden;
 
-    handle->directoryFiles = LoadDirectoryFiles(handle->path);
+    handle->directoryFiles.count = 0;
+    if (raylib_libretro_vfs_alt_load_dir_files != NULL) {
+        handle->directoryFiles = raylib_libretro_vfs_alt_load_dir_files(handle->path);
+    }
+    if (handle->directoryFiles.count == 0) {
+        handle->directoryFiles = LoadDirectoryFiles(handle->path);
+    }
     handle->directoryFilesIndex = -1;
 
     return handle;
@@ -608,7 +639,12 @@ static bool raylib_libretro_vfs_dirent_is_dir(struct retro_vfs_dir_handle* dirst
         return false;
     }
 
-    return DirectoryExists(dirstream->directoryFiles.paths[dirstream->directoryFilesIndex]);
+    const char* entryPath = dirstream->directoryFiles.paths[dirstream->directoryFilesIndex];
+    if (raylib_libretro_vfs_alt_stat != NULL) {
+        int result = raylib_libretro_vfs_alt_stat(entryPath, NULL);
+        if (result & RETRO_VFS_STAT_IS_DIRECTORY) return true;
+    }
+    return DirectoryExists(entryPath);
 }
 
 /**

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -2774,7 +2774,11 @@ static bool LoadLibretroGame(const char* gameFile) {
         return false;
     }
 
-    if (!FileExists(gameFile)) {
+    bool fileFound = FileExists(gameFile);
+    if (!fileFound && raylib_libretro_vfs_alt_stat != NULL) {
+        fileFound = (raylib_libretro_vfs_alt_stat(gameFile, NULL) & RETRO_VFS_STAT_IS_VALID) != 0;
+    }
+    if (!fileFound) {
         TraceLog(LOG_ERROR, "LIBRETRO: Given content does not exist: %s", gameFile);
         LIBRETRO.core.loaded = false;
         return false;


### PR DESCRIPTION
Serve archived disc content through the libretro VFS instead of rejecting need_fullpath zips. Fixes #304