### PR TITLE
touch: scale slider for on-screen controls

### DIFF
--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -250,6 +250,7 @@ bool Update(void* userData) {
     // Update virtual joypad from touch controls.
     if (data->menu->touchControls) {
         SetTouchHapticsEnabled(data->menu->touchHapticsEnabled);
+        SetTouchControlsScale(data->menu->touchScale);
         if (!data->menu->active) {
             UpdateLibretroTouchControls();
             if (IsTouchControlsMenuPressed()) {

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -110,6 +110,7 @@ typedef struct LibretroMenu {
     char loadGamePath[RAYLIB_LIBRETRO_VFS_MAX_PATH];
     bool touchControls;
     bool touchHapticsEnabled;
+    float touchScale;
     nk_bool disableHotKeysActive; // Disable HotKeys: pass all keys to the core, suspend frontend hotkeys.
     int sramAutoSaveIndex; // combobox index for the SRAM auto-save interval (Off / 15s / 30s / 60s / 2min / 5min / 10min)
     float sramAutoSaveAccumulator; // seconds since the last successful auto-save
@@ -292,6 +293,7 @@ static LibretroMenu menu = {
     .vsync              = nk_true,
     .fastForwardSpeed   = 3.0f,
     .slowMotionSpeed    = 0.5f,
+    .touchScale         = 1.0f,
     .menuComboIndex     = LIBRETRO_MENU_COMBO_SELECT_START,
     .hotkeys = {
         [LIBRETRO_HOTKEY_SCREENSHOT] = {
@@ -1596,6 +1598,9 @@ LibretroMenu* InitLibretroMenu(void) {
             // Touch Control
             nk_console_checkbox(gameplayMenu, "Touch Controls", &menu.touchControls);
 
+            // Touch Control Scale
+            nk_console_slider_float(gameplayMenu, "Touch Scale", 0.2f, &menu.touchScale, 3.0f, RAYLIB_LIBRETRO_MENU_SLIDER_STEP(0.2f, 3.0f));
+
             // Touch Haptics
             #if defined(PLATFORM_WEB)
             nk_console_checkbox(gameplayMenu, "Touch Haptics", &menu.touchHapticsEnabled);
@@ -2238,6 +2243,7 @@ static void LibretroMenuUpdateConfig(void) {
     rlconfig_set_int(menu.cfg, "raylib-libretro", "lockCursor", menu.lockCursor ? 1 : 0);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "touchControls", menu.touchControls ? 1 : 0);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "touchHaptics", menu.touchHapticsEnabled ? 1 : 0);
+    rlconfig_set_float(menu.cfg, "raylib-libretro", "touchScale", menu.touchScale);
     rlconfig_set_int(menu.cfg, "raylib-libretro", "orientation", menu.orientationIndex);
 
     rlconfig_set_int(menu.cfg, "raylib-libretro", "saveSlot", menu.saveSlotIndex);
@@ -2451,6 +2457,11 @@ static bool LoadLibretroMenuSettings(void) {
 #else
     menu.touchControls = rlconfig_get_int(menu.cfg, "raylib-libretro", "touchControls", 0) > 0;
 #endif
+
+    // Touch Scale
+    menu.touchScale = rlconfig_get_float(menu.cfg, "raylib-libretro", "touchScale", 1.0f);
+    if (menu.touchScale < 0.2f) menu.touchScale = 0.2f;
+    if (menu.touchScale > 3.0f) menu.touchScale = 3.0f;
 
     // Screen Orientation (0 = Landscape, 1 = Portrait, 2 = Auto; applied on Android)
     menu.orientationIndex = rlconfig_get_int(menu.cfg, "raylib-libretro", "orientation", 0);

--- a/include/raylib-libretro-menu.h
+++ b/include/raylib-libretro-menu.h
@@ -1599,7 +1599,7 @@ LibretroMenu* InitLibretroMenu(void) {
             nk_console_checkbox(gameplayMenu, "Touch Controls", &menu.touchControls);
 
             // Touch Control Scale
-            nk_console_slider_float(gameplayMenu, "Touch Scale", 0.2f, &menu.touchScale, 3.0f, RAYLIB_LIBRETRO_MENU_SLIDER_STEP(0.2f, 3.0f));
+            nk_console_slider_float(gameplayMenu, "Touch Scale", 0.4f, &menu.touchScale, 2.0f, RAYLIB_LIBRETRO_MENU_SLIDER_STEP(0.2f, 2.0f));
 
             // Touch Haptics
             #if defined(PLATFORM_WEB)
@@ -2460,8 +2460,8 @@ static bool LoadLibretroMenuSettings(void) {
 
     // Touch Scale
     menu.touchScale = rlconfig_get_float(menu.cfg, "raylib-libretro", "touchScale", 1.0f);
-    if (menu.touchScale < 0.2f) menu.touchScale = 0.2f;
-    if (menu.touchScale > 3.0f) menu.touchScale = 3.0f;
+    if (menu.touchScale < 0.4f) menu.touchScale = 0.4f;
+    if (menu.touchScale > 2.0f) menu.touchScale = 2.0f;
 
     // Screen Orientation (0 = Landscape, 1 = Portrait, 2 = Auto; applied on Android)
     menu.orientationIndex = rlconfig_get_int(menu.cfg, "raylib-libretro", "orientation", 0);

--- a/include/raylib-libretro-touch.h
+++ b/include/raylib-libretro-touch.h
@@ -414,8 +414,8 @@ void SetTouchHapticsEnabled(bool enabled) { LibretroTouchHapticsEnabled = enable
 bool GetTouchHapticsEnabled(void) { return LibretroTouchHapticsEnabled; }
 
 void SetTouchControlsScale(float scale) {
-    if (scale < 0.2f) scale = 0.2f;
-    if (scale > 3.0f) scale = 3.0f;
+    if (scale < 0.4f) scale = 0.4f;
+    if (scale > 2.0f) scale = 2.0f;
     if (LibretroTouchScale != scale) {
         LibretroTouchScale = scale;
         LibretroTouchCachedW = -1;

--- a/include/raylib-libretro-touch.h
+++ b/include/raylib-libretro-touch.h
@@ -40,6 +40,8 @@ void DrawLibretroTouchControls(void);
 bool IsTouchControlsMenuPressed(void);
 void SetTouchHapticsEnabled(bool enabled);
 bool GetTouchHapticsEnabled(void);
+void SetTouchControlsScale(float scale);
+float GetTouchControlsScale(void);
 
 #if defined(__cplusplus)
 }
@@ -57,6 +59,8 @@ bool GetTouchHapticsEnabled(void);
 
 #include "raymath.h"
 
+static float LibretroTouchScale = 1.0f;
+
 #if defined(__cplusplus)
 extern "C" {
 #endif
@@ -68,16 +72,19 @@ extern "C" {
  */
 static int GetLibretroTouchButtons(TouchControlsButton* btns, int w, int h) {
     float ref  = (float)((w < h) ? w : h);
-    float bs   = ref * 0.12f;   // D-pad / select / start button size
-    float fbs  = ref * 0.15f;   // face button size
-    float edge = ref * 0.02f;   // margin from screen edges
+    float sc   = LibretroTouchScale;
+    float bs   = ref * 0.12f * sc;   // D-pad / select / start button size
+    float fbs  = ref * 0.15f * sc;   // face button size
+    float edge = ref * 0.02f;        // margin from screen edges
 
     // D-pad: bottom-left, cross layout, buttons touching (no gap)
     //   . U .
     //   L . R
     //   . D .
+    float halfW = (float)w * 0.5f;
     float dy = h - 3*bs - edge;
     float dx = w * 0.04f;
+    if (dx + 3*bs > halfW) dx = halfW - 3*bs;
     int n = 0;
     btns[n++] = (TouchControlsButton){{ dx + bs,     dy,        bs, bs }, RETRO_DEVICE_ID_JOYPAD_UP,    "^", DARKGRAY };
     btns[n++] = (TouchControlsButton){{ dx,           dy + bs,   bs, bs }, RETRO_DEVICE_ID_JOYPAD_LEFT,  "<", DARKGRAY };
@@ -91,6 +98,7 @@ static int GetLibretroTouchButtons(TouchControlsButton* btns, int w, int h) {
     float fsp = fbs * 0.82f;  // center-to-center spacing (< fbs = slight overlap)
     float fy = h - (2*fsp + fbs) - edge;
     float fx = w - (2*fsp + fbs) - w * 0.04f;
+    if (fx < halfW) fx = halfW;
     btns[n++] = (TouchControlsButton){{ fx + fsp,     fy,         fbs, fbs }, RETRO_DEVICE_ID_JOYPAD_X, "", DARKBLUE  };
     btns[n++] = (TouchControlsButton){{ fx,            fy + fsp,   fbs, fbs }, RETRO_DEVICE_ID_JOYPAD_Y, "", DARKGREEN };
     btns[n++] = (TouchControlsButton){{ fx + 2*fsp,    fy + fsp,   fbs, fbs }, RETRO_DEVICE_ID_JOYPAD_A, "", MAROON    };
@@ -404,6 +412,16 @@ bool IsTouchControlsMenuPressed(void) {
 
 void SetTouchHapticsEnabled(bool enabled) { LibretroTouchHapticsEnabled = enabled; }
 bool GetTouchHapticsEnabled(void) { return LibretroTouchHapticsEnabled; }
+
+void SetTouchControlsScale(float scale) {
+    if (scale < 0.2f) scale = 0.2f;
+    if (scale > 3.0f) scale = 3.0f;
+    if (LibretroTouchScale != scale) {
+        LibretroTouchScale = scale;
+        LibretroTouchCachedW = -1;
+    }
+}
+float GetTouchControlsScale(void) { return LibretroTouchScale; }
 
 void DrawLibretroTouchControls(void) {
     LibretroTouchEnsureLayout();


### PR DESCRIPTION
Add a Touch Scale slider (0.2x-3.0x) in Settings > Gameplay to resize on-screen touch controls. Controls are clamped to their screen half to prevent overlap at large scales.

Fixes #322