### PR TITLE
Add PCSX-ReARMed PlayStation core

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 ## Features
 
-- Multi-System Emulator for NES, SNES, GB, GBA, SMS/GG
-- Shipped Cores: fceumm, snes9x, mgba, genesis_plus_gx, prboom
+- Multi-System Emulator for NES, SNES, GB, GBA, SMS/GG, PlayStation
+- Shipped Cores: fceumm, snes9x, mgba, genesis_plus_gx, prboom, swanstation
 - Gamepad, Keyboard, On-Screen Controls
 - Audio
 - Fast Forward, Slow Motion, Rewind
@@ -28,6 +28,7 @@
 | PC Engine / TurboGrafx-16 | `mednafen_pce_fast` | `.pce`, `.cue`, `.ccd`, `.chd`, `.toc`, `.m3u` |
 | WonderSwan / WonderSwan Color | `mednafen_wswan` | `.ws`, `.wsc`, `.pc2` |
 | Doom (PrBoom Engine) | `prboom` | `.wad`, `.iwad`, `.pwad`, `.lmp`, `.m3u` |
+| PlayStation | `swanstation` | `.cue`, `.bin`, `.img`, `.iso`, `.chd`, `.pbp`, `.m3u` |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Features
 
 - Multi-System Emulator for NES, SNES, GB, GBA, SMS/GG, PlayStation
-- Shipped Cores: fceumm, snes9x, mgba, genesis_plus_gx, prboom, swanstation
+- Shipped Cores: fceumm, snes9x, mgba, genesis_plus_gx, prboom, pcsx_rearmed
 - Gamepad, Keyboard, On-Screen Controls
 - Audio
 - Fast Forward, Slow Motion, Rewind
@@ -28,7 +28,7 @@
 | PC Engine / TurboGrafx-16 | `mednafen_pce_fast` | `.pce`, `.cue`, `.ccd`, `.chd`, `.toc`, `.m3u` |
 | WonderSwan / WonderSwan Color | `mednafen_wswan` | `.ws`, `.wsc`, `.pc2` |
 | Doom (PrBoom Engine) | `prboom` | `.wad`, `.iwad`, `.pwad`, `.lmp`, `.m3u` |
-| PlayStation | `swanstation` | `.cue`, `.bin`, `.img`, `.iso`, `.chd`, `.pbp`, `.m3u` |
+| PlayStation | `pcsx_rearmed` | `.bin`, `.cue`, `.img`, `.mdf`, `.pbp`, `.toc`, `.cbn`, `.m3u`, `.ccd`, `.chd`, `.iso` |
 
 ## Usage
 

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -107,6 +107,7 @@ set(CORE_INFO_NAMES
     prboom_libretro
     mednafen_pce_fast_libretro
     mednafen_wswan_libretro
+    swanstation_libretro
 )
 
 if ("${PLATFORM}" STREQUAL "Web")
@@ -256,6 +257,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
             "https://buildbot.libretro.com/nightly/linux/aarch64/latest/prboom_libretro.so.zip"
             "https://buildbot.libretro.com/nightly/linux/aarch64/latest/mednafen_pce_fast_libretro.so.zip"
             "https://buildbot.libretro.com/nightly/linux/aarch64/latest/mednafen_wswan_libretro.so.zip"
+            "https://buildbot.libretro.com/nightly/linux/aarch64/latest/swanstation_libretro.so.zip"
         )
     elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
         download_cores(
@@ -266,6 +268,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
             "https://buildbot.libretro.com/nightly/linux/x86_64/latest/prboom_libretro.so.zip"
             "https://buildbot.libretro.com/nightly/linux/x86_64/latest/mednafen_pce_fast_libretro.so.zip"
             "https://buildbot.libretro.com/nightly/linux/x86_64/latest/mednafen_wswan_libretro.so.zip"
+            "https://buildbot.libretro.com/nightly/linux/x86_64/latest/swanstation_libretro.so.zip"
         )
     endif()
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
@@ -278,6 +281,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
             "https://buildbot.libretro.com/nightly/windows/x86_64/latest/prboom_libretro.dll.zip"
             "https://buildbot.libretro.com/nightly/windows/x86_64/latest/mednafen_pce_fast_libretro.dll.zip"
             "https://buildbot.libretro.com/nightly/windows/x86_64/latest/mednafen_wswan_libretro.dll.zip"
