### PR TITLE
Fix Android build

### DIFF
--- a/bin/raylib-libretro.c
+++ b/bin/raylib-libretro.c
@@ -37,6 +37,8 @@
 #define RAYLIB_LIBRETRO_SHADERS_IMPLEMENTATION
 #include "../include/raylib-libretro-shaders.h"
 
+#include "raylib-libretro-android.h"
+
 #define RAYLIB_LIBRETRO_MENU_IMPLEMENTATION
 #include "../include/raylib-libretro-menu.h"
 
@@ -45,8 +47,6 @@
 
 #define RAYLIB_LIBRETRO_LOGO_IMPLEMENTATION
 #include "../include/raylib-libretro-logo.h"
-
-#include "raylib-libretro-android.h"
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>        // emscripten_set_main_loop / emscripten_cancel_main_loop

--- a/include/raylib-libretro-android.h
+++ b/include/raylib-libretro-android.h
@@ -19,6 +19,7 @@
 #include <android_native_app_glue.h>
 
 extern struct android_app *GetAndroidApp(void);
+static bool AndroidGetExternalStorageDir(struct android_app* app, char* out);
 
 #ifndef RAYLIB_LIBRETRO_ANDROID_ABI
     #if defined(__aarch64__)


### PR DESCRIPTION
Include the Android header before the menu header so that `AndroidGetExternalStorageDir` and `GetAndroidApp` are declared before use in `nk_console_file_add_files_android()`.

Fixes #342