### PR TITLE
feat: Game Focus mode — pass all keys to core, suspend hotkeys

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -100,7 +100,7 @@ A roadmap of some interesting features to consider.
 - [x] Multitap (`RETRO_DEVICE_JOYPAD_MULTITAP`)
 - [ ] On-screen overlay touch layouts (PNG, auto-scale, snap-to-edges)
 - [ ] Analog stick deadzone + sensitivity per port
-- [ ] Game-Focus mode (pass all keys through, ignore hotkeys)
+- [x] Game-Focus mode (pass all keys through, ignore hotkeys)
 
 ## Performance / Latency
 

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -271,7 +271,7 @@ bool Update(void* userData) {
 
         if (IsLibretroGameReady()) {
             KeyboardKey rewindKey = LibretroHotkeyToKeyboardKey(data->menu->hotkeys[LIBRETRO_HOTKEY_REWIND].key);
-            rewinding = data->menu->rewindEnabled && !data->menu->gameFocusActive && (IsKeyDown(rewindKey) || LibretroHotkeyGPDown(data->menu->hotkeys[LIBRETRO_HOTKEY_REWIND].gamepad));
+            rewinding = data->menu->rewindEnabled && !data->menu->disableHotKeysActive && (IsKeyDown(rewindKey) || LibretroHotkeyGPDown(data->menu->hotkeys[LIBRETRO_HOTKEY_REWIND].gamepad));
 
             // Capture and playback both run at REWIND_CAPTURES_PER_SECOND.
             if (data->menu->rewindEnabled) {
@@ -321,12 +321,11 @@ bool Update(void* userData) {
                     RewindBufferFree(&data->rewind);
                 }
 
-                // Fast Forward / Slow Motion — suspended in Game Focus mode so the bound
-                // keys can reach the core instead of changing playback speed.
+                // Fast Forward / Slow Motion
                 KeyboardKey key = LibretroHotkeyToKeyboardKey(data->menu->hotkeys[LIBRETRO_HOTKEY_FAST_FORWARD].key);
                 KeyboardKey slowMotionKey = LibretroHotkeyToKeyboardKey(data->menu->hotkeys[LIBRETRO_HOTKEY_SLOW_MOTION].key);
-                if (data->menu->gameFocusActive) {
-                    // Skip the FF/SM key handling block.
+                if (data->menu->disableHotKeysActive) {
+                    // Skip the Fast Forward / Slow Motion entirely.
                 }
                 else if (IsKeyDown(key) || LibretroHotkeyGPDown(data->menu->hotkeys[LIBRETRO_HOTKEY_FAST_FORWARD].gamepad)) {
                     if (IsKeyPressed(key) || LibretroHotkeyGPPressed(data->menu->hotkeys[LIBRETRO_HOTKEY_FAST_FORWARD].gamepad)) {
@@ -397,25 +396,24 @@ bool Update(void* userData) {
         SaveLibretroAllSettings();
         UnloadLibretroGame();
         CloseLibretro();
+        ShowLibretroMenu();
     }
     if (data->menu->shouldQuit) {
         return false;
     }
 
-    // Hot Keys
+    // Hot Key
     if (!menu.active) {
-
-        // Game Focus toggle — must run before the gameFocusActive gate so the user
-        // can always switch it back off.
-        if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.hotkeys[LIBRETRO_HOTKEY_GAME_FOCUS].key)) || LibretroHotkeyGPReleased(menu.hotkeys[LIBRETRO_HOTKEY_GAME_FOCUS].gamepad)) {
-            menu.gameFocusActive = !menu.gameFocusActive;
-            SetLibretroMessage(menu.gameFocusActive ? "Game Focus ON" : "Game Focus OFF", 2.0);
+        // Disable HotKeys Button
+        if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.hotkeys[LIBRETRO_HOTKEY_DISABLE_HOTKEYS].key)) || LibretroHotkeyGPReleased(menu.hotkeys[LIBRETRO_HOTKEY_DISABLE_HOTKEYS].gamepad)) {
+            menu.disableHotKeysActive = !menu.disableHotKeysActive;
+            SetLibretroMessage(menu.disableHotKeysActive ? "Hot Keys Disabled" : "Hot Keys Enabled", 2.0);
+            return true;
         }
     }
 
-    // The rest of the hotkey block is suspended in Game Focus mode so keys like
-    // F1–F7, Esc, and arrow keys can reach the core unmolested.
-    if (!menu.active && !menu.gameFocusActive) {
+    // Check all the other Hot Keys
+    if (!menu.active && !menu.disableHotKeysActive) {
 
         // Screenshot
         if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.hotkeys[LIBRETRO_HOTKEY_SCREENSHOT].key)) || LibretroHotkeyGPReleased(menu.hotkeys[LIBRETRO_HOTKEY_SCREENSHOT].gamepad) && IsLibretroGameReady()) {

--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -271,7 +271,7 @@ bool Update(void* userData) {
 
         if (IsLibretroGameReady()) {
             KeyboardKey rewindKey = LibretroHotkeyToKeyboardKey(data->menu->hotkeys[LIBRETRO_HOTKEY_REWIND].key);
-            rewinding = data->menu->rewindEnabled && (IsKeyDown(rewindKey) || LibretroHotkeyGPDown(data->menu->hotkeys[LIBRETRO_HOTKEY_REWIND].gamepad));
+            rewinding = data->menu->rewindEnabled && !data->menu->gameFocusActive && (IsKeyDown(rewindKey) || LibretroHotkeyGPDown(data->menu->hotkeys[LIBRETRO_HOTKEY_REWIND].gamepad));
 
             // Capture and playback both run at REWIND_CAPTURES_PER_SECOND.
             if (data->menu->rewindEnabled) {
@@ -321,10 +321,14 @@ bool Update(void* userData) {
                     RewindBufferFree(&data->rewind);
                 }
 
-                // Fast Forward
+                // Fast Forward / Slow Motion — suspended in Game Focus mode so the bound
+                // keys can reach the core instead of changing playback speed.
                 KeyboardKey key = LibretroHotkeyToKeyboardKey(data->menu->hotkeys[LIBRETRO_HOTKEY_FAST_FORWARD].key);
                 KeyboardKey slowMotionKey = LibretroHotkeyToKeyboardKey(data->menu->hotkeys[LIBRETRO_HOTKEY_SLOW_MOTION].key);
-                if (IsKeyDown(key) || LibretroHotkeyGPDown(data->menu->hotkeys[LIBRETRO_HOTKEY_FAST_FORWARD].gamepad)) {
+                if (data->menu->gameFocusActive) {
+                    // Skip the FF/SM key handling block.
+                }
+                else if (IsKeyDown(key) || LibretroHotkeyGPDown(data->menu->hotkeys[LIBRETRO_HOTKEY_FAST_FORWARD].gamepad)) {
                     if (IsKeyPressed(key) || LibretroHotkeyGPPressed(data->menu->hotkeys[LIBRETRO_HOTKEY_FAST_FORWARD].gamepad)) {
                         // Halve audio stream volume during fast-forward without touching
                         // LIBRETRO.volume so restore is just re-applying the stored value.
@@ -400,6 +404,18 @@ bool Update(void* userData) {
 
     // Hot Keys
     if (!menu.active) {
+
+        // Game Focus toggle — must run before the gameFocusActive gate so the user
+        // can always switch it back off.
+        if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.hotkeys[LIBRETRO_HOTKEY_GAME_FOCUS].key)) || LibretroHotkeyGPReleased(menu.hotkeys[LIBRETRO_HOTKEY_GAME_FOCUS].gamepad)) {
+            menu.gameFocusActive = !menu.gameFocusActive;
+            SetLibretroMessage(menu.gameFocusActive ? "Game Focus ON" : "Game Focus OFF", 2.0);
+        }
+    }
+
+    // The rest of the hotkey block is suspended in Game Focus mode so keys like
+    // F1–F7, Esc, and arrow keys can reach the core unmolested.
+    if (!menu.active && !menu.gameFocusActive) {
 
         // Screenshot
         if (IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.hotkeys[LIBRETRO_HOTKEY_SCREENSHOT].key)) || LibretroHotkeyGPReleased(menu.hotkeys[LIBRETRO_HOTKEY_SCREENSHOT].gamepad) && IsLibretroGameReady()) {

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -60,7 +60,7 @@ typedef enum LibretroHotkey {
     LIBRETRO_HOTKEY_MUTE,
     LIBRETRO_HOTKEY_FAST_FORWARD,
     LIBRETRO_HOTKEY_SLOW_MOTION,
-    LIBRETRO_HOTKEY_GAME_FOCUS,
+    LIBRETRO_HOTKEY_DISABLE_HOTKEYS,
     LIBRETRO_HOTKEY_COUNT,
 } LibretroHotkey;
 
@@ -110,7 +110,7 @@ typedef struct LibretroMenu {
     char loadGamePath[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     bool touchControls;
     bool touchHapticsEnabled;
-    nk_bool gameFocusActive; // Game Focus mode: pass all keys to the core, suspend frontend hotkeys.
+    nk_bool disableHotKeysActive; // Disable HotKeys: pass all keys to the core, suspend frontend hotkeys.
     int sramAutoSaveIndex; // combobox index for the SRAM auto-save interval (Off / 15s / 30s / 60s / 2min / 5min / 10min)
     float sramAutoSaveAccumulator; // seconds since the last successful auto-save
     int orientationIndex;                 // Android screen orientation: 0 = Landscape, 1 = Portrait, 2 = Auto
@@ -396,8 +396,8 @@ static LibretroMenu menu = {
             .key = (nk_rune)'G',
             .gamepad = NK_GAMEPAD_BUTTON_INVALID
         },
-        [LIBRETRO_HOTKEY_GAME_FOCUS] = {
-            .name = "Game Focus",
+        [LIBRETRO_HOTKEY_DISABLE_HOTKEYS] = {
+            .name = "Disable Hot Keys",
             .defaultKey = NK_CONSOLE_KEY_F12,
             .key = NK_CONSOLE_KEY_F12,
             .gamepad = NK_GAMEPAD_BUTTON_INVALID
@@ -1611,9 +1611,9 @@ LibretroMenu* InitLibretroMenu(void) {
             // Rewind
             nk_console_checkbox(gameplayMenu, "Rewind", &menu.rewindEnabled);
 
-            // Game Focus: pass all keys to the core, suspend frontend hotkeys.
-            nk_console_checkbox(gameplayMenu, "Game Focus", &menu.gameFocusActive)
-                ->tooltip = "Pass all keys to the core and suspend frontend hotkeys";
+            // Disable Hot Keys
+            nk_console_checkbox(gameplayMenu, "Disable Hot Keys", &menu.disableHotKeysActive)
+                ->tooltip = "Pass all keyboard input to the core and suspend frontend hotkeys";
 
             // Analog to D-Pad
             nk_console_combobox(gameplayMenu, "Analog to D-Pad",
@@ -2600,7 +2600,7 @@ void UpdateLibretroMenu(void) { // If there is no menu, skip.
     }
 
     // Menu Key
-    if ((IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.hotkeys[LIBRETRO_HOTKEY_MENU].key)) || LibretroHotkeyGPReleased(menu.hotkeys[LIBRETRO_HOTKEY_MENU].gamepad)) && !menu.active) {
+    if ((!menu.disableHotKeysActive && IsKeyReleased(LibretroHotkeyToKeyboardKey(menu.hotkeys[LIBRETRO_HOTKEY_MENU].key)) || LibretroHotkeyGPReleased(menu.hotkeys[LIBRETRO_HOTKEY_MENU].gamepad)) && !menu.active) {
         ShowLibretroMenu();
     }
 

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -2231,6 +2231,7 @@ static void LibretroMenuUpdateConfig(void) {
     rlconfig_set_int(menu.cfg, "raylib-libretro", "theme", menu.themeSelectedIndex);
     rlconfig_set_float(menu.cfg, "raylib-libretro", "volume", LIBRETRO.volume);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "rewind", menu.rewindEnabled ? 1 : 0);
+    rlconfig_set_int(menu.cfg, "raylib-libretro", "disableHotKeys", menu.disableHotKeysActive ? 1 : 0);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "analogToDpad", LIBRETRO.analogToDpadIndex);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "menuCombo", menu.menuComboIndex);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "hideCursor", menu.hideCursor ? 1 : 0);
@@ -2428,6 +2429,9 @@ static bool LoadLibretroMenuSettings(void) {
 
     // Rewind
     menu.rewindEnabled = rlconfig_get_int(menu.cfg, "raylib-libretro", "rewind", 0) > 0;
+
+    // Disable Hot Keys
+    menu.disableHotKeysActive = (nk_bool)(rlconfig_get_int(menu.cfg, "raylib-libretro", "disableHotKeys", 0) > 0);
 
     // Analog to D-Pad
     LIBRETRO.analogToDpadIndex = rlconfig_get_int(menu.cfg, "raylib-libretro", "analogToDpad", 0);

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -60,6 +60,7 @@ typedef enum LibretroHotkey {
     LIBRETRO_HOTKEY_MUTE,
     LIBRETRO_HOTKEY_FAST_FORWARD,
     LIBRETRO_HOTKEY_SLOW_MOTION,
+    LIBRETRO_HOTKEY_GAME_FOCUS,
     LIBRETRO_HOTKEY_COUNT,
 } LibretroHotkey;
 
@@ -109,6 +110,7 @@ typedef struct LibretroMenu {
     char loadGamePath[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     bool touchControls;
     bool touchHapticsEnabled;
+    nk_bool gameFocusActive;              // Game Focus mode: pass all keys to the core, suspend frontend hotkeys.
     int orientationIndex;                 // Android screen orientation: 0 = Landscape, 1 = Portrait, 2 = Auto
     nk_bool hideCursor;
     nk_bool lockCursor;
@@ -390,6 +392,12 @@ static LibretroMenu menu = {
             .name = "Slow Motion",
             .defaultKey = (nk_rune)'G',
             .key = (nk_rune)'G',
+            .gamepad = NK_GAMEPAD_BUTTON_INVALID
+        },
+        [LIBRETRO_HOTKEY_GAME_FOCUS] = {
+            .name = "Game Focus",
+            .defaultKey = NK_CONSOLE_KEY_F12,
+            .key = NK_CONSOLE_KEY_F12,
             .gamepad = NK_GAMEPAD_BUTTON_INVALID
         },
     },

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -1611,6 +1611,10 @@ LibretroMenu* InitLibretroMenu(void) {
             // Rewind
             nk_console_checkbox(gameplayMenu, "Rewind", &menu.rewindEnabled);
 
+            // Game Focus: pass all keys to the core, suspend frontend hotkeys.
+            nk_console_checkbox(gameplayMenu, "Game Focus", &menu.gameFocusActive)
+                ->tooltip = "Pass all keys to the core and suspend frontend hotkeys";
+
             // Analog to D-Pad
             nk_console_combobox(gameplayMenu, "Analog to D-Pad",
                 "None|Left Analog|Right Analog", '|', &LIBRETRO.analogToDpadIndex)


### PR DESCRIPTION
Fixes #314

Adds a `Game Focus` toggle (default F12, also exposed in Settings → Hotkeys) that suspends the frontend hotkey block — including rewind, fast-forward, and slow motion — so keys like F1–F7, Esc, and arrow keys reach the loaded core unimpeded. The toggle itself stays live so the user can always switch it back off, and an OSD message confirms each transition.