### PR TITLE
feat: per-port rebindable gamepad button mapping

### DIFF
--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -89,6 +89,7 @@ typedef struct LibretroMenu {
     int portDeviceIndex[16];              // per-port combobox selection index
     char portDeviceOptions[16][512];      // per-port pipe-separated device list (must outlive the combobox)
     char portDeviceLabel[16][16];         // per-port "Port N" label (must outlive the combobox)
+    char gamepadRebindPortLabel[16][16];  // per-port "Port N" label for the Gamepad Controls submenu
     nk_console* loadGameWidget;
     nk_console* saveStateButton;
     nk_console* loadStateButton;
@@ -1632,6 +1633,56 @@ LibretroMenu* InitLibretroMenu(void) {
             LibretroMenuKeyConsole(kbMenu, "R3",     RETRO_DEVICE_ID_JOYPAD_R3);
         }
 
+        // Gamepad Controls — per-port remap of libretro buttons to physical raylib gamepad buttons.
+        // Combobox indices align with the raylib GamepadButton enum so they can be written straight
+        // into LIBRETRO.gamepadButtonMap[port][btn]; index 0 (GAMEPAD_BUTTON_UNKNOWN) means "use default".
+        {
+            static const char* gamepadButtonNames =
+                "(Default)|D-Pad Up|D-Pad Right|D-Pad Down|D-Pad Left|"
+                "Face Up (Y/Triangle)|Face Right (B/Circle)|Face Down (A/Cross)|Face Left (X/Square)|"
+                "L1|L2|R1|R2|Select|Home|Start|L3|R3";
+
+            nk_console* gpMenu = nk_console_button(settings, "Gamepad Controls");
+            nk_console_button_set_symbol(gpMenu, NK_SYMBOL_TRIANGLE_RIGHT);
+            nk_console_add_event(gpMenu, NK_CONSOLE_EVENT_BACK, &MenuCommitSettings);
+            nk_console_button_set_symbol(
+                nk_console_button_onclick(gpMenu, "Gamepad Controls", &nk_console_button_back),
+                NK_SYMBOL_TRIANGLE_UP);
+
+            for (int port = 0; port < 4; port++) {
+                TextCopy(menu.gamepadRebindPortLabel[port], TextFormat("Port %d", port + 1));
+                nk_console* portMenu = nk_console_button(gpMenu, menu.gamepadRebindPortLabel[port]);
+                nk_console_button_set_symbol(portMenu, NK_SYMBOL_TRIANGLE_RIGHT);
+                nk_console_add_event(portMenu, NK_CONSOLE_EVENT_BACK, &MenuCommitSettings);
+                nk_console_button_set_symbol(
+                    nk_console_button_onclick(portMenu, menu.gamepadRebindPortLabel[port], &nk_console_button_back),
+                    NK_SYMBOL_TRIANGLE_UP);
+
+                static const struct { const char* label; int btn; } rows[] = {
+                    {"B",      RETRO_DEVICE_ID_JOYPAD_B},
+                    {"Y",      RETRO_DEVICE_ID_JOYPAD_Y},
+                    {"Select", RETRO_DEVICE_ID_JOYPAD_SELECT},
+                    {"Start",  RETRO_DEVICE_ID_JOYPAD_START},
+                    {"Up",     RETRO_DEVICE_ID_JOYPAD_UP},
+                    {"Down",   RETRO_DEVICE_ID_JOYPAD_DOWN},
+                    {"Left",   RETRO_DEVICE_ID_JOYPAD_LEFT},
+                    {"Right",  RETRO_DEVICE_ID_JOYPAD_RIGHT},
+                    {"A",      RETRO_DEVICE_ID_JOYPAD_A},
+                    {"X",      RETRO_DEVICE_ID_JOYPAD_X},
+                    {"L",      RETRO_DEVICE_ID_JOYPAD_L},
+                    {"R",      RETRO_DEVICE_ID_JOYPAD_R},
+                    {"L2",     RETRO_DEVICE_ID_JOYPAD_L2},
+                    {"R2",     RETRO_DEVICE_ID_JOYPAD_R2},
+                    {"L3",     RETRO_DEVICE_ID_JOYPAD_L3},
+                    {"R3",     RETRO_DEVICE_ID_JOYPAD_R3},
+                };
+                for (size_t r = 0; r < sizeof(rows)/sizeof(rows[0]); r++) {
+                    nk_console_combobox(portMenu, rows[r].label, gamepadButtonNames, '|',
+                        &LIBRETRO.gamepadButtonMap[port][rows[r].btn]);
+                }
+            }
+        }
+
         // Directories
         {
             nk_console* dirMenu = nk_console_button(settings, "Directories");
@@ -2207,6 +2258,15 @@ static void LibretroMenuUpdateConfig(void) {
     for (int i = 0; i <= RETRO_DEVICE_ID_JOYPAD_R3; i++) {
         rlconfig_set_int(menu.cfg, "raylib-libretro", TextFormat("keyboard%d", i), LIBRETRO.keyboardPlayer1[i]);
     }
+
+    // Per-port gamepad button remap ([inputPort0], [inputPort1], …). Each key is the libretro
+    // button index; the value is a raylib GamepadButton, or 0 to fall back to the default.
+    for (int port = 0; port < 16; port++) {
+        const char* section = TextFormat("inputPort%d", port);
+        for (int i = 0; i <= RETRO_DEVICE_ID_JOYPAD_R3; i++) {
+            rlconfig_set_int(menu.cfg, section, TextFormat("button%d", i), LIBRETRO.gamepadButtonMap[port][i]);
+        }
+    }
 }
 
 static bool SaveLibretroMenuSettings(void) {
@@ -2435,6 +2495,14 @@ static bool LoadLibretroMenuSettings(void) {
     // Keyboard Controls
     for (int i = 0; i <= RETRO_DEVICE_ID_JOYPAD_R3; i++) {
         LIBRETRO.keyboardPlayer1[i] = rlconfig_get_int(menu.cfg, "raylib-libretro", TextFormat("keyboard%d", i), LIBRETRO.keyboardPlayer1[i]);
+    }
+
+    // Per-port gamepad button remap
+    for (int port = 0; port < 16; port++) {
+        const char* section = TextFormat("inputPort%d", port);
+        for (int i = 0; i <= RETRO_DEVICE_ID_JOYPAD_R3; i++) {
+            LIBRETRO.gamepadButtonMap[port][i] = rlconfig_get_int(menu.cfg, section, TextFormat("button%d", i), LIBRETRO.gamepadButtonMap[port][i]);
+        }
     }
 
     TraceLog(LOG_INFO, "MENU: Loaded menu settings from %s", RAYLIB_LIBRETRO_CFG_FILE);

--- a/include/raylib-libretro-touch.h
+++ b/include/raylib-libretro-touch.h
@@ -184,7 +184,7 @@ static bool LibretroTouchIsPhysicalButtonDown(int buttonId) {
     int key = LibretroTouchJoypadKeyboard(buttonId);
     if (key != KEY_NULL && IsKeyDown(key)) return true;
     if (IsGamepadAvailable(0)) {
-        int gbtn = LibretroRetroJoypadButtonToGamepadButton(buttonId);
+        int gbtn = LibretroGetGamepadButtonForPort(0, buttonId);
         if (gbtn != GAMEPAD_BUTTON_UNKNOWN && IsGamepadButtonDown(0, gbtn)) return true;
     }
     return false;

--- a/include/raylib-libretro.h
+++ b/include/raylib-libretro.h
@@ -131,6 +131,7 @@ static void LibretroMapPixelFormatARGB8888ToRGBA8888(void *output_, const void *
 
 static int LibretroRetroPixelFormatToPixelFormat(int pixelFormat);
 static int LibretroRetroJoypadButtonToGamepadButton(int button);
+static int LibretroGetGamepadButtonForPort(int port, int button);
 static int LibretroRetroJoypadButtontoRetroKey(int button);
 static bool LibretroAnalogToDpadPressed(int port, int btn);
 static int LibretroRetroKeyToKeyboardKey(int key);
@@ -394,6 +395,9 @@ typedef struct LibretroData {
     bool integerScaling;
     int analogToDpadIndex; // 0=None, 1=Left Analog, 2=Right Analog
     int keyboardPlayer1[RETRO_DEVICE_ID_JOYPAD_R3 + 1];
+    // Per-port libretro→raylib gamepad button remap. 0 (GAMEPAD_BUTTON_UNKNOWN)
+    // means "use the default identity mapping" — see LibretroGetGamepadButtonForPort().
+    int gamepadButtonMap[16][RETRO_DEVICE_ID_JOYPAD_R3 + 1];
     char coreDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char saveDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     char coreAssetsDirectory[RAYLIB_LIBRETRO_VFS_MAX_PATH];
@@ -2281,7 +2285,7 @@ static int16_t LibretroInputState(unsigned port, unsigned device, unsigned index
                         if (btn < 16 && LIBRETRO.core.virtualJoypadState[btn]) {
                             pressed = true;
                         } else if (gpAvail) {
-                            int gamepadButton = LibretroRetroJoypadButtonToGamepadButton(btn);
+                            int gamepadButton = LibretroGetGamepadButtonForPort(0, btn);
                             pressed = (gamepadButton != GAMEPAD_BUTTON_UNKNOWN && IsGamepadButtonDown(0, gamepadButton));
                         }
                         if (!pressed) {
@@ -2297,7 +2301,7 @@ static int16_t LibretroInputState(unsigned port, unsigned device, unsigned index
                             }
                         }
                     } else if (gpAvail) {
-                        pressed = IsGamepadButtonDown((int)physicalPad, LibretroRetroJoypadButtonToGamepadButton(btn));
+                        pressed = IsGamepadButtonDown((int)physicalPad, LibretroGetGamepadButtonForPort((int)physicalPad, btn));
                     }
                     if (!pressed) pressed = LibretroAnalogToDpadPressed((int)physicalPad, btn);
                     if (pressed) mask |= (1 << btn);
@@ -2311,7 +2315,7 @@ static int16_t LibretroInputState(unsigned port, unsigned device, unsigned index
                     return 1;
                 }
                 if (IsGamepadAvailable(0)) {
-                    int gamepadButton = LibretroRetroJoypadButtonToGamepadButton(id);
+                    int gamepadButton = LibretroGetGamepadButtonForPort(0, id);
                     if (gamepadButton != GAMEPAD_BUTTON_UNKNOWN && IsGamepadButtonDown(0, gamepadButton)) {
                         return 1;
                     }
@@ -2333,7 +2337,7 @@ static int16_t LibretroInputState(unsigned port, unsigned device, unsigned index
             if (!IsGamepadAvailable((int)physicalPad)) {
                 return LibretroAnalogToDpadPressed((int)physicalPad, id) ? 1 : 0;
             }
-            int gamepadButton = LibretroRetroJoypadButtonToGamepadButton(id);
+            int gamepadButton = LibretroGetGamepadButtonForPort((int)physicalPad, id);
             if (IsGamepadButtonDown((int)physicalPad, gamepadButton)) return 1;
             return LibretroAnalogToDpadPressed((int)physicalPad, id) ? 1 : 0;
         }
@@ -2425,7 +2429,7 @@ static int16_t LibretroInputState(unsigned port, unsigned device, unsigned index
                         float value = GetGamepadAxisMovement(port, GAMEPAD_AXIS_RIGHT_TRIGGER);
                         return (int16_t)((value + 1.0f) * 0.5f * 0x7fff);
                     }
-                    int gamepadButton = LibretroRetroJoypadButtonToGamepadButton(id);
+                    int gamepadButton = LibretroGetGamepadButtonForPort(port, id);
                     return IsGamepadButtonDown(port, gamepadButton) ? 0x7fff : 0;
                 }
             }
@@ -4305,6 +4309,59 @@ static int LibretroRetroJoypadButtonToGamepadButton(int button) {
     }
 
     return GAMEPAD_BUTTON_UNKNOWN;
+}
+
+/**
+ * Look up the raylib GamepadButton for a libretro joypad button, consulting
+ * any per-port remap configured via SetLibretroGamepadButtonMapping(). When
+ * the remap slot is 0 (GAMEPAD_BUTTON_UNKNOWN) the default identity mapping
+ * from LibretroRetroJoypadButtonToGamepadButton() is returned.
+ */
+static int LibretroGetGamepadButtonForPort(int port, int button) {
+    if (port >= 0 && port < 16 && button >= 0 && button <= RETRO_DEVICE_ID_JOYPAD_R3) {
+        int mapped = LIBRETRO.gamepadButtonMap[port][button];
+        if (mapped != GAMEPAD_BUTTON_UNKNOWN) {
+            return mapped;
+        }
+    }
+    return LibretroRetroJoypadButtonToGamepadButton(button);
+}
+
+/**
+ * Override the raylib GamepadButton that a libretro joypad button maps to for
+ * the given physical gamepad port. Pass GAMEPAD_BUTTON_UNKNOWN to clear the
+ * override and fall back to the default identity mapping.
+ * @param port Physical gamepad port (0-15).
+ * @param retroButton One of RETRO_DEVICE_ID_JOYPAD_* up to _R3.
+ * @param gamepadButton raylib GamepadButton, or GAMEPAD_BUTTON_UNKNOWN to clear.
+ * @return true on success, false if port or retroButton is out of range.
+ */
+static bool SetLibretroGamepadButtonMapping(int port, int retroButton, int gamepadButton) {
+    if (port < 0 || port >= 16) return false;
+    if (retroButton < 0 || retroButton > RETRO_DEVICE_ID_JOYPAD_R3) return false;
+    LIBRETRO.gamepadButtonMap[port][retroButton] = gamepadButton;
+    return true;
+}
+
+/**
+ * Get the configured per-port override for a libretro joypad button.
+ * Returns 0 (GAMEPAD_BUTTON_UNKNOWN) when no override is configured —
+ * call LibretroGetGamepadButtonForPort() for the effective mapping.
+ */
+static int GetLibretroGamepadButtonMapping(int port, int retroButton) {
+    if (port < 0 || port >= 16) return GAMEPAD_BUTTON_UNKNOWN;
+    if (retroButton < 0 || retroButton > RETRO_DEVICE_ID_JOYPAD_R3) return GAMEPAD_BUTTON_UNKNOWN;
+    return LIBRETRO.gamepadButtonMap[port][retroButton];
+}
+
+/**
+ * Clear every per-button override for a port, restoring the default mapping.
+ */
+static void ResetLibretroGamepadButtonMapping(int port) {
+    if (port < 0 || port >= 16) return;
+    for (int b = 0; b <= RETRO_DEVICE_ID_JOYPAD_R3; b++) {
+        LIBRETRO.gamepadButtonMap[port][b] = GAMEPAD_BUTTON_UNKNOWN;
+    }
 }
 
 static bool LibretroAnalogToDpadPressed(int port, int btn) {


### PR DESCRIPTION
Fixes #315

Adds a per-port libretro→raylib gamepad button remap table on `LibretroData`, threads the physical port through the existing input lookups, and exposes a Settings → Gamepad Controls submenu with one screen per port (P1–P4) that persists each binding under `[inputPortN]` in the config.