+            "https://buildbot.libretro.com/nightly/windows/x86_64/latest/swanstation_libretro.dll.zip"
         )
     endif()
 elseif (APPLE)
@@ -295,6 +299,7 @@ elseif (APPLE)
             "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/prboom_libretro.dylib.zip"
             "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/mednafen_pce_fast_libretro.dylib.zip"
             "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/mednafen_wswan_libretro.dylib.zip"
+            "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/swanstation_libretro.dylib.zip"
         )
     else()
         download_cores(
@@ -305,6 +310,7 @@ elseif (APPLE)
             "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/prboom_libretro.dylib.zip"
             "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/mednafen_pce_fast_libretro.dylib.zip"
             "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/mednafen_wswan_libretro.dylib.zip"
+            "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/swanstation_libretro.dylib.zip"
         )
     endif()
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Android")
@@ -316,6 +322,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Android")
         "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/prboom_libretro_android.so.zip"
         "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/mednafen_pce_fast_libretro_android.so.zip"
         "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/mednafen_wswan_libretro_android.so.zip"
+        "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/swanstation_libretro_android.so.zip"
     )
 endif()
 

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -79,35 +79,51 @@ function(download_cores)
     endforeach()
 endfunction()
 
-# copy_core_info(<name> [<name> ...])
-# Copies each core's .info metadata file from the libretro-core-info submodule.
+# download_nightly_cores(<base_url> <ext>)
+# Downloads the canonical core set (CORES) from a libretro nightly buildbot
+# directory. <base_url> is the directory holding the archives; <ext> is the
+# library extension as it appears before .zip (.so, .dll, .dylib, _android.so).
+# Builds "<base_url>/<core>_libretro<ext>.zip" for each core.
+function(download_nightly_cores BASE_URL EXT)
+    set(URLS "")
+    foreach(CORE IN LISTS CORES)
+        list(APPEND URLS "${BASE_URL}/${CORE}_libretro${EXT}.zip")
+    endforeach()
+    download_cores(${URLS})
+endfunction()
+
+# copy_core_info(<core> [<core> ...])
+# Copies each core's <core>_libretro.info metadata from the libretro-core-info
+# submodule into CORES_DIR.
 set(CORE_INFO_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../vendor/libretro-core-info")
 function(copy_core_info)
     file(MAKE_DIRECTORY "${CORES_DIR}")
-    foreach(CORE_NAME IN LISTS ARGN)
-        set(INFO_SRC "${CORE_INFO_DIR}/${CORE_NAME}.info")
-        set(INFO_DST "${CORES_DIR}/${CORE_NAME}.info")
+    foreach(CORE IN LISTS ARGN)
+        set(INFO_SRC "${CORE_INFO_DIR}/${CORE}_libretro.info")
+        set(INFO_DST "${CORES_DIR}/${CORE}_libretro.info")
         if (EXISTS "${INFO_SRC}")
             file(COPY_FILE "${INFO_SRC}" "${INFO_DST}" ONLY_IF_DIFFERENT)
         else()
             # A missing .info means the core ships but silently never appears in
             # the menu (ScanLibretroCoreDirectory is .info-driven). Fail loudly
             # for bundled cores rather than discovering it at runtime.
-            message(FATAL_ERROR "${CORE_NAME}.info not found in ${CORE_INFO_DIR}. "
+            message(FATAL_ERROR "${CORE}_libretro.info not found in ${CORE_INFO_DIR}. "
                 "Run: git submodule update --init -- vendor/libretro-core-info")
         endif()
     endforeach()
 endfunction()
 
-set(CORE_INFO_NAMES
-    fceumm_libretro
-    snes9x_libretro
-    mgba_libretro
-    genesis_plus_gx_libretro
-    prboom_libretro
-    mednafen_pce_fast_libretro
-    mednafen_wswan_libretro
-    pcsx_rearmed_libretro
+# The cores bundled with every build, as their short names. Download URLs,
+# .info files and web side-module outputs are all derived as <core>_libretro*.
+set(CORES
+    fceumm
+    snes9x
+    mgba
+    genesis_plus_gx
+    prboom
+    mednafen_pce_fast
+    mednafen_wswan
+    pcsx_rearmed
 )
 
 if ("${PLATFORM}" STREQUAL "Web")
@@ -265,40 +281,13 @@ if ("${PLATFORM}" STREQUAL "Web")
     )
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     if (CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
-        download_cores(
-            "https://buildbot.libretro.com/nightly/linux/aarch64/latest/fceumm_libretro.so.zip"
-            "https://buildbot.libretro.com/nightly/linux/aarch64/latest/snes9x_libretro.so.zip"
-            "https://buildbot.libretro.com/nightly/linux/aarch64/latest/mgba_libretro.so.zip"
-            "https://buildbot.libretro.com/nightly/linux/aarch64/latest/genesis_plus_gx_libretro.so.zip"
-            "https://buildbot.libretro.com/nightly/linux/aarch64/latest/prboom_libretro.so.zip"
-            "https://buildbot.libretro.com/nightly/linux/aarch64/latest/mednafen_pce_fast_libretro.so.zip"
-            "https://buildbot.libretro.com/nightly/linux/aarch64/latest/mednafen_wswan_libretro.so.zip"
-            "https://buildbot.libretro.com/nightly/linux/aarch64/latest/pcsx_rearmed_libretro.so.zip"
-        )
+        download_nightly_cores("https://buildbot.libretro.com/nightly/linux/aarch64/latest" ".so")
     elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-        download_cores(
-            "https://buildbot.libretro.com/nightly/linux/x86_64/latest/fceumm_libretro.so.zip"
-            "https://buildbot.libretro.com/nightly/linux/x86_64/latest/snes9x_libretro.so.zip"
-            "https://buildbot.libretro.com/nightly/linux/x86_64/latest/mgba_libretro.so.zip"
-            "https://buildbot.libretro.com/nightly/linux/x86_64/latest/genesis_plus_gx_libretro.so.zip"
-            "https://buildbot.libretro.com/nightly/linux/x86_64/latest/prboom_libretro.so.zip"
-            "https://buildbot.libretro.com/nightly/linux/x86_64/latest/mednafen_pce_fast_libretro.so.zip"
-            "https://buildbot.libretro.com/nightly/linux/x86_64/latest/mednafen_wswan_libretro.so.zip"
-            "https://buildbot.libretro.com/nightly/linux/x86_64/latest/pcsx_rearmed_libretro.so.zip"
-        )
+        download_nightly_cores("https://buildbot.libretro.com/nightly/linux/x86_64/latest" ".so")
     endif()
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     if (CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-        download_cores(
-            "https://buildbot.libretro.com/nightly/windows/x86_64/latest/fceumm_libretro.dll.zip"
-            "https://buildbot.libretro.com/nightly/windows/x86_64/latest/snes9x_libretro.dll.zip"
-            "https://buildbot.libretro.com/nightly/windows/x86_64/latest/mgba_libretro.dll.zip"
-            "https://buildbot.libretro.com/nightly/windows/x86_64/latest/genesis_plus_gx_libretro.dll.zip"
-            "https://buildbot.libretro.com/nightly/windows/x86_64/latest/prboom_libretro.dll.zip"
-            "https://buildbot.libretro.com/nightly/windows/x86_64/latest/mednafen_pce_fast_libretro.dll.zip"
-            "https://buildbot.libretro.com/nightly/windows/x86_64/latest/mednafen_wswan_libretro.dll.zip"
-            "https://buildbot.libretro.com/nightly/windows/x86_64/latest/pcsx_rearmed_libretro.dll.zip"
-        )
+        download_nightly_cores("https://buildbot.libretro.com/nightly/windows/x86_64/latest" ".dll")
     endif()
 elseif (APPLE)
     target_link_libraries(raylib-libretro PUBLIC
@@ -307,42 +296,15 @@ elseif (APPLE)
         "-framework OpenGL"
     )
     if (CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-        download_cores(
-            "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/fceumm_libretro.dylib.zip"
-            "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/snes9x_libretro.dylib.zip"
-            "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/mgba_libretro.dylib.zip"
-            "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/genesis_plus_gx_libretro.dylib.zip"
-            "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/prboom_libretro.dylib.zip"
-            "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/mednafen_pce_fast_libretro.dylib.zip"
-            "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/mednafen_wswan_libretro.dylib.zip"
-            "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/pcsx_rearmed_libretro.dylib.zip"
-        )
+        download_nightly_cores("https://buildbot.libretro.com/nightly/apple/osx/arm64/latest" ".dylib")
     else()
-        download_cores(
-            "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/fceumm_libretro.dylib.zip"
-            "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/snes9x_libretro.dylib.zip"
-            "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/mgba_libretro.dylib.zip"
-            "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/genesis_plus_gx_libretro.dylib.zip"
-            "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/prboom_libretro.dylib.zip"
-            "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/mednafen_pce_fast_libretro.dylib.zip"
-            "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/mednafen_wswan_libretro.dylib.zip"
-            "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/pcsx_rearmed_libretro.dylib.zip"
-        )
+        download_nightly_cores("https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest" ".dylib")
     endif()
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Android")
-    download_cores(
-        "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/fceumm_libretro_android.so.zip"
-        "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/snes9x_libretro_android.so.zip"
-        "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/mgba_libretro_android.so.zip"
-        "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/genesis_plus_gx_libretro_android.so.zip"
-        "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/prboom_libretro_android.so.zip"
-        "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/mednafen_pce_fast_libretro_android.so.zip"
-        "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/mednafen_wswan_libretro_android.so.zip"
-        "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/pcsx_rearmed_libretro_android.so.zip"
-    )
+    download_nightly_cores("https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}" "_android.so")
 endif()
 
-copy_core_info(${CORE_INFO_NAMES})
+copy_core_info(${CORES})
 
 install(TARGETS raylib-libretro DESTINATION .)
 install(FILES ../README.md DESTINATION .)

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -148,9 +148,15 @@ if ("${PLATFORM}" STREQUAL "Web")
     #   REPO       git URL
     #   MAKEFILE   Makefile filename (e.g. Makefile or Makefile.libretro)
     #   SUBDIR     subdirectory of source to run make in (pass "" for root)
-    #   ARGN...    extra arguments appended to the make command line
+    #   ARGN...    extra flags injected via EMCC_CFLAGS for the make step, so
+    #              every emcc compile/link picks them up regardless of the core's
+    #              Makefile (e.g. -sUSE_ZLIB=1 to give a core zlib's headers/port).
+    #              Pair with a matching flag on the main module's link options so
+    #              the symbols exist there.
     function(build_libretro_side_module CORE_NAME REPO MAKEFILE SUBDIR)
-        set(EXTRA_MAKE_ARGS "${ARGN}")
+        # ARGN carries optional flags for EMCC_CFLAGS (see header above).
+        set(EXTRA_EMCC_CFLAGS "${ARGN}")
+        string(REPLACE ";" " " EXTRA_EMCC_CFLAGS "${EXTRA_EMCC_CFLAGS}")
         set(SRC_DIR "${CMAKE_BINARY_DIR}/cores-src/${CORE_NAME}")
         if (SUBDIR)
             set(BUILD_DIR "${SRC_DIR}/${SUBDIR}")
@@ -204,10 +210,18 @@ if ("${PLATFORM}" STREQUAL "Web")
             endif()
         endif()
 
+        # emcc reads EMCC_CFLAGS and appends it to every compile/link it runs,
+        # so this reaches the core's sources without the Makefile cooperating.
+        if (EXTRA_EMCC_CFLAGS)
+            set(MAKE_ENV ${CMAKE_COMMAND} -E env "EMCC_CFLAGS=${EXTRA_EMCC_CFLAGS}")
+        else()
+            set(MAKE_ENV "")
+        endif()
+
         add_custom_command(
             OUTPUT "${SO_FILE}"
-            COMMAND "${EMMAKE_EXECUTABLE}" make -f "${MAKEFILE}"
-                    platform=emscripten fpic=-fPIC ${EXTRA_MAKE_ARGS} -j
+            COMMAND ${MAKE_ENV} "${EMMAKE_EXECUTABLE}" make -f "${MAKEFILE}"
+                    platform=emscripten fpic=-fPIC -j
             COMMAND ${CMAKE_COMMAND} -E copy "${BC_FILE}" "${A_FILE}"
             COMMAND "${EMCC_EXECUTABLE}" -O2 -sSIDE_MODULE=2
                     "-sEXPORTED_FUNCTIONS=${LIBRETRO_EXPORTS_CSV}"
@@ -229,7 +243,7 @@ if ("${PLATFORM}" STREQUAL "Web")
     build_libretro_side_module(prboom        "https://github.com/libretro/libretro-prboom"       "Makefile"          "")
     build_libretro_side_module(mednafen_pce_fast "https://github.com/libretro/beetle-pce-fast-libretro" "Makefile"     "")
     build_libretro_side_module(mednafen_wswan "https://github.com/libretro/beetle-wswan-libretro" "Makefile"          "")
-    build_libretro_side_module(pcsx_rearmed  "https://github.com/libretro/pcsx_rearmed"           "Makefile.libretro" "")
+    build_libretro_side_module(pcsx_rearmed  "https://github.com/libretro/pcsx_rearmed"           "Makefile.libretro" "" "-sUSE_ZLIB=1")
 
     if (LIBRETRO_SIDE_MODULES)
         add_custom_target(libretro-side-modules ALL DEPENDS ${LIBRETRO_SIDE_MODULES})
@@ -242,6 +256,7 @@ if ("${PLATFORM}" STREQUAL "Web")
     target_link_options(raylib-libretro PUBLIC
         -sUSE_GLFW=3
         -sMAIN_MODULE=1
+        -sUSE_ZLIB=1 # pcsx_rearmed's side module imports zlib symbols at dlopen; provide the port here
         -sALLOW_MEMORY_GROWTH=1
         -sEXPORTED_RUNTIME_METHODS=ccall # shell.html ccalls LoadLibretroGameFromJS / ResizeCanvasFromJS
         -lidbfs.js # Emscripten's File System API

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -107,7 +107,7 @@ set(CORE_INFO_NAMES
     prboom_libretro
     mednafen_pce_fast_libretro
     mednafen_wswan_libretro
-    swanstation_libretro
+    pcsx_rearmed_libretro
 )
 
 if ("${PLATFORM}" STREQUAL "Web")
@@ -229,6 +229,7 @@ if ("${PLATFORM}" STREQUAL "Web")
     build_libretro_side_module(prboom        "https://github.com/libretro/libretro-prboom"       "Makefile"          "")
     build_libretro_side_module(mednafen_pce_fast "https://github.com/libretro/beetle-pce-fast-libretro" "Makefile"     "")
     build_libretro_side_module(mednafen_wswan "https://github.com/libretro/beetle-wswan-libretro" "Makefile"          "")
+    build_libretro_side_module(pcsx_rearmed  "https://github.com/libretro/pcsx_rearmed"           "Makefile.libretro" "")
 
     if (LIBRETRO_SIDE_MODULES)
         add_custom_target(libretro-side-modules ALL DEPENDS ${LIBRETRO_SIDE_MODULES})
@@ -257,7 +258,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
             "https://buildbot.libretro.com/nightly/linux/aarch64/latest/prboom_libretro.so.zip"
             "https://buildbot.libretro.com/nightly/linux/aarch64/latest/mednafen_pce_fast_libretro.so.zip"
             "https://buildbot.libretro.com/nightly/linux/aarch64/latest/mednafen_wswan_libretro.so.zip"
-            "https://buildbot.libretro.com/nightly/linux/aarch64/latest/swanstation_libretro.so.zip"
+            "https://buildbot.libretro.com/nightly/linux/aarch64/latest/pcsx_rearmed_libretro.so.zip"
         )
     elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
         download_cores(
@@ -268,7 +269,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
             "https://buildbot.libretro.com/nightly/linux/x86_64/latest/prboom_libretro.so.zip"
             "https://buildbot.libretro.com/nightly/linux/x86_64/latest/mednafen_pce_fast_libretro.so.zip"
             "https://buildbot.libretro.com/nightly/linux/x86_64/latest/mednafen_wswan_libretro.so.zip"
-            "https://buildbot.libretro.com/nightly/linux/x86_64/latest/swanstation_libretro.so.zip"
+            "https://buildbot.libretro.com/nightly/linux/x86_64/latest/pcsx_rearmed_libretro.so.zip"
         )
     endif()
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
@@ -281,7 +282,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
             "https://buildbot.libretro.com/nightly/windows/x86_64/latest/prboom_libretro.dll.zip"
             "https://buildbot.libretro.com/nightly/windows/x86_64/latest/mednafen_pce_fast_libretro.dll.zip"
             "https://buildbot.libretro.com/nightly/windows/x86_64/latest/mednafen_wswan_libretro.dll.zip"
-            "https://buildbot.libretro.com/nightly/windows/x86_64/latest/swanstation_libretro.dll.zip"
+            "https://buildbot.libretro.com/nightly/windows/x86_64/latest/pcsx_rearmed_libretro.dll.zip"
         )
     endif()
 elseif (APPLE)
@@ -299,7 +300,7 @@ elseif (APPLE)
             "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/prboom_libretro.dylib.zip"
             "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/mednafen_pce_fast_libretro.dylib.zip"
             "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/mednafen_wswan_libretro.dylib.zip"
-            "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/swanstation_libretro.dylib.zip"
+            "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/pcsx_rearmed_libretro.dylib.zip"
         )
     else()
         download_cores(
@@ -310,7 +311,7 @@ elseif (APPLE)
             "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/prboom_libretro.dylib.zip"
             "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/mednafen_pce_fast_libretro.dylib.zip"
             "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/mednafen_wswan_libretro.dylib.zip"
-            "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/swanstation_libretro.dylib.zip"
+            "https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/pcsx_rearmed_libretro.dylib.zip"
         )
     endif()
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Android")
@@ -322,7 +323,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Android")
         "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/prboom_libretro_android.so.zip"
         "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/mednafen_pce_fast_libretro_android.so.zip"
         "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/mednafen_wswan_libretro_android.so.zip"
-        "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/swanstation_libretro_android.so.zip"
+        "https://buildbot.libretro.com/nightly/android/latest/${CMAKE_ANDROID_ARCH_ABI}/pcsx_rearmed_libretro_android.so.zip"
     )
 endif()
 

--- a/bin/shell.html
+++ b/bin/shell.html
@@ -6,7 +6,7 @@
     <meta name="description" content="A libretro frontend built with raylib — play retro games in your browser.">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover">
     <!-- Render UA surfaces (scrollbars, the pre-paint frame) dark to match the
-         #11111b backdrop and avoid a white flash on first navigation. -->
+         backdrop and avoid a white flash on first navigation. -->
     <meta name="color-scheme" content="dark">
 
     <!-- Progressive Web App: installable + standalone "Add to Home Screen".


### PR DESCRIPTION
Adds the PCSX-ReARMed core to the build process for all platforms including Emscripten/web, and updates README. Fixes #306